### PR TITLE
fix calculation to make sure get_supply_amount can afford target amount

### DIFF
--- a/modules/cdp_engine/src/lib.rs
+++ b/modules/cdp_engine/src/lib.rs
@@ -608,7 +608,7 @@ impl<T: Trait> Module<T> {
 
 		// forth: handle bad debt and collateral
 		if !supply_amount.is_zero() 				// supply_amount must not be zero
-		&& collateral_balance >= supply_amount		// can afford supply_amount
+		&& collateral_balance >= supply_amount		// make sure supply can afford target debit amount
 		&& slippage_limit > Ratio::from_natural(0)	// slippage_limit must be greater than zero
 		&& slippage.map_or(false, |s| s <= slippage_limit)
 		{

--- a/modules/cdp_treasury/src/lib.rs
+++ b/modules/cdp_treasury/src/lib.rs
@@ -251,15 +251,13 @@ impl<T: Trait> CDPTreasuryExtended<T::AccountId> for Module<T> {
 		supply_amount: BalanceOf<T>,
 		target_amount: BalanceOf<T>,
 	) {
-		if T::Dex::exchange_currency(
+		if let Ok(amount) = T::Dex::exchange_currency(
 			Self::account_id(),
 			(currency_id, supply_amount),
 			(T::GetStableCurrencyId::get(), target_amount),
-		)
-		.is_ok()
-		{
+		) {
 			<TotalCollaterals<T>>::mutate(currency_id, |balance| *balance -= supply_amount);
-			<SurplusPool<T>>::mutate(|surplus| *surplus += target_amount);
+			<SurplusPool<T>>::mutate(|surplus| *surplus += amount);
 		}
 	}
 

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -7,7 +7,7 @@ use sp_runtime::{
 		AccountIdConversion, AtLeast32Bit, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Member, Saturating,
 		UniqueSaturatedInto, Zero,
 	},
-	DispatchResult, ModuleId,
+	DispatchError, ModuleId,
 };
 use support::{DexManager, Price, Rate, Ratio};
 use system::{self as system, ensure_signed};
@@ -259,7 +259,7 @@ impl<T: Trait> Module<T> {
 		other_currency_id: CurrencyIdOf<T>,
 		other_currency_amount: BalanceOf<T>,
 		min_base_currency_amount: BalanceOf<T>,
-	) -> DispatchResult {
+	) -> rstd::result::Result<BalanceOf<T>, DispatchError> {
 		ensure!(
 			!other_currency_amount.is_zero()
 				&& T::Currency::ensure_can_withdraw(other_currency_id, &who, other_currency_amount).is_ok(),
@@ -284,6 +284,7 @@ impl<T: Trait> Module<T> {
 				pool.1.saturating_sub(base_currency_amount),
 			);
 		});
+
 		Self::deposit_event(RawEvent::Swap(
 			who,
 			other_currency_id,
@@ -291,7 +292,7 @@ impl<T: Trait> Module<T> {
 			base_currency_id,
 			base_currency_amount,
 		));
-		Ok(())
+		Ok(base_currency_amount)
 	}
 
 	// use base currency to swap other currency
@@ -300,7 +301,7 @@ impl<T: Trait> Module<T> {
 		other_currency_id: CurrencyIdOf<T>,
 		base_currency_amount: BalanceOf<T>,
 		min_other_currency_amount: BalanceOf<T>,
-	) -> DispatchResult {
+	) -> rstd::result::Result<BalanceOf<T>, DispatchError> {
 		let base_currency_id = T::GetBaseCurrencyId::get();
 		ensure!(
 			!base_currency_amount.is_zero()
@@ -325,6 +326,7 @@ impl<T: Trait> Module<T> {
 				pool.1.saturating_add(base_currency_amount),
 			);
 		});
+
 		Self::deposit_event(RawEvent::Swap(
 			who,
 			base_currency_id,
@@ -332,7 +334,7 @@ impl<T: Trait> Module<T> {
 			other_currency_id,
 			other_currency_amount,
 		));
-		Ok(())
+		Ok(other_currency_amount)
 	}
 
 	// use other currency to swap another other currency
@@ -342,7 +344,7 @@ impl<T: Trait> Module<T> {
 		supply_other_currency_amount: BalanceOf<T>,
 		target_other_currency_id: CurrencyIdOf<T>,
 		min_target_other_currency_amount: BalanceOf<T>,
-	) -> DispatchResult {
+	) -> rstd::result::Result<BalanceOf<T>, DispatchError> {
 		ensure!(
 			!supply_other_currency_amount.is_zero()
 				&& T::Currency::ensure_can_withdraw(supply_other_currency_id, &who, supply_other_currency_amount)
@@ -392,6 +394,7 @@ impl<T: Trait> Module<T> {
 				pool.1.saturating_add(intermediate_base_currency_amount),
 			);
 		});
+
 		Self::deposit_event(RawEvent::Swap(
 			who,
 			supply_other_currency_id,
@@ -399,7 +402,7 @@ impl<T: Trait> Module<T> {
 			target_other_currency_id,
 			target_other_currency_amount,
 		));
-		Ok(())
+		Ok(target_other_currency_amount)
 	}
 
 	// get the minimum amount of supply currency needed for the target currency amount
@@ -480,7 +483,7 @@ impl<T: Trait> DexManager<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>> for Modul
 		who: T::AccountId,
 		supply: (CurrencyIdOf<T>, BalanceOf<T>),
 		target: (CurrencyIdOf<T>, BalanceOf<T>),
-	) -> DispatchResult {
+	) -> rstd::result::Result<BalanceOf<T>, DispatchError> {
 		let base_currency_id = T::GetBaseCurrencyId::get();
 		ensure!(target.0 != supply.0, Error::<T>::CanNotSwapItself);
 		if target.0 == base_currency_id {

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -144,7 +144,7 @@ fn swap_other_to_base_work() {
 			DexModule::swap_other_to_base(CAROL, BTC, 10000, 5000000),
 			Error::<Runtime>::InacceptablePrice,
 		);
-		assert_ok!(DexModule::swap_other_to_base(CAROL, BTC, 10000, 4950000));
+		assert_eq!(DexModule::swap_other_to_base(CAROL, BTC, 10000, 4950000).is_ok(), true);
 
 		let swap_event = TestEvent::dex(RawEvent::Swap(CAROL, BTC, 10000, AUSD, 4950000));
 		assert!(System::events().iter().any(|record| record.event == swap_event));
@@ -171,7 +171,7 @@ fn swap_base_to_other_work() {
 			DexModule::swap_base_to_other(CAROL, BTC, 10000, 5000),
 			Error::<Runtime>::InacceptablePrice,
 		);
-		assert_ok!(DexModule::swap_base_to_other(CAROL, BTC, 10000, 4950));
+		assert_eq!(DexModule::swap_base_to_other(CAROL, BTC, 10000, 4950).is_ok(), true);
 
 		let swap_event = TestEvent::dex(RawEvent::Swap(CAROL, AUSD, 10000, BTC, 4950));
 		assert!(System::events().iter().any(|record| record.event == swap_event));
@@ -200,7 +200,7 @@ fn swap_other_to_other_work() {
 			DexModule::swap_other_to_other(CAROL, DOT, 1000, BTC, 35),
 			Error::<Runtime>::InacceptablePrice,
 		);
-		assert_ok!(DexModule::swap_other_to_other(CAROL, DOT, 1000, BTC, 34));
+		assert_eq!(DexModule::swap_other_to_other(CAROL, DOT, 1000, BTC, 34).is_ok(), true);
 
 		let swap_event = TestEvent::dex(RawEvent::Swap(CAROL, DOT, 1000, BTC, 34));
 		assert!(System::events().iter().any(|record| record.event == swap_event));
@@ -250,9 +250,15 @@ fn exchange_currency_work() {
 			DexModule::exchange_currency(CAROL, (BTC, 101), (DOT, 1000)),
 			Error::<Runtime>::TokenNotEnough
 		);
-		assert_ok!(DexModule::exchange_currency(CAROL, (BTC, 100), (AUSD, 4950)));
-		assert_ok!(DexModule::exchange_currency(CAROL, (AUSD, 4950), (BTC, 90)));
-		assert_ok!(DexModule::exchange_currency(CAROL, (BTC, 90), (DOT, 300)));
+		assert_eq!(
+			DexModule::exchange_currency(CAROL, (BTC, 100), (AUSD, 4950)).is_ok(),
+			true
+		);
+		assert_eq!(
+			DexModule::exchange_currency(CAROL, (AUSD, 4950), (BTC, 90)).is_ok(),
+			true
+		);
+		assert_eq!(DexModule::exchange_currency(CAROL, (BTC, 90), (DOT, 300)).is_ok(), true);
 	});
 }
 
@@ -261,7 +267,10 @@ fn get_supply_amount_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(DexModule::add_liquidity(Origin::signed(ALICE), BTC, 10000, 10000));
 		let supply_amount = DexModule::get_supply_amount(BTC, AUSD, 4950);
-		assert_ok!(DexModule::exchange_currency(BOB, (BTC, supply_amount), (AUSD, 4950)));
+		assert_eq!(
+			DexModule::exchange_currency(BOB, (BTC, supply_amount), (AUSD, 4950)).is_ok(),
+			true
+		);
 	});
 }
 

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -9,7 +9,7 @@ use mock::{DexModule, ExtBuilder, Origin, Runtime, System, TestEvent, Tokens, AC
 #[test]
 fn calculate_swap_target_amount_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(DexModule::calculate_swap_target_amount(10000, 10000, 10000), 4950);
+		assert!(DexModule::calculate_swap_target_amount(10000, 10000, 10000) <= 4950);
 		// when target pool is 1
 		assert_eq!(DexModule::calculate_swap_target_amount(10000, 1, 10000), 0);
 		// when supply is too big
@@ -22,8 +22,41 @@ fn calculate_swap_target_amount_work() {
 #[test]
 fn calculate_swap_supply_amount_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert!(DexModule::calculate_swap_supply_amount(10000, 10000, 4950) <= 10000);
-		assert_eq!(DexModule::calculate_swap_supply_amount(10000, 1, 1), 0);
+		assert!(DexModule::calculate_swap_supply_amount(10000, 10000, 4950) >= 10000);
+		// when target amount is too big
+		assert_eq!(DexModule::calculate_swap_supply_amount(10000, 10000, 10000), 0);
+		// when target amount is zero
+		assert_eq!(DexModule::calculate_swap_supply_amount(10000, 10000, 0), 0);
+	});
+}
+
+#[test]
+fn make_sure_get_supply_amount_needed_can_affort_target() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(DexModule::add_liquidity(
+			Origin::signed(ALICE),
+			BTC,
+			500000000000,
+			100000000000000000
+		));
+		assert_ok!(DexModule::add_liquidity(
+			Origin::signed(BOB),
+			DOT,
+			80000000000,
+			4000000000000000
+		));
+
+		let target_amount_btc_ausd = 90000000000000;
+		let surply_amount_btc_ausd = DexModule::get_supply_amount_needed(BTC, AUSD, target_amount_btc_ausd);
+		assert!(DexModule::get_target_amount_available(BTC, AUSD, surply_amount_btc_ausd) >= target_amount_btc_ausd);
+
+		let target_amount_ausd_dot = 8000000000000;
+		let surply_amount_ausd_dot = DexModule::get_supply_amount_needed(BTC, AUSD, target_amount_ausd_dot);
+		assert!(DexModule::get_target_amount_available(BTC, AUSD, surply_amount_ausd_dot) >= target_amount_ausd_dot);
+
+		let target_amount_btc_dot = 60000000000;
+		let surply_amount_btc_dot = DexModule::get_supply_amount_needed(BTC, AUSD, target_amount_btc_dot);
+		assert!(DexModule::get_target_amount_available(BTC, AUSD, surply_amount_btc_dot) >= target_amount_btc_dot);
 	});
 }
 

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -6,7 +6,7 @@ use rstd::{
 	cmp::{Eq, PartialEq},
 	fmt::Debug,
 };
-use sp_runtime::DispatchResult;
+use sp_runtime::{DispatchError, DispatchResult};
 
 pub type Price = FixedU128;
 pub type ExchangeRate = FixedU128;
@@ -59,7 +59,7 @@ pub trait DexManager<AccountId, CurrencyId, Balance> {
 		who: AccountId,
 		supply: (CurrencyId, Balance),
 		target: (CurrencyId, Balance),
-	) -> DispatchResult;
+	) -> rstd::result::Result<Balance, DispatchError>;
 
 	fn get_exchange_slippage(
 		supply_currency_id: CurrencyId,
@@ -84,8 +84,8 @@ where
 		_who: AccountId,
 		_supply: (CurrencyId, Balance),
 		_target: (CurrencyId, Balance),
-	) -> DispatchResult {
-		Ok(())
+	) -> rstd::result::Result<Balance, DispatchError> {
+		Ok(Default::default())
 	}
 
 	fn get_exchange_slippage(

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -105,7 +105,7 @@ mod tests {
 			.build()
 			.execute_with(|| {
 				assert_eq!(DexModule::calculate_swap_target_amount(10000, 10000, 10000), 4995);
-				assert_eq!(DexModule::calculate_swap_supply_amount(10000, 10000, 4995), 9996);
+				assert!(DexModule::calculate_swap_supply_amount(10000, 10000, 4995) >= 9996);
 
 				assert_eq!(DexModule::liquidity_pool(XBTC), (0, 0));
 				assert_eq!(DexModule::total_shares(XBTC), 0);


### PR DESCRIPTION
fix #137 

In calculation steps, when multiple an FixedU128,  adding 1 to the result. The result may be a bit larger, but can ensure to swap target amount successfully.

Later, will decide whether to add 1 or not based on the remainder, that needs FixedU128 support new multiple function.