### PR TITLE
refactor token flows among modules

### DIFF
--- a/modules/auction_manager/src/mock.rs
+++ b/modules/auction_manager/src/mock.rs
@@ -103,9 +103,9 @@ impl cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = AuctionManagerModule;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
-	type Dex = ();
+	type DEX = ();
 }
-pub type CdpTreasury = cdp_treasury::Module<Runtime>;
+pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 
 pub struct MockPriceSource;
 impl PriceProvider<CurrencyId, Price> for MockPriceSource {
@@ -130,7 +130,7 @@ impl Trait for Runtime {
 	type AuctionDurationSoftCap = AuctionDurationSoftCap;
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
-	type Treasury = CdpTreasury;
+	type CDPTreasury = CDPTreasuryModule;
 	type GetAmountAdjustment = GetAmountAdjustment;
 	type PriceSource = MockPriceSource;
 }

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -5,8 +5,8 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{
-	Auction as AuctionModule, AuctionManagerModule, CdpTreasury, ExtBuilder, Runtime, System, TestEvent, Tokens, ACA,
-	ALICE, AUSD, BOB, BTC, CAROL,
+	Auction as AuctionModule, AuctionManagerModule, CDPTreasuryModule, ExtBuilder, Runtime, System, TestEvent, Tokens,
+	ACA, ALICE, AUSD, BOB, BTC, CAROL,
 };
 
 #[test]
@@ -59,19 +59,19 @@ fn new_surplus_auction_work() {
 fn on_new_bid_for_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
-		assert_eq!(CdpTreasury::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 4), None).accept_bid, false);
 		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 5), None).accept_bid, true);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 995);
-		assert_eq!(CdpTreasury::surplus_pool(), 5);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 5);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 10), Some((BOB, 5))).accept_bid,
 			true
 		);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &CAROL), 990);
-		assert_eq!(CdpTreasury::surplus_pool(), 10);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 10);
 	});
 }
 
@@ -81,7 +81,7 @@ fn on_new_bid_for_debit_auction_work() {
 		AuctionManagerModule::new_debit_auction(200, 100);
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
-		assert_eq!(CdpTreasury::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 99), None).accept_bid,
@@ -92,14 +92,14 @@ fn on_new_bid_for_debit_auction_work() {
 			true
 		);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
-		assert_eq!(CdpTreasury::surplus_pool(), 100);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 200), Some((BOB, 100))).accept_bid,
 			true
 		);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 100);
-		assert_eq!(CdpTreasury::surplus_pool(), 100);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &CAROL), 900);
 	});
@@ -110,7 +110,6 @@ fn on_new_bid_for_surplus_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		AuctionManagerModule::new_surplus_auction(100);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &CdpTreasury::account_id()), 100);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
 		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 0), None).accept_bid, false);
 		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 50), None).accept_bid, true);
@@ -188,11 +187,13 @@ fn bid_when_soft_cap_for_surplus_auction_work() {
 #[test]
 fn reverse_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &CAROL, 100));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
 		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(CdpTreasury::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 200), None).accept_bid,
 			true
@@ -200,27 +201,30 @@ fn reverse_collateral_auction_work() {
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
 		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
-		assert_eq!(CdpTreasury::surplus_pool(), 200);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 200);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(2, 0, (BOB, 400), Some((BOB, 200))).accept_bid,
 			true
 		);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 50);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 50);
 		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1050);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
-		assert_eq!(CdpTreasury::surplus_pool(), 200);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 200);
 	});
 }
 
 #[test]
 fn on_auction_ended_for_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &CAROL, 100));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
 		assert_eq!(Tokens::free_balance(BTC, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(CdpTreasury::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 200), None).accept_bid,
 			true
@@ -228,8 +232,9 @@ fn on_auction_ended_for_collateral_auction_work() {
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
 		AuctionManagerModule::on_auction_ended(0, Some((BOB, 200)));
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
-		assert_eq!(Tokens::free_balance(BTC, &BOB), 1100);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(Tokens::free_balance(BTC, &BOB), 1100);
 	});
 }
 
@@ -259,9 +264,10 @@ fn on_auction_ended_for_debit_auction_work() {
 #[test]
 fn on_auction_ended_for_surplus_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CDPTreasuryModule::on_system_surplus(100));
 		AuctionManagerModule::new_surplus_auction(100);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &AuctionManagerModule::account_id()), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
 		assert_eq!(Tokens::total_issuance(ACA), 3000);
@@ -269,12 +275,11 @@ fn on_auction_ended_for_surplus_auction_work() {
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 500), None).accept_bid,
 			true
 		);
-		assert_eq!(Tokens::free_balance(AUSD, &AuctionManagerModule::account_id()), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 500);
 		assert_eq!(Tokens::total_issuance(ACA), 2500);
 		AuctionManagerModule::on_auction_ended(0, Some((BOB, 500)));
-		assert_eq!(Tokens::free_balance(AUSD, &AuctionManagerModule::account_id()), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1100);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 0);
 	});
@@ -290,8 +295,6 @@ fn cancel_surplus_auction_work() {
 		AuctionManagerModule::new_surplus_auction(100);
 		assert_eq!(AuctionManagerModule::surplus_auctions(0).is_some(), true);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &AuctionManagerModule::account_id()), 100);
-		assert_eq!(CdpTreasury::surplus_pool(), 0);
 		assert_eq!(AuctionModule::auction_info(0).is_some(), true);
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 500), None).accept_bid,
@@ -306,7 +309,6 @@ fn cancel_surplus_auction_work() {
 
 		assert_eq!(AuctionManagerModule::surplus_auctions(0).is_some(), false);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 0);
-		assert_eq!(CdpTreasury::surplus_pool(), 100);
 		assert_eq!(AuctionModule::auction_info(0).is_some(), false);
 	});
 }
@@ -374,14 +376,20 @@ fn cancel_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &CAROL, 10));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 10);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 100);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
 		assert_ok!(AuctionModule::bid(Some(BOB).into(), 0, 80));
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 920);
-		assert_eq!(CdpTreasury::total_collaterals(BTC), 0);
-		assert_eq!(CdpTreasury::debit_pool(), 0);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 80);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+
 		assert_ok!(AuctionManagerModule::cancel_collateral_auction(0));
 
 		let cancel_auction_event = TestEvent::auction_manager(RawEvent::CancelAuction(0));
@@ -392,9 +400,9 @@ fn cancel_collateral_auction_work() {
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
-		assert_eq!(CdpTreasury::total_collaterals(BTC), 10);
-		assert_eq!(CdpTreasury::debit_pool(), 80);
-		assert_eq!(CdpTreasury::surplus_pool(), 80);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 80);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 80);
 		assert_eq!(AuctionManagerModule::collateral_auctions(0).is_some(), false);
 		assert_eq!(AuctionModule::auction_info(0).is_some(), false);
 	});

--- a/modules/cdp_treasury/src/mock.rs
+++ b/modules/cdp_treasury/src/mock.rs
@@ -45,6 +45,7 @@ pub type Balance = u64;
 pub type Amount = i64;
 pub type CurrencyId = u32;
 pub type Share = u64;
+pub type AuctionId = u64;
 
 pub const ALICE: AccountId = 0;
 pub const BOB: AccountId = 1;
@@ -118,12 +119,13 @@ impl dex::Trait for Runtime {
 	type GetBaseCurrencyId = GetStableCurrencyId;
 	type GetExchangeFee = GetExchangeFee;
 }
-pub type DexModule = dex::Module<Runtime>;
+pub type DEXModule = dex::Module<Runtime>;
 
 pub struct MockAuctionManager;
 impl AuctionManager<AccountId> for MockAuctionManager {
 	type CurrencyId = CurrencyId;
 	type Balance = Balance;
+	type AuctionId = AuctionId;
 
 	fn new_collateral_auction(
 		_who: &AccountId,
@@ -136,6 +138,18 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
 
 	fn new_surplus_auction(_amount: Self::Balance) {}
+
+	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
+		Ok(())
+	}
+
+	fn get_total_collateral_in_auction(_id: Self::CurrencyId) -> Self::Balance {
+		Default::default()
+	}
+
+	fn get_total_surplus_in_auction() -> Self::Balance {
+		Default::default()
+	}
 
 	fn get_total_debit_in_auction() -> Self::Balance {
 		Default::default()
@@ -156,9 +170,9 @@ impl Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = MockAuctionManager;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
-	type Dex = DexModule;
+	type DEX = DEXModule;
 }
-pub type CdpTreasuryModule = Module<Runtime>;
+pub type CDPTreasuryModule = Module<Runtime>;
 
 pub struct ExtBuilder {
 	endowed_accounts: Vec<(AccountId, CurrencyId, Balance)>,
@@ -167,7 +181,14 @@ pub struct ExtBuilder {
 impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
-			endowed_accounts: vec![(ALICE, ACA, 1000), (ALICE, AUSD, 1000), (ALICE, BTC, 1000)],
+			endowed_accounts: vec![
+				(ALICE, ACA, 1000),
+				(ALICE, AUSD, 1000),
+				(ALICE, BTC, 1000),
+				(BOB, ACA, 1000),
+				(BOB, AUSD, 1000),
+				(BOB, BTC, 1000),
+			],
 		}
 	}
 }

--- a/modules/cdp_treasury/src/tests.rs
+++ b/modules/cdp_treasury/src/tests.rs
@@ -5,19 +5,19 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{
-	CdpTreasuryModule, Currencies, DexModule, ExtBuilder, Origin, Runtime, System, TestEvent, ALICE, AUSD, BOB, BTC,
+	CDPTreasuryModule, Currencies, DEXModule, ExtBuilder, Origin, Runtime, System, TestEvent, ALICE, AUSD, BOB, BTC,
 };
 use sp_runtime::traits::{BadOrigin, OnFinalize};
 
 #[test]
 fn set_collateral_auction_maximum_size_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(CdpTreasuryModule::collateral_auction_maximum_size(BTC), 0);
+		assert_eq!(CDPTreasuryModule::collateral_auction_maximum_size(BTC), 0);
 		assert_noop!(
-			CdpTreasuryModule::set_collateral_auction_maximum_size(Origin::signed(5), BTC, 200),
+			CDPTreasuryModule::set_collateral_auction_maximum_size(Origin::signed(5), BTC, 200),
 			BadOrigin
 		);
-		assert_ok!(CdpTreasuryModule::set_collateral_auction_maximum_size(
+		assert_ok!(CDPTreasuryModule::set_collateral_auction_maximum_size(
 			Origin::signed(1),
 			BTC,
 			200
@@ -29,12 +29,12 @@ fn set_collateral_auction_maximum_size_work() {
 			.iter()
 			.any(|record| record.event == update_collateral_auction_maximum_size_event));
 
-		assert_ok!(CdpTreasuryModule::set_collateral_auction_maximum_size(
+		assert_ok!(CDPTreasuryModule::set_collateral_auction_maximum_size(
 			Origin::ROOT,
 			BTC,
 			200
 		));
-		assert_eq!(CdpTreasuryModule::collateral_auction_maximum_size(BTC), 200);
+		assert_eq!(CDPTreasuryModule::collateral_auction_maximum_size(BTC), 200);
 	});
 }
 
@@ -42,7 +42,7 @@ fn set_collateral_auction_maximum_size_work() {
 fn set_debit_and_surplus_handle_params_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
-			CdpTreasuryModule::set_debit_and_surplus_handle_params(
+			CDPTreasuryModule::set_debit_and_surplus_handle_params(
 				Origin::signed(5),
 				Some(100),
 				Some(1000),
@@ -51,7 +51,7 @@ fn set_debit_and_surplus_handle_params_work() {
 			),
 			BadOrigin
 		);
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
+		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
 			Origin::signed(1),
 			Some(100),
 			Some(1000),
@@ -78,137 +78,65 @@ fn set_debit_and_surplus_handle_params_work() {
 			.iter()
 			.any(|record| record.event == update_debit_auction_fixed_size_event));
 
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
+		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
 			Origin::ROOT,
 			Some(100),
 			Some(1000),
 			Some(200),
 			Some(100),
 		));
-		assert_eq!(CdpTreasuryModule::surplus_auction_fixed_size(), 100);
-		assert_eq!(CdpTreasuryModule::surplus_buffer_size(), 1000);
-		assert_eq!(CdpTreasuryModule::initial_amount_per_debit_auction(), 200);
-		assert_eq!(CdpTreasuryModule::debit_auction_fixed_size(), 100);
-	});
-}
-
-#[test]
-fn create_surplus_auction_on_finailize_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			Some(100),
-			Some(1000),
-			None,
-			None,
-		));
-		CdpTreasuryModule::on_system_surplus(1099);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1099);
-		CdpTreasuryModule::on_finalize(1);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1099);
-		CdpTreasuryModule::on_system_surplus(102);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 1201);
-		CdpTreasuryModule::on_finalize(2);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1001);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 1001);
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			Some(0),
-			None,
-			None,
-			None,
-		));
-		CdpTreasuryModule::on_system_surplus(99);
-		CdpTreasuryModule::on_finalize(3);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1100);
-	});
-}
-
-#[test]
-fn create_debit_auction_on_finailize_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			None,
-			None,
-			Some(200),
-			Some(100),
-		));
-		CdpTreasuryModule::on_system_debit(99);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 99);
-		CdpTreasuryModule::on_finalize(1);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 99);
-		CdpTreasuryModule::on_system_debit(2);
-		CdpTreasuryModule::on_finalize(2);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 1);
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			None,
-			None,
-			Some(0),
-			None,
-		));
-		CdpTreasuryModule::on_system_debit(99);
-		CdpTreasuryModule::on_finalize(3);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 100);
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			None,
-			None,
-			Some(200),
-			Some(0),
-		));
-		CdpTreasuryModule::on_finalize(4);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 100);
+		assert_eq!(CDPTreasuryModule::surplus_auction_fixed_size(), 100);
+		assert_eq!(CDPTreasuryModule::surplus_buffer_size(), 1000);
+		assert_eq!(CDPTreasuryModule::initial_amount_per_debit_auction(), 200);
+		assert_eq!(CDPTreasuryModule::debit_auction_fixed_size(), 100);
 	});
 }
 
 #[test]
 fn on_system_debit_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 0);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 0);
-		CdpTreasuryModule::on_system_debit(1000);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 1000);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+		assert_ok!(CDPTreasuryModule::on_system_debit(1000));
+		assert_eq!(CDPTreasuryModule::debit_pool(), 1000);
 	});
 }
 
 #[test]
 fn on_system_surplus_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 0);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 0);
-		CdpTreasuryModule::on_system_surplus(1000);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 1000);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1000);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 1000);
 	});
 }
 
 #[test]
 fn offset_debit_and_surplus_on_finalize_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 0);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 0);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 0);
-		CdpTreasuryModule::on_system_surplus(1000);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 1000);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1000);
-		CdpTreasuryModule::on_finalize(1);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 1000);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1000);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 0);
-		CdpTreasuryModule::on_system_debit(300);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 300);
-		CdpTreasuryModule::on_finalize(2);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 700);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 700);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 0);
-		CdpTreasuryModule::on_system_debit(800);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 800);
-		CdpTreasuryModule::on_finalize(3);
-		assert_eq!(Currencies::free_balance(AUSD, &CdpTreasuryModule::account_id()), 0);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 0);
-		assert_eq!(CdpTreasuryModule::debit_pool(), 100);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 1000);
+		CDPTreasuryModule::on_finalize(1);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 1000);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+		assert_ok!(CDPTreasuryModule::on_system_debit(300));
+		assert_eq!(CDPTreasuryModule::debit_pool(), 300);
+		CDPTreasuryModule::on_finalize(2);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 700);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 700);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+		assert_ok!(CDPTreasuryModule::on_system_debit(800));
+		assert_eq!(CDPTreasuryModule::debit_pool(), 800);
+		CDPTreasuryModule::on_finalize(3);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 100);
 	});
 }
 
@@ -216,7 +144,7 @@ fn offset_debit_and_surplus_on_finalize_work() {
 fn deposit_backed_debit_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 1000);
-		assert_ok!(CdpTreasuryModule::deposit_backed_debit(&ALICE, 1000));
+		assert_ok!(CDPTreasuryModule::deposit_backed_debit(&ALICE, 1000));
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 2000);
 	});
 }
@@ -225,10 +153,10 @@ fn deposit_backed_debit_work() {
 fn withdraw_backed_debit_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 1000);
-		assert_ok!(CdpTreasuryModule::withdraw_backed_debit(&ALICE, 1000));
+		assert_ok!(CDPTreasuryModule::withdraw_backed_debit(&ALICE, 1000));
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 0);
 		assert_noop!(
-			CdpTreasuryModule::withdraw_backed_debit(&ALICE, 1000),
+			CDPTreasuryModule::withdraw_backed_debit(&ALICE, 1000),
 			orml_tokens::Error::<Runtime>::BalanceTooLow,
 		);
 	});
@@ -237,67 +165,80 @@ fn withdraw_backed_debit_work() {
 #[test]
 fn emergency_shutdown_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CdpTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::ROOT,
-			Some(100),
-			Some(1000),
-			None,
-			None,
-		));
-		CdpTreasuryModule::on_system_surplus(2000);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 2000);
-		CdpTreasuryModule::on_finalize(1);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 1000);
-		assert_eq!(CdpTreasuryModule::is_shutdown(), false);
-		CdpTreasuryModule::emergency_shutdown();
-		assert_eq!(CdpTreasuryModule::is_shutdown(), true);
-		CdpTreasuryModule::on_system_surplus(1000);
-		CdpTreasuryModule::on_finalize(2);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 2000);
+		assert_eq!(CDPTreasuryModule::is_shutdown(), false);
+		CDPTreasuryModule::emergency_shutdown();
+		assert_eq!(CDPTreasuryModule::is_shutdown(), true);
 	});
 }
 
 #[test]
-fn deposit_system_collateral_work() {
+fn transfer_system_surplus_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 0);
-		assert_eq!(Currencies::free_balance(BTC, &CdpTreasuryModule::account_id()), 0);
-		CdpTreasuryModule::deposit_system_collateral(BTC, 100);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 100);
-		assert_eq!(Currencies::free_balance(BTC, &CdpTreasuryModule::account_id()), 100);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_noop!(
+			CDPTreasuryModule::transfer_system_surplus(&ALICE, 500),
+			Error::<Runtime>::SurplusPoolNotEnough,
+		);
+		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 1000);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
+		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 1000);
+		assert_ok!(CDPTreasuryModule::transfer_system_surplus(&ALICE, 500));
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 500);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 500);
+		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 1500);
+	});
+}
+
+#[test]
+fn transfer_collateral_from_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(Currencies::free_balance(BTC, &CDPTreasuryModule::account_id()), 0);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
+		assert_eq!(
+			CDPTreasuryModule::transfer_collateral_from(BTC, &ALICE, 10000).is_ok(),
+			false
+		);
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &ALICE, 500));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 500);
+		assert_eq!(Currencies::free_balance(BTC, &CDPTreasuryModule::account_id()), 500);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 500);
 	});
 }
 
 #[test]
 fn transfer_system_collateral_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		CdpTreasuryModule::deposit_system_collateral(BTC, 500);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 500);
-		assert_eq!(Currencies::free_balance(BTC, &CdpTreasuryModule::account_id()), 500);
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &ALICE, 500));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 500);
+		assert_eq!(Currencies::free_balance(BTC, &CDPTreasuryModule::account_id()), 500);
+		assert_eq!(Currencies::free_balance(BTC, &BOB), 1000);
 		assert_noop!(
-			CdpTreasuryModule::transfer_system_collateral(BTC, &BOB, 501),
+			CDPTreasuryModule::transfer_system_collateral(BTC, &BOB, 501),
 			Error::<Runtime>::CollateralNotEnough,
 		);
-		assert_ok!(CdpTreasuryModule::transfer_system_collateral(BTC, &BOB, 400));
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 100);
-		assert_eq!(Currencies::free_balance(BTC, &CdpTreasuryModule::account_id()), 100);
-		assert_eq!(Currencies::free_balance(BTC, &BOB), 400);
+		assert_ok!(CDPTreasuryModule::transfer_system_collateral(BTC, &BOB, 400));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
+		assert_eq!(Currencies::free_balance(BTC, &CDPTreasuryModule::account_id()), 100);
+		assert_eq!(Currencies::free_balance(BTC, &BOB), 1400);
 	});
 }
 
 #[test]
 fn get_total_collaterals_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		CdpTreasuryModule::deposit_system_collateral(BTC, 500);
-		assert_eq!(CdpTreasuryModule::get_total_collaterals(BTC), 500);
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &ALICE, 500));
+		assert_eq!(CDPTreasuryModule::get_total_collaterals(BTC), 500);
 	});
 }
 
 #[test]
 fn get_surplus_pool_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		CdpTreasuryModule::on_system_surplus(1000);
-		assert_eq!(CdpTreasuryModule::get_surplus_pool(), 1000);
+		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
+		assert_eq!(CDPTreasuryModule::get_surplus_pool(), 1000);
+		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
 	});
 }
 
@@ -305,7 +246,7 @@ fn get_surplus_pool_work() {
 fn get_stable_currency_ratio_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(
-			CdpTreasuryModule::get_stable_currency_ratio(100),
+			CDPTreasuryModule::get_stable_currency_ratio(100),
 			Ratio::from_rational(100, Currencies::total_issuance(AUSD))
 		);
 	});
@@ -314,28 +255,13 @@ fn get_stable_currency_ratio_work() {
 #[test]
 fn swap_collateral_to_stable_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(DexModule::add_liquidity(Origin::signed(ALICE), BTC, 100, 1000));
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 0);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 0);
-		CdpTreasuryModule::deposit_system_collateral(BTC, 100);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 100);
-		CdpTreasuryModule::swap_collateral_to_stable(BTC, 100, 500);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 0);
-		assert_eq!(CdpTreasuryModule::surplus_pool(), 500);
-	});
-}
-
-#[test]
-fn create_collateral_auctions_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CdpTreasuryModule::set_collateral_auction_maximum_size(
-			Origin::ROOT,
-			BTC,
-			100
-		));
-		CdpTreasuryModule::deposit_system_collateral(BTC, 1000);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 1000);
-		CdpTreasuryModule::create_collateral_auctions(BTC, 700, 2100, ALICE);
-		assert_eq!(CdpTreasuryModule::total_collaterals(BTC), 300);
+		assert_ok!(DEXModule::add_liquidity(Origin::signed(ALICE), BTC, 100, 1000));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_ok!(CDPTreasuryModule::transfer_collateral_from(BTC, &BOB, 100));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
+		assert_ok!(CDPTreasuryModule::swap_collateral_to_stable(BTC, 100, 500));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 500);
 	});
 }

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -9,7 +9,7 @@ use sp_runtime::{
 	},
 	DispatchError, ModuleId,
 };
-use support::{DexManager, Price, Rate, Ratio};
+use support::{DEXManager, Price, Rate, Ratio};
 use system::{self as system, ensure_signed};
 
 mod mock;
@@ -492,7 +492,7 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-impl<T: Trait> DexManager<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>> for Module<T> {
+impl<T: Trait> DEXManager<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>> for Module<T> {
 	fn get_target_amount(
 		supply_currency_id: CurrencyIdOf<T>,
 		target_currency_id: CurrencyIdOf<T>,

--- a/modules/emergency_shutdown/src/tests.rs
+++ b/modules/emergency_shutdown/src/tests.rs
@@ -5,7 +5,7 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{
-	CdpEngineModule, CdpTreasury, EmergencyShutdownModule, ExtBuilder, HonzonModule, Origin, Runtime, System,
+	CDPEngineModule, CDPTreasuryModule, EmergencyShutdownModule, ExtBuilder, HonzonModule, Origin, Runtime, System,
 	TestEvent, ALICE,
 };
 use sp_runtime::traits::BadOrigin;
@@ -15,8 +15,8 @@ fn emergency_shutdown_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(EmergencyShutdownModule::is_shutdown(), false);
 		assert_eq!(HonzonModule::is_shutdown(), false);
-		assert_eq!(CdpEngineModule::is_shutdown(), false);
-		assert_eq!(CdpTreasury::is_shutdown(), false);
+		assert_eq!(CDPEngineModule::is_shutdown(), false);
+		assert_eq!(CDPTreasuryModule::is_shutdown(), false);
 		assert_noop!(
 			EmergencyShutdownModule::emergency_shutdown(Origin::signed(5)),
 			BadOrigin,
@@ -28,8 +28,8 @@ fn emergency_shutdown_work() {
 
 		assert_eq!(EmergencyShutdownModule::is_shutdown(), true);
 		assert_eq!(HonzonModule::is_shutdown(), true);
-		assert_eq!(CdpEngineModule::is_shutdown(), true);
-		assert_eq!(CdpTreasury::is_shutdown(), true);
+		assert_eq!(CDPEngineModule::is_shutdown(), true);
+		assert_eq!(CDPTreasuryModule::is_shutdown(), true);
 		assert_noop!(
 			EmergencyShutdownModule::emergency_shutdown(Origin::ROOT),
 			Error::<Runtime>::AlreadyShutdown,
@@ -46,12 +46,6 @@ fn open_collateral_refund_fail() {
 			Error::<Runtime>::MustAfterShutdown,
 		);
 		assert_ok!(EmergencyShutdownModule::emergency_shutdown(Origin::ROOT));
-		CdpTreasury::on_system_surplus(100);
-		assert_eq!(CdpTreasury::get_surplus_pool(), 100);
-		assert_noop!(
-			EmergencyShutdownModule::open_collateral_refund(Origin::ROOT),
-			Error::<Runtime>::ExistSurplus,
-		);
 	});
 }
 

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -13,20 +13,20 @@ pub type ExchangeRate = FixedU128;
 pub type Ratio = FixedU128;
 pub type Rate = FixedU128;
 
-pub trait RiskManager<AccountId, CurrencyId, Amount, DebitAmount> {
-	fn check_position_adjustment(
-		account_id: &AccountId,
+pub trait RiskManager<AccountId, CurrencyId, Balance, DebitBalance> {
+	fn check_position_valid(
 		currency_id: CurrencyId,
-		collaterals: Amount,
-		debits: DebitAmount,
+		collateral_balance: Balance,
+		debit_balance: DebitBalance,
 	) -> DispatchResult;
 
-	fn check_debit_cap(currency_id: CurrencyId, debits: DebitAmount) -> DispatchResult;
+	fn check_debit_cap(currency_id: CurrencyId, total_debit_balance: DebitBalance) -> DispatchResult;
 }
 
 pub trait AuctionManager<AccountId> {
 	type CurrencyId;
 	type Balance;
+	type AuctionId: FullCodec + Debug + Clone + Eq + PartialEq;
 
 	fn new_collateral_auction(
 		who: &AccountId,
@@ -36,19 +36,15 @@ pub trait AuctionManager<AccountId> {
 	);
 	fn new_debit_auction(amount: Self::Balance, fix: Self::Balance);
 	fn new_surplus_auction(amount: Self::Balance);
+	fn cancel_auction(id: Self::AuctionId) -> DispatchResult;
+
+	fn get_total_collateral_in_auction(id: Self::CurrencyId) -> Self::Balance;
+	fn get_total_surplus_in_auction() -> Self::Balance;
 	fn get_total_debit_in_auction() -> Self::Balance;
 	fn get_total_target_in_auction() -> Self::Balance;
 }
 
-pub trait AuctionManagerExtended<AccountId>: AuctionManager<AccountId> {
-	type AuctionId: FullCodec + Debug + Clone + Eq + PartialEq;
-
-	fn get_total_collateral_in_auction(id: Self::CurrencyId) -> Self::Balance;
-	fn get_total_surplus_in_auction() -> Self::Balance;
-	fn cancel_auction(id: Self::AuctionId) -> DispatchResult;
-}
-
-pub trait DexManager<AccountId, CurrencyId, Balance> {
+pub trait DEXManager<AccountId, CurrencyId, Balance> {
 	fn get_target_amount(
 		supply_currency_id: CurrencyId,
 		target_currency_id: CurrencyId,
@@ -76,7 +72,7 @@ pub trait DexManager<AccountId, CurrencyId, Balance> {
 	) -> Option<Ratio>;
 }
 
-impl<AccountId, CurrencyId, Balance> DexManager<AccountId, CurrencyId, Balance> for ()
+impl<AccountId, CurrencyId, Balance> DEXManager<AccountId, CurrencyId, Balance> for ()
 where
 	Balance: Default,
 {
@@ -119,27 +115,35 @@ pub trait CDPTreasury<AccountId> {
 	type Balance;
 	type CurrencyId;
 
-	fn on_system_debit(amount: Self::Balance);
-	fn on_system_surplus(amount: Self::Balance);
+	fn get_surplus_pool() -> Self::Balance;
+	fn get_debit_pool() -> Self::Balance;
+	fn get_total_collaterals(id: Self::CurrencyId) -> Self::Balance;
+
+	fn on_system_debit(amount: Self::Balance) -> DispatchResult;
+	fn on_system_surplus(amount: Self::Balance) -> DispatchResult;
 	fn deposit_backed_debit(who: &AccountId, amount: Self::Balance) -> DispatchResult;
 	fn withdraw_backed_debit(who: &AccountId, amount: Self::Balance) -> DispatchResult;
-	fn deposit_system_collateral(currency_id: Self::CurrencyId, amount: Self::Balance);
+	fn transfer_system_surplus(to: &AccountId, amount: Self::Balance) -> DispatchResult;
+	fn transfer_surplus_from(from: &AccountId, amount: Self::Balance) -> DispatchResult;
 	fn transfer_system_collateral(
 		currency_id: Self::CurrencyId,
 		to: &AccountId,
 		amount: Self::Balance,
 	) -> DispatchResult;
+	fn transfer_collateral_from(
+		currency_id: Self::CurrencyId,
+		from: &AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult;
 }
 
 pub trait CDPTreasuryExtended<AccountId>: CDPTreasury<AccountId> {
-	fn get_surplus_pool() -> Self::Balance;
-	fn get_total_collaterals(id: Self::CurrencyId) -> Self::Balance;
 	fn get_stable_currency_ratio(amount: Self::Balance) -> Ratio;
 	fn swap_collateral_to_stable(
 		currency_id: Self::CurrencyId,
 		supply_amount: Self::Balance,
 		target_amount: Self::Balance,
-	);
+	) -> DispatchResult;
 	fn create_collateral_auctions(
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -499,7 +499,7 @@ impl module_auction_manager::Trait for Runtime {
 	type AuctionDurationSoftCap = AuctionDurationSoftCap;
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
-	type Treasury = module_cdp_treasury::Module<Runtime>;
+	type CDPTreasury = module_cdp_treasury::Module<Runtime>;
 	type GetAmountAdjustment = GetAmountAdjustment;
 	type PriceSource = module_prices::Module<Runtime>;
 }
@@ -511,7 +511,7 @@ impl module_loans::Trait for Runtime {
 	type RiskManager = module_cdp_engine::Module<Runtime>;
 	type DebitBalance = Balance;
 	type DebitAmount = Amount;
-	type Treasury = module_cdp_treasury::Module<Runtime>;
+	type CDPTreasury = module_cdp_treasury::Module<Runtime>;
 }
 
 /// A runtime transaction submitter.
@@ -524,7 +524,7 @@ parameter_types! {
 	pub const DefaultDebitExchangeRate: ExchangeRate = ExchangeRate::from_rational(1, 10);
 	pub const DefaultLiquidationPenalty: Rate = Rate::from_rational(5, 100);
 	pub const MinimumDebitValue: Balance = 1 * DOLLARS;
-	pub const MaxSlippageSwapWithDex: Ratio = Ratio::from_rational(5, 100);
+	pub const MaxSlippageSwapWithDEX: Ratio = Ratio::from_rational(5, 100);
 }
 
 impl module_cdp_engine::Trait for Runtime {
@@ -537,11 +537,11 @@ impl module_cdp_engine::Trait for Runtime {
 	type DefaultLiquidationPenalty = DefaultLiquidationPenalty;
 	type MinimumDebitValue = MinimumDebitValue;
 	type GetStableCurrencyId = GetStableCurrencyId;
-	type Treasury = module_cdp_treasury::Module<Runtime>;
+	type CDPTreasury = module_cdp_treasury::Module<Runtime>;
 	type UpdateOrigin = pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, FinancialCouncilInstance>;
-	type MaxSlippageSwapWithDex = MaxSlippageSwapWithDex;
+	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
 	type Currency = orml_currencies::Module<Runtime>;
-	type Dex = module_dex::Module<Runtime>;
+	type DEX = module_dex::Module<Runtime>;
 	type Call = Call;
 	type SubmitTransaction = SubmitTransaction;
 }
@@ -553,7 +553,7 @@ impl module_honzon::Trait for Runtime {
 impl module_emergency_shutdown::Trait for Runtime {
 	type Event = Event;
 	type PriceSource = module_prices::Module<Runtime>;
-	type Treasury = module_cdp_treasury::Module<Runtime>;
+	type CDPTreasury = module_cdp_treasury::Module<Runtime>;
 	type AuctionManagerHandler = module_auction_manager::Module<Runtime>;
 	type OnShutdown = (
 		module_cdp_treasury::Module<Runtime>,
@@ -581,7 +581,7 @@ impl module_cdp_treasury::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type AuctionManagerHandler = module_auction_manager::Module<Runtime>;
 	type UpdateOrigin = pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, FinancialCouncilInstance>;
-	type Dex = module_dex::Module<Runtime>;
+	type DEX = module_dex::Module<Runtime>;
 }
 
 parameter_types! {
@@ -640,10 +640,10 @@ construct_runtime!(
 		Auction: orml_auction::{Module, Storage, Call, Event<T>},
 		AuctionManager: module_auction_manager::{Module, Storage, Call, Event<T>},
 		Loans: module_loans::{Module, Storage, Call, Event<T>},
-		CdpEngine: module_cdp_engine::{Module, Storage, Call, Event<T>, Config<T>, ValidateUnsigned},
 		Honzon: module_honzon::{Module, Storage, Call, Event<T>},
 		Dex: module_dex::{Module, Storage, Call, Event<T>},
 		CdpTreasury: module_cdp_treasury::{Module, Storage, Call, Config<T>, Event<T>},
+		CdpEngine: module_cdp_engine::{Module, Storage, Call, Event<T>, Config<T>, ValidateUnsigned},
 		EmergencyShutdown: module_emergency_shutdown::{Module, Storage, Call, Event<T>},
 		Accounts: module_accounts::{Module, Call, Storage},
 		AirDrop: module_airdrop::{Module, Call, Storage, Event<T>},


### PR DESCRIPTION
breaking changes:
1. Lots of renaming for call name, event , error,  trait field.  
2. `auction_manager` module do not keep assets in auction no longer, all related assets kept in `cdp_treasury` now.
3. now, token flows among modules are more atomatic by using `transfer` instead of the combination of `withdraw/deposit`.
4. modify some functions to expose results.
5. make `cdp_treasury::on_finalize` execute after `cdp_engine::on_finalize`.
6. optimistic code.


close #144 
@qwer951123  remember update bots, honzon platform, sdk...