### PR TITLE
rename CurrencyId to AirDropCurrencyId in airdrop::Trait

### DIFF
--- a/modules/airdrop/src/lib.rs
+++ b/modules/airdrop/src/lib.rs
@@ -9,24 +9,24 @@ mod tests;
 
 pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-	type CurrencyId: Parameter + Member + Copy + MaybeSerializeDeserialize + Ord;
+	type AirDropCurrencyId: Parameter + Member + Copy + MaybeSerializeDeserialize + Ord;
 	type Balance: Parameter + Member + AtLeast32Bit + Default + Copy + MaybeSerializeDeserialize;
 }
 
 decl_storage! {
 	trait Store for Module<T: Trait> as AirDrop {
-		AirDrops get(fn airdrops): double_map hasher(twox_64_concat) T::AccountId, hasher(twox_64_concat) T::CurrencyId => T::Balance;
+		AirDrops get(fn airdrops): double_map hasher(twox_64_concat) T::AccountId, hasher(twox_64_concat) T::AirDropCurrencyId => T::Balance;
 	}
 }
 
 decl_event!(
 	pub enum Event<T> where
 		<T as system::Trait>::AccountId,
-		<T as Trait>::CurrencyId,
+		<T as Trait>::AirDropCurrencyId,
 		<T as Trait>::Balance,
 	{
-		Airdrop(AccountId, CurrencyId, Balance),
-		UpdateAirdrop(AccountId, CurrencyId, Balance),
+		Airdrop(AccountId, AirDropCurrencyId, Balance),
+		UpdateAirdrop(AccountId, AirDropCurrencyId, Balance),
 	}
 );
 
@@ -37,7 +37,7 @@ decl_module! {
 		pub fn airdrop(
 			origin,
 			to: T::AccountId,
-			currency_id: T::CurrencyId,
+			currency_id: T::AirDropCurrencyId,
 			amount: T::Balance,
 		) {
 			ensure_root(origin)?;
@@ -48,7 +48,7 @@ decl_module! {
 		pub fn update_airdrop(
 			origin,
 			to: T::AccountId,
-			currency_id: T::CurrencyId,
+			currency_id: T::AirDropCurrencyId,
 			amount: T::Balance,
 		) {
 			ensure_root(origin)?;

--- a/modules/airdrop/src/mock.rs
+++ b/modules/airdrop/src/mock.rs
@@ -25,12 +25,12 @@ impl_outer_event! {
 pub type AccountId = u64;
 pub type BlockNumber = u64;
 pub type Balance = u64;
-pub type CurrencyId = u32;
+pub type AirDropCurrencyId = u32;
 
 pub const ALICE: AccountId = 0;
 pub const BOB: AccountId = 1;
-pub const KAR: CurrencyId = 0;
-pub const ACA: CurrencyId = 1;
+pub const KAR: AirDropCurrencyId = 0;
+pub const ACA: AirDropCurrencyId = 1;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Runtime;
@@ -68,7 +68,7 @@ pub type System = system::Module<Runtime>;
 
 impl Trait for Runtime {
 	type Event = TestEvent;
-	type CurrencyId = CurrencyId;
+	type AirDropCurrencyId = AirDropCurrencyId;
 	type Balance = Balance;
 }
 pub type Airdrop = Module<Runtime>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -648,7 +648,7 @@ impl module_accounts::Trait for Runtime {
 
 impl module_airdrop::Trait for Runtime {
 	type Event = Event;
-	type CurrencyId = AirDropCurrencyId;
+	type AirDropCurrencyId = AirDropCurrencyId;
 	type Balance = Balance;
 }
 


### PR DESCRIPTION
Avoid being treated as the same type in type registeration of SDK