### PR TITLE
support exchange with DEX directly when liquidate unsafe CDP 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "module-cdp-treasury",
+ "module-dex",
  "module-support",
  "module-vaults",
  "orml-currencies",
@@ -2694,6 +2695,7 @@ version = "0.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-dex",
  "module-support",
  "orml-auction",
  "orml-currencies",

--- a/modules/accounts/src/tests.rs
+++ b/modules/accounts/src/tests.rs
@@ -3,9 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{assert_noop, assert_ok};
-use mock::{Accounts, Currencies, ExtBuilder, Origin, Runtime, TimeModule, ALICE, AUSD, BOB, BTC};
-use sp_runtime::traits::OnFinalize;
+use frame_support::assert_ok;
+use mock::{Accounts, ExtBuilder, Origin, TimeModule, ALICE};
 
 #[test]
 fn try_free_transfer_over_cap() {

--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -227,8 +227,7 @@ impl<T: Trait> Module<T> {
 				confiscate_collateral_amount,
 			)
 			.expect("never failed after balance check");
-			T::Treasury::deposit_system_collateral(collateral_auction.currency_id, confiscate_collateral_amount)
-				.expect("never failed because this amount can not cause overflow");
+			T::Treasury::deposit_system_collateral(collateral_auction.currency_id, confiscate_collateral_amount);
 
 			// refund remain collateral to auction owner
 			if !refund_collateral_amount.is_zero() {
@@ -631,7 +630,6 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-		bad_debt: Self::Balance,
 	) {
 		if Self::total_collateral_in_auction(currency_id)
 			.checked_add(&amount)
@@ -643,7 +641,6 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 			T::Currency::deposit(currency_id, &Self::account_id(), amount).expect("never failed after overflow check");
 			<TotalCollateralInAuction<T>>::mutate(currency_id, |balance| *balance += amount);
 			<TotalTargetInAuction<T>>::mutate(|balance| *balance += target);
-			T::Treasury::on_system_debit(bad_debt);
 
 			let block_number = <system::Module<T>>::block_number();
 			let auction_id: AuctionIdOf<T> = T::Auction::new_auction(block_number, None);

--- a/modules/auction_manager/src/mock.rs
+++ b/modules/auction_manager/src/mock.rs
@@ -98,6 +98,7 @@ impl cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = AuctionManagerModule;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type Dex = ();
 }
 pub type CdpTreasury = cdp_treasury::Module<Runtime>;
 

--- a/modules/cdp_engine/Cargo.toml
+++ b/modules/cdp_engine/Cargo.toml
@@ -22,6 +22,7 @@ primitives = { package = "sp-core",  git = "https://github.com/paritytech/substr
 runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate.git", default-features = false }
 pallet-balances= { package = "pallet-balances", git = "https://github.com/paritytech/substrate.git", default-features = false }
 orml-currencies = { package = "orml-currencies", path = "../../orml/currencies", default-features = false }
+dex = { package = "module-dex", path = "../dex", default-features = false }
 
 [features]
 default = ["std"]

--- a/modules/cdp_engine/src/lib.rs
+++ b/modules/cdp_engine/src/lib.rs
@@ -8,7 +8,8 @@ use sp_runtime::{
 	DispatchResult,
 };
 use support::{
-	AuctionManager, CDPTreasury, EmergencyShutdown, ExchangeRate, Price, PriceProvider, Rate, Ratio, RiskManager,
+	CDPTreasury, CDPTreasuryExtended, DexManager, EmergencyShutdown, ExchangeRate, Price, PriceProvider, Rate, Ratio,
+	RiskManager,
 };
 use system::ensure_root;
 
@@ -24,11 +25,6 @@ type AmountOf<T> = <<T as vaults::Trait>::Currency as MultiCurrencyExtended<<T a
 
 pub trait Trait: system::Trait + vaults::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-	type AuctionManagerHandler: AuctionManager<
-		Self::AccountId,
-		Balance = BalanceOf<Self>,
-		CurrencyId = CurrencyIdOf<Self>,
-	>;
 	type PriceSource: PriceProvider<CurrencyIdOf<Self>, Price>;
 	type CollateralCurrencyIds: Get<Vec<CurrencyIdOf<Self>>>;
 	type GlobalStabilityFee: Get<Rate>;
@@ -36,8 +32,11 @@ pub trait Trait: system::Trait + vaults::Trait {
 	type DefaulDebitExchangeRate: Get<ExchangeRate>;
 	type MinimumDebitValue: Get<BalanceOf<Self>>;
 	type GetStableCurrencyId: Get<CurrencyIdOf<Self>>;
-	type Treasury: CDPTreasury<Self::AccountId, Balance = BalanceOf<Self>, CurrencyId = CurrencyIdOf<Self>>;
+	type Treasury: CDPTreasuryExtended<Self::AccountId, Balance = BalanceOf<Self>, CurrencyId = CurrencyIdOf<Self>>;
 	type UpdateOrigin: EnsureOrigin<Self::Origin>;
+	type MaxSlippageSwapWithDex: Get<Ratio>;
+	type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyIdOf<Self>, Balance = BalanceOf<Self>>;
+	type Dex: DexManager<Self::AccountId, CurrencyIdOf<Self>, BalanceOf<Self>>;
 }
 
 decl_event!(
@@ -79,7 +78,6 @@ decl_storage! {
 		pub RequiredCollateralRatio get(fn required_collateral_ratio): map CurrencyIdOf<T> => Option<Ratio>;
 		pub MaximumTotalDebitValue get(fn maximum_total_debit_value): map CurrencyIdOf<T> => BalanceOf<T>;
 		pub DebitExchangeRate get(fn debit_exchange_rate): map CurrencyIdOf<T> => Option<ExchangeRate>;
-		pub MaximumCollateralAuctionSize get(fn maximum_collateral_auction_size): map CurrencyIdOf<T> => BalanceOf<T>;
 		pub IsShutdown get(fn is_shutdown): bool;
 	}
 }
@@ -88,12 +86,13 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
-		fn set_maximum_collateral_auction_size(origin, currency_id: CurrencyIdOf<T>, size: BalanceOf<T>) {
-			T::UpdateOrigin::try_origin(origin)
-				.map(|_| ())
-				.or_else(ensure_root)?;
-			<MaximumCollateralAuctionSize<T>>::insert(currency_id, size);
-		}
+		const CollateralCurrencyIds: Vec<CurrencyIdOf<T>> = T::CollateralCurrencyIds::get();
+		const GlobalStabilityFee: Rate = T::GlobalStabilityFee::get();
+		const DefaultLiquidationRatio: Ratio = T::DefaultLiquidationRatio::get();
+		const DefaulDebitExchangeRate: ExchangeRate = T::DefaulDebitExchangeRate::get();
+		const MinimumDebitValue: BalanceOf<T> = T::MinimumDebitValue::get();
+		const GetStableCurrencyId: CurrencyIdOf<T> = T::GetStableCurrencyId::get();
+		const MaxSlippageSwapWithDex: Ratio = T::MaxSlippageSwapWithDex::get();
 
 		pub fn set_collateral_params(
 			origin,
@@ -234,8 +233,7 @@ impl<T: Trait> Module<T> {
 			-grab_debit_amount,
 		)
 		.map_err(|_| Error::<T>::GrabCollateralAndDebitFailed)?;
-		<T as Trait>::Treasury::deposit_system_collateral(currency_id, confiscate_collateral_amount)
-			.expect("never failed because this amount can not cause overflow");
+		<T as Trait>::Treasury::deposit_system_collateral(currency_id, confiscate_collateral_amount);
 		<T as Trait>::Treasury::on_system_debit(debt_in_stable_currency);
 
 		Self::deposit_event(RawEvent::SettleCdpInDebit(currency_id, who));
@@ -246,10 +244,11 @@ impl<T: Trait> Module<T> {
 	pub fn liquidate_unsafe_cdp(who: T::AccountId, currency_id: CurrencyIdOf<T>) -> DispatchResult {
 		let debit_balance = <vaults::Module<T>>::debits(&who, currency_id);
 		let collateral_balance = <vaults::Module<T>>::collaterals(&who, currency_id);
+		let stable_currency_id = T::GetStableCurrencyId::get();
 
 		// first: ensure the cdp is unsafe
-		let feed_price = T::PriceSource::get_price(T::GetStableCurrencyId::get(), currency_id)
-			.ok_or(Error::<T>::InvalidFeedPrice)?;
+		let feed_price =
+			T::PriceSource::get_price(stable_currency_id, currency_id).ok_or(Error::<T>::InvalidFeedPrice)?;
 		let collateral_ratio =
 			Self::calculate_collateral_ratio(currency_id, collateral_balance, debit_balance, feed_price);
 		let liquidation_ratio = Self::liquidation_ratio(currency_id).unwrap_or_else(T::DefaultLiquidationRatio::get);
@@ -266,43 +265,47 @@ impl<T: Trait> Module<T> {
 		<vaults::Module<T>>::update_collaterals_and_debits(who.clone(), currency_id, -grab_amount, -grab_debit_amount)
 			.map_err(|_| Error::<T>::GrabCollateralAndDebitFailed)?;
 
-		// third: create collateral auction
+		// third: calculate bad_debt and target
 		let bad_debt = DebitExchangeRateConvertor::<T>::convert((currency_id, debit_balance));
 		let mut target = bad_debt;
 		if let Some(penalty_ratio) = Self::liquidation_penalty(currency_id) {
 			target = target.saturating_add(penalty_ratio.saturating_mul_int(&target));
 		}
-		let maximum_collateral_auction_size = Self::maximum_collateral_auction_size(currency_id);
-		let mut unhandled_collateral_amount = collateral_balance;
-		let mut unhandled_target = target;
-		let mut unhandled_bad_debt = bad_debt;
 
-		while !unhandled_collateral_amount.is_zero() {
-			let (lot_collateral_amount, lot_target, lot_bad_debt) = if unhandled_collateral_amount
-				> maximum_collateral_auction_size
-				&& !maximum_collateral_auction_size.is_zero()
-			{
-				let rate = Rate::from_rational(maximum_collateral_auction_size, collateral_balance);
-				(
-					maximum_collateral_auction_size,
-					rate.saturating_mul_int(&target),
-					rate.saturating_mul_int(&bad_debt),
-				)
-			} else {
-				(unhandled_collateral_amount, unhandled_target, unhandled_bad_debt)
-			};
+		// add system debit to cdp treasury
+		<T as Trait>::Treasury::on_system_debit(bad_debt);
 
-			T::AuctionManagerHandler::new_collateral_auction(
-				&who,
-				currency_id,
-				lot_collateral_amount,
-				lot_target,
-				lot_bad_debt,
-			);
+		// if collateral_balance can swap enough native token in DEX and exchange slippage is blow the limit,
+		// directly exchange with DEX, otherwise create collateral auctions.
+		let supply_amount = T::Dex::get_supply_amount(currency_id, stable_currency_id, target);
+		let slippage = T::Dex::get_exchange_slippage(currency_id, stable_currency_id, supply_amount);
+		let slippage_limit = T::MaxSlippageSwapWithDex::get();
 
-			unhandled_collateral_amount -= lot_collateral_amount;
-			unhandled_target -= lot_target;
-			unhandled_bad_debt -= lot_bad_debt;
+		// forth: handle bad debt and collateral
+		if !supply_amount.is_zero() 				// supply_amount must not be zero
+		&& collateral_balance >= supply_amount		// can afford supply_amount
+		&& slippage_limit > Ratio::from_natural(0)	// slippage_limit must be greater than zero
+		&& slippage.is_some()
+		&& slippage.unwrap_or_default() <= slippage_limit
+		{
+			// directly exchange with DEX
+			// deposit supply_amount collateral to cdp treasury
+			<T as Trait>::Treasury::deposit_system_collateral(currency_id, supply_amount);
+
+			// exchange with Dex by cdp treasury
+			<T as Trait>::Treasury::swap_collateral_to_stable(currency_id, supply_amount, target);
+
+			// refund remain collateral to who
+			let refund_collateral_amount = collateral_balance - supply_amount;
+			if !refund_collateral_amount.is_zero() {
+				<T as Trait>::Currency::deposit(currency_id, &who, refund_collateral_amount).expect("never failed");
+			}
+		} else {
+			// deposit collateral_balance collateral to cdp treasury
+			<T as Trait>::Treasury::deposit_system_collateral(currency_id, collateral_balance);
+
+			// create collateral auctions by cdp treasury
+			<T as Trait>::Treasury::create_collateral_auctions(currency_id, collateral_balance, target, who.clone());
 		}
 
 		Self::deposit_event(RawEvent::LiquidateUnsafeCdp(

--- a/modules/cdp_engine/src/lib.rs
+++ b/modules/cdp_engine/src/lib.rs
@@ -285,8 +285,7 @@ impl<T: Trait> Module<T> {
 		if !supply_amount.is_zero() 				// supply_amount must not be zero
 		&& collateral_balance >= supply_amount		// can afford supply_amount
 		&& slippage_limit > Ratio::from_natural(0)	// slippage_limit must be greater than zero
-		&& slippage.is_some()
-		&& slippage.unwrap_or_default() <= slippage_limit
+		&& slippage.map_or(false, |s| s <= slippage_limit)
 		{
 			// directly exchange with DEX
 			// deposit supply_amount collateral to cdp treasury

--- a/modules/cdp_engine/src/tests.rs
+++ b/modules/cdp_engine/src/tests.rs
@@ -247,7 +247,7 @@ fn remain_debit_value_too_small_check() {
 }
 
 #[test]
-fn liquidate_unsafe_cdp_work() {
+fn liquidate_unsafe_cdp_by_collateral_auction() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(CdpEngineModule::set_collateral_params(
 			Origin::ROOT,
@@ -283,6 +283,7 @@ fn liquidate_unsafe_cdp_work() {
 			.iter()
 			.any(|record| record.event == liquidate_unsafe_cdp_event));
 
+		assert_eq!(CdpTreasury::debit_pool(), 50);
 		assert_eq!(Currencies::balance(BTC, &ALICE), 900);
 		assert_eq!(Currencies::balance(AUSD, &ALICE), 50);
 		assert_eq!(VaultsModule::debits(ALICE, BTC), 0);
@@ -348,27 +349,6 @@ fn on_finalize_work() {
 			Some(ExchangeRate::from_rational(10201, 10000))
 		);
 		assert_eq!(CdpEngineModule::debit_exchange_rate(DOT), None);
-	});
-}
-
-#[test]
-fn set_maximum_collateral_auction_size_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			CdpEngineModule::set_maximum_collateral_auction_size(Origin::signed(5), BTC, 20,),
-			BadOrigin
-		);
-		assert_ok!(CdpEngineModule::set_maximum_collateral_auction_size(
-			Origin::signed(1),
-			BTC,
-			20,
-		));
-		assert_ok!(CdpEngineModule::set_maximum_collateral_auction_size(
-			Origin::ROOT,
-			BTC,
-			20
-		));
-		assert_eq!(CdpEngineModule::maximum_collateral_auction_size(BTC), 20);
 	});
 }
 

--- a/modules/cdp_treasury/Cargo.toml
+++ b/modules/cdp_treasury/Cargo.toml
@@ -21,6 +21,7 @@ runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate
 pallet-balances= { package = "pallet-balances", git = "https://github.com/paritytech/substrate.git", default-features = false }
 orml-currencies = { package = "orml-currencies", path = "../../orml/currencies", default-features = false }
 orml-auction = { package = "orml-auction", path = "../../orml/auction", default-features = false }
+dex = { package = "module-dex", path = "../dex", default-features = false }
 
 [features]
 default = ["std"]

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -30,7 +30,7 @@ parameter_types! {
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 	pub const GetBaseCurrencyId: CurrencyId = AUSD;
-	pub const GetExchangeFee: FixedU128 = FixedU128::from_rational(1, 100);
+	pub const GetExchangeFee: Rate = Rate::from_rational(1, 100);
 	pub const ExistentialDeposit: u128 = 0;
 }
 
@@ -87,6 +87,7 @@ pub const CAROL: AccountId = 3;
 pub const AUSD: CurrencyId = 1;
 pub const BTC: CurrencyId = 2;
 pub const DOT: CurrencyId = 3;
+pub const ACA: CurrencyId = 4;
 
 pub struct ExtBuilder {
 	endowed_accounts: Vec<(AccountId, CurrencyId, Balance)>,

--- a/modules/emergency_shutdown/src/mock.rs
+++ b/modules/emergency_shutdown/src/mock.rs
@@ -156,7 +156,6 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-		bad_debt: Self::Balance,
 	) {
 	}
 
@@ -202,12 +201,16 @@ impl cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = MockAuctionManager;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type Dex = ();
 }
 pub type CdpTreasury = cdp_treasury::Module<Runtime>;
 
+parameter_types! {
+	pub const MaxSlippageSwapWithDex: Ratio = Ratio::from_rational(50, 100);
+}
+
 impl cdp_engine::Trait for Runtime {
 	type Event = TestEvent;
-	type AuctionManagerHandler = MockAuctionManager;
 	type PriceSource = MockPriceSource;
 	type CollateralCurrencyIds = CollateralCurrencyIds;
 	type GlobalStabilityFee = GlobalStabilityFee;
@@ -217,6 +220,9 @@ impl cdp_engine::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type Treasury = CdpTreasury;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type MaxSlippageSwapWithDex = MaxSlippageSwapWithDex;
+	type Currency = Currencies;
+	type Dex = ();
 }
 pub type CdpEngineModule = cdp_engine::Module<Runtime>;
 

--- a/modules/honzon/src/mock.rs
+++ b/modules/honzon/src/mock.rs
@@ -156,7 +156,6 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-		bad_debt: Self::Balance,
 	) {
 	}
 
@@ -184,12 +183,16 @@ impl cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = MockAuctionManager;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type Dex = ();
 }
 pub type CdpTreasury = cdp_treasury::Module<Runtime>;
 
+parameter_types! {
+	pub const MaxSlippageSwapWithDex: Ratio = Ratio::from_rational(50, 100);
+}
+
 impl cdp_engine::Trait for Runtime {
 	type Event = TestEvent;
-	type AuctionManagerHandler = MockAuctionManager;
 	type PriceSource = MockPriceSource;
 	type CollateralCurrencyIds = CollateralCurrencyIds;
 	type GlobalStabilityFee = GlobalStabilityFee;
@@ -199,6 +202,9 @@ impl cdp_engine::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type Treasury = CdpTreasury;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type MaxSlippageSwapWithDex = MaxSlippageSwapWithDex;
+	type Currency = Currencies;
+	type Dex = ();
 }
 pub type CdpEngineModule = cdp_engine::Module<Runtime>;
 

--- a/modules/vaults/src/mock.rs
+++ b/modules/vaults/src/mock.rs
@@ -128,7 +128,6 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-		bad_debt: Self::Balance,
 	) {
 	}
 
@@ -156,6 +155,7 @@ impl cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = MockAuctionManager;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type Dex = ();
 }
 pub type CdpTreasury = cdp_treasury::Module<Runtime>;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -411,11 +411,11 @@ parameter_types! {
 	pub const DefaultLiquidationRatio: Ratio = Ratio::from_rational(3, 2);
 	pub const DefaulDebitExchangeRate: ExchangeRate = ExchangeRate::from_rational(1, 1);
 	pub const MinimumDebitValue: Balance = 1_000_000_000_000_000;
+	pub const MaxSlippageSwapWithDex: Ratio = Ratio::from_rational(1, 100);
 }
 
 impl module_cdp_engine::Trait for Runtime {
 	type Event = Event;
-	type AuctionManagerHandler = module_auction_manager::Module<Runtime>;
 	type PriceSource = module_prices::Module<Runtime>;
 	type CollateralCurrencyIds = CollateralCurrencyIds;
 	type GlobalStabilityFee = GlobalStabilityFee;
@@ -425,6 +425,9 @@ impl module_cdp_engine::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type Treasury = module_cdp_treasury::Module<Runtime>;
 	type UpdateOrigin = pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, FinancialCouncilInstance>;
+	type MaxSlippageSwapWithDex = MaxSlippageSwapWithDex;
+	type Currency = orml_currencies::Module<Runtime>;
+	type Dex = module_dex::Module<Runtime>;
 }
 
 impl module_honzon::Trait for Runtime {
@@ -461,6 +464,7 @@ impl module_cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = module_auction_manager::Module<Runtime>;
 	type UpdateOrigin = pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, FinancialCouncilInstance>;
+	type Dex = module_dex::Module<Runtime>;
 }
 
 construct_runtime!(


### PR DESCRIPTION
1. Add slippage calculation function in dex module
2. Liquidate unsafe CDP will directly exchange with DEX when meets some conditions
3. All auctions creation functions be called in cdp_treasury module now