### PR TITLE
reduce the use of association types in module Trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,6 +2960,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "orml-currencies",
  "orml-tokens",
  "orml-traits",
@@ -2980,12 +2981,12 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "parity-scale-codec",
  "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -2995,6 +2996,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "module-cdp-treasury",
+ "module-primitives",
  "module-support",
  "orml-auction",
  "orml-tokens",
@@ -3018,6 +3020,7 @@ dependencies = [
  "module-cdp-treasury",
  "module-dex",
  "module-loans",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
@@ -3040,6 +3043,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "module-dex",
+ "module-primitives",
  "module-support",
  "orml-auction",
  "orml-currencies",
@@ -3061,6 +3065,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "module-cdp-treasury",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
@@ -3109,10 +3114,10 @@ dependencies = [
  "frame-system",
  "module-cdp-treasury",
  "module-loans",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
- "orml-traits",
  "pallet-balances",
  "parity-scale-codec",
  "serde",
@@ -3128,15 +3133,12 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-staking-pool",
  "module-support",
- "orml-traits",
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -3145,6 +3147,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-support",
  "orml-traits",
  "parity-scale-codec",
@@ -3164,10 +3167,10 @@ dependencies = [
  "module-cdp-engine",
  "module-cdp-treasury",
  "module-loans",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
- "orml-traits",
  "pallet-balances",
  "parity-scale-codec",
  "serde",
@@ -3204,6 +3207,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
@@ -3223,6 +3227,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-support",
  "orml-traits",
  "parity-scale-codec",
@@ -3239,6 +3244,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-support",
  "orml-traits",
  "parity-scale-codec",
@@ -3264,6 +3270,7 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "frame-system",
+ "module-primitives",
  "module-support",
  "orml-currencies",
  "orml-tokens",
@@ -3310,7 +3317,6 @@ version = "0.4.4"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
- "module-primitives",
  "orml-utilities",
  "parity-scale-codec",
  "sp-runtime",

--- a/modules/accounts/Cargo.toml
+++ b/modules/accounts/Cargo.toml
@@ -9,19 +9,19 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 pallet-transaction-payment = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false }
-
-orml-traits = { path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
+orml-traits = { path = "../../orml/traits", default-features = false }
 
 [features]
 default = ["std"]
@@ -30,12 +30,12 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
-	"orml-traits/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-tokens/std",
 	"orml-currencies/std",
 	"pallet-transaction-payment/std",
 	"pallet-balances/std",
 	"pallet-timestamp/std",
+	"primitives/std",
 ]

--- a/modules/accounts/src/lib.rs
+++ b/modules/accounts/src/lib.rs
@@ -12,15 +12,14 @@ use frame_support::{
 	weights::{DispatchInfo, PostDispatchInfo},
 	IsSubType,
 };
-use orml_traits::MultiCurrency;
-use rstd::prelude::*;
+use frame_system::{self as system, ensure_signed};
 use sp_runtime::{
 	traits::{DispatchInfoOf, SaturatedConversion, Saturating, SignedExtension, Zero},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
 };
-use system::ensure_signed;
+use sp_std::prelude::*;
 
 mod mock;
 mod tests;
@@ -37,7 +36,6 @@ pub trait Trait: system::Trait + pallet_transaction_payment::Trait + orml_curren
 	type FreeTransferPeriod: Get<MomentOf<Self>>;
 	type FreeTransferDeposit: Get<DepositBalanceOf<Self>>;
 	type Time: Time;
-	type Currency: MultiCurrency<Self::AccountId> + Send + Sync;
 	type DepositCurrency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 }
 
@@ -126,13 +124,13 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 	}
 }
 
-impl<T: Trait + Send + Sync> rstd::fmt::Debug for ChargeTransactionPayment<T> {
+impl<T: Trait + Send + Sync> sp_std::fmt::Debug for ChargeTransactionPayment<T> {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "ChargeTransactionPayment<{:?}>", self.0)
 	}
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }
@@ -148,7 +146,7 @@ where
 	type AdditionalSigned = ();
 	type Pre = ();
 
-	fn additional_signed(&self) -> rstd::result::Result<(), TransactionValidityError> {
+	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
 		Ok(())
 	}
 
@@ -195,7 +193,7 @@ where
 			<T as pallet_transaction_payment::Trait>::OnTransactionPayment::on_unbalanced(imbalance);
 			fee
 		} else {
-			0.into()
+			Zero::zero()
 		};
 
 		let mut r = ValidTransaction::default();

--- a/modules/accounts/src/mock.rs
+++ b/modules/accounts/src/mock.rs
@@ -4,32 +4,12 @@
 
 use super::*;
 use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{ConvertInto, IdentityLookup},
 	Perbill,
 };
-
-impl_outer_origin! {
-	pub enum Origin for Runtime {}
-}
-
-impl_outer_dispatch! {
-	pub enum Call for Runtime where origin: Origin {
-		orml_currencies::Currencies,
-	}
-}
-
-parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: u32 = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
-	pub const ExistentialDeposit: u64 = 1;
-	pub const CreationFee: u64 = 2;
-	pub const GetNativeCurrencyId: CurrencyId = ACA;
-}
 
 pub type AccountId = u64;
 pub type BlockNumber = u64;
@@ -46,6 +26,23 @@ pub const BTC: CurrencyId = 2;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Runtime;
+
+impl_outer_origin! {
+	pub enum Origin for Runtime {}
+}
+
+impl_outer_dispatch! {
+	pub enum Call for Runtime where origin: Origin {
+		orml_currencies::Currencies,
+	}
+}
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: u32 = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
 
 impl system::Trait for Runtime {
 	type Origin = Origin;
@@ -69,6 +66,10 @@ impl system::Trait for Runtime {
 	type OnKilledAccount = ();
 }
 
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1;
+}
+
 impl orml_tokens::Trait for Runtime {
 	type Event = ();
 	type Balance = Balance;
@@ -89,6 +90,10 @@ impl pallet_balances::Trait for Runtime {
 pub type PalletBalances = pallet_balances::Module<Runtime>;
 
 pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Runtime, PalletBalances, Balance>;
+
+parameter_types! {
+	pub const GetNativeCurrencyId: CurrencyId = ACA;
+}
 
 impl orml_currencies::Trait for Runtime {
 	type Event = ();
@@ -133,7 +138,6 @@ impl Trait for Runtime {
 	type FreeTransferCount = FreeTransferCount;
 	type FreeTransferPeriod = FreeTransferPeriod;
 	type Time = TimeModule;
-	type Currency = Currencies;
 	type FreeTransferDeposit = FreeTransferDeposit;
 	type DepositCurrency = pallet_balances::Module<Self>;
 }
@@ -152,7 +156,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
 		pallet_balances::GenesisConfig::<Runtime> {

--- a/modules/accounts/src/tests.rs
+++ b/modules/accounts/src/tests.rs
@@ -8,6 +8,7 @@ use frame_support::{
 	weights::{DispatchClass, DispatchInfo},
 };
 use mock::{Accounts, Call, Currencies, ExtBuilder, Origin, Runtime, TimeModule, ACA, ALICE, AUSD, BOB};
+use orml_traits::MultiCurrency;
 
 #[test]
 fn enable_free_transfer_require_deposit() {

--- a/modules/airdrop/Cargo.toml
+++ b/modules/airdrop/Cargo.toml
@@ -9,12 +9,12 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 
 [features]
 default = ["std"]
@@ -23,6 +23,6 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"primitives/std",
 ]

--- a/modules/airdrop/src/mock.rs
+++ b/modules/airdrop/src/mock.rs
@@ -4,8 +4,20 @@
 
 use super::*;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
+
+pub type AccountId = u64;
+pub type BlockNumber = u64;
+
+pub const ALICE: AccountId = 0;
+pub const BOB: AccountId = 1;
+pub const CHARLIE: AccountId = 2;
+pub const ACA: AirDropCurrencyId = AirDropCurrencyId::ACA;
+pub const KAR: AirDropCurrencyId = AirDropCurrencyId::KAR;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Runtime;
 
 mod airdrop {
 	pub use super::super::*;
@@ -22,26 +34,11 @@ impl_outer_event! {
 	}
 }
 
-pub type AccountId = u64;
-pub type BlockNumber = u64;
-pub type Balance = u64;
-pub type AirDropCurrencyId = u32;
-
-pub const ALICE: AccountId = 0;
-pub const BOB: AccountId = 1;
-pub const CHARLIE: AccountId = 2;
-pub const KAR: AirDropCurrencyId = 0;
-pub const ACA: AirDropCurrencyId = 1;
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Runtime;
-
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: u32 = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
-	pub const CreationFee: u64 = 2;
 }
 
 impl system::Trait for Runtime {
@@ -69,8 +66,6 @@ pub type System = system::Module<Runtime>;
 
 impl Trait for Runtime {
 	type Event = TestEvent;
-	type AirDropCurrencyId = AirDropCurrencyId;
-	type Balance = Balance;
 }
 pub type Airdrop = Module<Runtime>;
 
@@ -83,7 +78,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
 		GenesisConfig::<Runtime> {

--- a/modules/auction_manager/Cargo.toml
+++ b/modules/auction_manager/Cargo.toml
@@ -9,17 +9,17 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
 utilities = { path = "../../utilities", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-auction = { path = "../../orml/auction", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
@@ -31,11 +31,12 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-traits/std",
 	"orml-tokens/std",
 	"support/std",
-	"runtime-io/std",
+	"sp-io/std",
 	"utilities/std",
+	"primitives/std",
 ]

--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -1,23 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, HasCompact};
+use codec::{Decode, Encode};
 use frame_support::{
 	debug, decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, IsSubType, IterableStorageMap,
 };
+use frame_system::{self as system, ensure_none, offchain::SubmitUnsignedTransaction};
 use orml_traits::{Auction, AuctionHandler, MultiCurrency, OnNewBidResult};
-use rstd::{
-	cmp::{Eq, PartialEq},
-	prelude::*,
-};
+use primitives::{Balance, CurrencyId};
 use sp_runtime::{
-	traits::{BlakeTwo256, CheckedAdd, CheckedSub, Hash, Saturating, Zero},
+	traits::{BlakeTwo256, Hash, Saturating, Zero},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity, ValidTransaction,
 	},
 	DispatchResult, RandomNumberGenerator, RuntimeDebug,
 };
+use sp_std::{
+	cmp::{Eq, PartialEq},
+	prelude::*,
+};
 use support::{AuctionManager, CDPTreasury, OnEmergencyShutdown, PriceProvider, Rate};
-use system::{ensure_none, offchain::SubmitUnsignedTransaction};
 use utilities::{OffchainErr, OffchainLock};
 
 mod mock;
@@ -27,7 +28,7 @@ const DB_PREFIX: &[u8] = b"acala/auction-manager-offchain-worker/";
 
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, Clone, RuntimeDebug)]
-pub struct CollateralAuctionItem<AccountId, CurrencyId, Balance: HasCompact, BlockNumber> {
+pub struct CollateralAuctionItem<AccountId, BlockNumber> {
 	owner: AccountId,
 	currency_id: CurrencyId,
 	#[codec(compact)]
@@ -39,7 +40,7 @@ pub struct CollateralAuctionItem<AccountId, CurrencyId, Balance: HasCompact, Blo
 
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, Clone, RuntimeDebug)]
-pub struct DebitAuctionItem<Balance: HasCompact, BlockNumber> {
+pub struct DebitAuctionItem<BlockNumber> {
 	#[codec(compact)]
 	amount: Balance,
 	#[codec(compact)]
@@ -49,29 +50,27 @@ pub struct DebitAuctionItem<Balance: HasCompact, BlockNumber> {
 
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, Clone, RuntimeDebug)]
-pub struct SurplusAuctionItem<Balance: HasCompact, BlockNumber> {
+pub struct SurplusAuctionItem<BlockNumber> {
 	#[codec(compact)]
 	amount: Balance,
 	start_time: BlockNumber,
 }
 
-type CurrencyIdOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::CurrencyId;
-type BalanceOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::Balance;
 type AuctionIdOf<T> =
 	<<T as Trait>::Auction as Auction<<T as system::Trait>::AccountId, <T as system::Trait>::BlockNumber>>::AuctionId;
 
 pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-	type Currency: MultiCurrency<Self::AccountId>;
-	type Auction: Auction<Self::AccountId, Self::BlockNumber, Balance = BalanceOf<Self>>;
+	type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>;
+	type Auction: Auction<Self::AccountId, Self::BlockNumber, Balance = Balance>;
 	type MinimumIncrementSize: Get<Rate>;
 	type AuctionTimeToClose: Get<Self::BlockNumber>;
 	type AuctionDurationSoftCap: Get<Self::BlockNumber>;
-	type GetStableCurrencyId: Get<CurrencyIdOf<Self>>;
-	type GetNativeCurrencyId: Get<CurrencyIdOf<Self>>;
+	type GetStableCurrencyId: Get<CurrencyId>;
+	type GetNativeCurrencyId: Get<CurrencyId>;
 	type GetAmountAdjustment: Get<Rate>;
-	type CDPTreasury: CDPTreasury<Self::AccountId, Balance = BalanceOf<Self>, CurrencyId = CurrencyIdOf<Self>>;
-	type PriceSource: PriceProvider<CurrencyIdOf<Self>>;
+	type CDPTreasury: CDPTreasury<Self::AccountId, Balance = Balance, CurrencyId = CurrencyId>;
+	type PriceSource: PriceProvider<CurrencyId>;
 
 	/// A dispatchable call type.
 	type Call: From<Call<Self>> + IsSubType<Module<Self>, Self>;
@@ -90,8 +89,8 @@ decl_event!(
 	pub enum Event<T>
 	where
 		AuctionId = AuctionIdOf<T>,
-		CurrencyId = CurrencyIdOf<T>,
-		Balance = BalanceOf<T>,
+		CurrencyId = CurrencyId,
+		Balance = Balance,
 	{
 		NewCollateralAuction(AuctionId, CurrencyId, Balance, Balance),
 		NewDebitAuction(AuctionId, Balance, Balance),
@@ -115,15 +114,15 @@ decl_error! {
 decl_storage! {
 	trait Store for Module<T: Trait> as AuctionManager {
 		pub CollateralAuctions get(fn collateral_auctions): map hasher(twox_64_concat) AuctionIdOf<T> =>
-			Option<CollateralAuctionItem<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>, T::BlockNumber>>;
+			Option<CollateralAuctionItem<T::AccountId, T::BlockNumber>>;
 		pub DebitAuctions get(fn debit_auctions): map hasher(twox_64_concat) AuctionIdOf<T> =>
-			Option<DebitAuctionItem<BalanceOf<T>, T::BlockNumber>>;
+			Option<DebitAuctionItem<T::BlockNumber>>;
 		pub SurplusAuctions get(fn surplus_auctions): map hasher(twox_64_concat) AuctionIdOf<T> =>
-			Option<SurplusAuctionItem<BalanceOf<T>, T::BlockNumber>>;
-		pub TotalCollateralInAuction get(fn total_collateral_in_auction): map hasher(twox_64_concat) CurrencyIdOf<T> => BalanceOf<T>;
-		pub TotalTargetInAuction get(fn total_target_in_auction): BalanceOf<T>;
-		pub TotalDebitInAuction get(fn total_debit_in_auction): BalanceOf<T>;
-		pub TotalSurplusInAuction get(fn total_surplus_in_auction): BalanceOf<T>;
+			Option<SurplusAuctionItem<T::BlockNumber>>;
+		pub TotalCollateralInAuction get(fn total_collateral_in_auction): map hasher(twox_64_concat) CurrencyId => Balance;
+		pub TotalTargetInAuction get(fn total_target_in_auction): Balance;
+		pub TotalDebitInAuction get(fn total_debit_in_auction): Balance;
+		pub TotalSurplusInAuction get(fn total_surplus_in_auction): Balance;
 		pub IsShutdown get(fn is_shutdown): bool;
 	}
 }
@@ -135,8 +134,8 @@ decl_module! {
 		const MinimumIncrementSize: Rate = T::MinimumIncrementSize::get();
 		const AuctionTimeToClose: T::BlockNumber = T::AuctionTimeToClose::get();
 		const AuctionDurationSoftCap: T::BlockNumber = T::AuctionDurationSoftCap::get();
-		const GetStableCurrencyId: CurrencyIdOf<T> = T::GetStableCurrencyId::get();
-		const GetNativeCurrencyId: CurrencyIdOf<T> = T::GetNativeCurrencyId::get();
+		const GetStableCurrencyId: CurrencyId = T::GetStableCurrencyId::get();
+		const GetNativeCurrencyId: CurrencyId = T::GetNativeCurrencyId::get();
 		const GetAmountAdjustment: Rate = T::GetAmountAdjustment::get();
 
 		#[weight = frame_support::weights::SimpleDispatchInfo::default()]
@@ -148,7 +147,7 @@ decl_module! {
 
 		// Runs after every block.
 		fn offchain_worker(now: T::BlockNumber) {
-			if Self::is_shutdown() && runtime_io::offchain::is_validator() {
+			if Self::is_shutdown() && sp_io::offchain::is_validator() {
 				if let Err(e) = Self::_offchain_worker(now) {
 					debug::info!(
 						target: "auction-manager offchain worker",
@@ -186,7 +185,7 @@ impl<T: Trait> Module<T> {
 		let offchain_lock = OffchainLock::new(DB_PREFIX.to_vec());
 		offchain_lock.acquire_offchain_lock(|_: Option<()>| ())?;
 
-		let random_seed = runtime_io::offchain::random_seed();
+		let random_seed = sp_io::offchain::random_seed();
 		let mut rng = RandomNumberGenerator::<BlakeTwo256>::new(BlakeTwo256::hash(&random_seed[..]));
 		match rng.pick_u32(2) {
 			0 => {
@@ -233,7 +232,7 @@ impl<T: Trait> Module<T> {
 			if let Some((bidder, bid_price)) = auction_info.bid {
 				let native_currency_id = T::GetNativeCurrencyId::get();
 				if T::Currency::free_balance(native_currency_id, &bidder)
-					.checked_add(&bid_price)
+					.checked_add(bid_price)
 					.is_some()
 				{
 					// TODO: transfer from RESERVED TREASURY instead of mint
@@ -247,7 +246,7 @@ impl<T: Trait> Module<T> {
 		}
 
 		// decrease total surplus in auction
-		<TotalSurplusInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
+		TotalSurplusInAuction::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
 
 		// remove the auction info in auction module
 		T::Auction::remove_auction(id);
@@ -268,7 +267,7 @@ impl<T: Trait> Module<T> {
 		}
 
 		// derease total debit in auction
-		<TotalDebitInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
+		TotalDebitInAuction::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
 
 		// remove the auction info in auction module
 		T::Auction::remove_auction(id);
@@ -290,7 +289,7 @@ impl<T: Trait> Module<T> {
 		let stable_currency_id = T::GetStableCurrencyId::get();
 		let settle_price = T::PriceSource::get_relative_price(stable_currency_id, collateral_auction.currency_id)
 			.ok_or(Error::<T>::InvalidFeedPrice)?;
-		let confiscate_collateral_amount = rstd::cmp::min(
+		let confiscate_collateral_amount = sp_std::cmp::min(
 			settle_price.saturating_mul_int(&collateral_auction.target),
 			collateral_auction.amount,
 		);
@@ -318,10 +317,10 @@ impl<T: Trait> Module<T> {
 		system::Module::<T>::dec_ref(&collateral_auction.owner);
 
 		// decrease total collateral and target in auction
-		<TotalCollateralInAuction<T>>::mutate(collateral_auction.currency_id, |balance| {
+		TotalCollateralInAuction::mutate(collateral_auction.currency_id, |balance| {
 			*balance = balance.saturating_sub(collateral_auction.amount)
 		});
-		<TotalTargetInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(collateral_auction.target));
+		TotalTargetInAuction::mutate(|balance| *balance = balance.saturating_sub(collateral_auction.target));
 
 		// remove collateral auction
 		<CollateralAuctions<T>>::remove(id);
@@ -345,14 +344,14 @@ impl<T: Trait> Module<T> {
 	/// Check `new_price` is larger than minimum increment
 	/// Formula: new_price - last_price >= max(last_price, target_price) * minimum_increment
 	pub fn check_minimum_increment(
-		new_price: BalanceOf<T>,
-		last_price: BalanceOf<T>,
-		target_price: BalanceOf<T>,
+		new_price: Balance,
+		last_price: Balance,
+		target_price: Balance,
 		minimum_increment: Rate,
 	) -> bool {
 		if let (Some(target), Some(result)) = (
-			minimum_increment.checked_mul_int(rstd::cmp::max(&target_price, &last_price)),
-			new_price.checked_sub(&last_price),
+			minimum_increment.checked_mul_int(sp_std::cmp::max(&target_price, &last_price)),
+			new_price.checked_sub(last_price),
 		) {
 			return result >= target;
 		}
@@ -378,17 +377,17 @@ impl<T: Trait> Module<T> {
 	pub fn collateral_auction_bid_handler(
 		now: T::BlockNumber,
 		id: AuctionIdOf<T>,
-		new_bid: (T::AccountId, BalanceOf<T>),
-		last_bid: Option<(T::AccountId, BalanceOf<T>)>,
+		new_bid: (T::AccountId, Balance),
+		last_bid: Option<(T::AccountId, Balance)>,
 	) -> OnNewBidResult<T::BlockNumber> {
 		if let Some(mut collateral_auction) = Self::collateral_auctions(id) {
 			// get last price, if these's no bid set 0
-			let last_price: BalanceOf<T> = match last_bid {
-				None => 0.into(),
+			let last_price: Balance = match last_bid {
+				None => Zero::zero(),
 				Some((_, price)) => price,
 			};
 			let stable_currency_id = T::GetStableCurrencyId::get();
-			let mut payment = rstd::cmp::min(collateral_auction.target, new_bid.1);
+			let mut payment = sp_std::cmp::min(collateral_auction.target, new_bid.1);
 
 			// check new price is larger than minimum increment and new bidder has enough stable coin
 			if Self::check_minimum_increment(
@@ -403,7 +402,7 @@ impl<T: Trait> Module<T> {
 
 				// if these's bid before, return stablecoin from new bidder to last bidder
 				if let Some((last_bidder, last_price)) = last_bid {
-					let refund = rstd::cmp::min(last_price, collateral_auction.target);
+					let refund = sp_std::cmp::min(last_price, collateral_auction.target);
 					T::Currency::transfer(stable_currency_id, &new_bid.0, &last_bidder, refund)
 						.expect("never failed after balance check");
 
@@ -422,7 +421,7 @@ impl<T: Trait> Module<T> {
 				// if bid_price > target, the auction is in reverse, refund collateral to it's origin from auction cdp treasury
 				if new_bid.1 > collateral_auction.target {
 					let new_collateral_amount =
-						Rate::from_rational(rstd::cmp::max(last_price, collateral_auction.target), new_bid.1)
+						Rate::from_rational(sp_std::cmp::max(last_price, collateral_auction.target), new_bid.1)
 							.checked_mul_int(&collateral_auction.amount)
 							.unwrap_or(collateral_auction.amount);
 					let deduct_collateral_amount = collateral_auction.amount.saturating_sub(new_collateral_amount);
@@ -435,7 +434,7 @@ impl<T: Trait> Module<T> {
 					.is_ok()
 					{
 						// update collateral auction when refund collateral to owner success
-						<TotalCollateralInAuction<T>>::mutate(collateral_auction.currency_id, |balance| {
+						TotalCollateralInAuction::mutate(collateral_auction.currency_id, |balance| {
 							*balance = balance.saturating_sub(deduct_collateral_amount)
 						});
 						collateral_auction.amount = new_collateral_amount;
@@ -461,12 +460,12 @@ impl<T: Trait> Module<T> {
 	pub fn debit_auction_bid_handler(
 		now: T::BlockNumber,
 		id: AuctionIdOf<T>,
-		new_bid: (T::AccountId, BalanceOf<T>),
-		last_bid: Option<(T::AccountId, BalanceOf<T>)>,
+		new_bid: (T::AccountId, Balance),
+		last_bid: Option<(T::AccountId, Balance)>,
 	) -> OnNewBidResult<T::BlockNumber> {
 		if let Some(mut debit_auction) = Self::debit_auctions(id) {
-			let last_price: BalanceOf<T> = match last_bid {
-				None => 0.into(),
+			let last_price: Balance = match last_bid {
+				None => Zero::zero(),
 				Some((_, price)) => price,
 			};
 			let stable_currency_id = T::GetStableCurrencyId::get();
@@ -499,7 +498,7 @@ impl<T: Trait> Module<T> {
 				// calculate new amount of issue native token
 				if new_bid.1 > debit_auction.fix {
 					debit_auction.amount =
-						Rate::from_rational(rstd::cmp::max(last_price, debit_auction.fix), new_bid.1)
+						Rate::from_rational(sp_std::cmp::max(last_price, debit_auction.fix), new_bid.1)
 							.checked_mul_int(&debit_auction.amount)
 							.unwrap_or(debit_auction.amount);
 					<DebitAuctions<T>>::insert(id, debit_auction.clone());
@@ -523,12 +522,12 @@ impl<T: Trait> Module<T> {
 	pub fn surplus_auction_bid_handler(
 		now: T::BlockNumber,
 		id: AuctionIdOf<T>,
-		new_bid: (T::AccountId, BalanceOf<T>),
-		last_bid: Option<(T::AccountId, BalanceOf<T>)>,
+		new_bid: (T::AccountId, Balance),
+		last_bid: Option<(T::AccountId, Balance)>,
 	) -> OnNewBidResult<T::BlockNumber> {
 		if let Some(surplus_auction) = Self::surplus_auctions(id) {
-			let last_price: BalanceOf<T> = match last_bid {
-				None => 0.into(),
+			let last_price: Balance = match last_bid {
+				None => Zero::zero(),
 				Some((_, price)) => price,
 			};
 			let native_currency_id = T::GetNativeCurrencyId::get();
@@ -537,7 +536,7 @@ impl<T: Trait> Module<T> {
 			if Self::check_minimum_increment(
 				new_bid.1,
 				last_price,
-				0.into(),
+				Zero::zero(),
 				Self::get_minimum_increment_size(now, surplus_auction.start_time),
 			) && T::Currency::ensure_can_withdraw(native_currency_id, &new_bid.0, new_bid.1).is_ok()
 				&& !new_bid.1.is_zero()
@@ -576,9 +575,9 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
-	pub fn collateral_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, BalanceOf<T>)>) {
+	pub fn collateral_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, Balance)>) {
 		if let (Some(collateral_auction), Some((bidder, _))) = (Self::collateral_auctions(id), winner) {
-			let amount = rstd::cmp::min(
+			let amount = sp_std::cmp::min(
 				collateral_auction.amount,
 				Self::total_collateral_in_auction(collateral_auction.currency_id),
 			);
@@ -592,22 +591,22 @@ impl<T: Trait> Module<T> {
 			// decrease account ref of collateral auction owner
 			system::Module::<T>::dec_ref(&collateral_auction.owner);
 
-			<TotalCollateralInAuction<T>>::mutate(collateral_auction.currency_id, |balance| {
+			TotalCollateralInAuction::mutate(collateral_auction.currency_id, |balance| {
 				*balance = balance.saturating_sub(amount)
 			});
-			<TotalTargetInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(collateral_auction.target));
+			TotalTargetInAuction::mutate(|balance| *balance = balance.saturating_sub(collateral_auction.target));
 			<CollateralAuctions<T>>::remove(id);
 
 			<Module<T>>::deposit_event(RawEvent::AuctionDealed(id));
 		}
 	}
 
-	pub fn debit_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, BalanceOf<T>)>) {
+	pub fn debit_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, Balance)>) {
 		if let Some(debit_auction) = Self::debit_auctions(id) {
 			if let Some((bidder, _)) = winner {
 				// issue the amount of native token to winner
 				if T::Currency::free_balance(T::GetNativeCurrencyId::get(), &bidder)
-					.checked_add(&debit_auction.amount)
+					.checked_add(debit_auction.amount)
 					.is_some()
 				{
 					// TODO: transfer from RESERVED TREASURY instead of mint
@@ -619,7 +618,7 @@ impl<T: Trait> Module<T> {
 				system::Module::<T>::dec_ref(&bidder);
 
 				// decrease debit in auction and delete auction
-				<TotalDebitInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
+				TotalDebitInAuction::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
 				<DebitAuctions<T>>::remove(id);
 
 				<Module<T>>::deposit_event(RawEvent::AuctionDealed(id));
@@ -649,7 +648,7 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
-	pub fn surplus_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, BalanceOf<T>)>) {
+	pub fn surplus_auction_end_handler(id: AuctionIdOf<T>, winner: Option<(T::AccountId, Balance)>) {
 		if let (Some(surplus_auction), Some((bidder, _))) = (Self::surplus_auctions(id), winner) {
 			// deposit unbacked stable token to winner by cdp treasury, ignore Err
 			let _ = T::CDPTreasury::deposit_unbacked_debit_to(&bidder, surplus_auction.amount);
@@ -658,7 +657,7 @@ impl<T: Trait> Module<T> {
 			system::Module::<T>::dec_ref(&bidder);
 
 			// decrease surplus in auction
-			<TotalSurplusInAuction<T>>::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
+			TotalSurplusInAuction::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
 			<SurplusAuctions<T>>::remove(id);
 
 			<Module<T>>::deposit_event(RawEvent::AuctionDealed(id));
@@ -666,12 +665,12 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-impl<T: Trait> AuctionHandler<T::AccountId, BalanceOf<T>, T::BlockNumber, AuctionIdOf<T>> for Module<T> {
+impl<T: Trait> AuctionHandler<T::AccountId, Balance, T::BlockNumber, AuctionIdOf<T>> for Module<T> {
 	fn on_new_bid(
 		now: T::BlockNumber,
 		id: AuctionIdOf<T>,
-		new_bid: (T::AccountId, BalanceOf<T>),
-		last_bid: Option<(T::AccountId, BalanceOf<T>)>,
+		new_bid: (T::AccountId, Balance),
+		last_bid: Option<(T::AccountId, Balance)>,
 	) -> OnNewBidResult<T::BlockNumber> {
 		if <CollateralAuctions<T>>::contains_key(id) {
 			Self::collateral_auction_bid_handler(now, id, new_bid, last_bid)
@@ -687,7 +686,7 @@ impl<T: Trait> AuctionHandler<T::AccountId, BalanceOf<T>, T::BlockNumber, Auctio
 		}
 	}
 
-	fn on_auction_ended(id: AuctionIdOf<T>, winner: Option<(T::AccountId, BalanceOf<T>)>) {
+	fn on_auction_ended(id: AuctionIdOf<T>, winner: Option<(T::AccountId, Balance)>) {
 		if <CollateralAuctions<T>>::contains_key(id) {
 			Self::collateral_auction_end_handler(id, winner)
 		} else if <DebitAuctions<T>>::contains_key(id) {
@@ -699,8 +698,8 @@ impl<T: Trait> AuctionHandler<T::AccountId, BalanceOf<T>, T::BlockNumber, Auctio
 }
 
 impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
-	type CurrencyId = CurrencyIdOf<T>;
-	type Balance = BalanceOf<T>;
+	type CurrencyId = CurrencyId;
+	type Balance = Balance;
 	type AuctionId = AuctionIdOf<T>;
 
 	fn new_collateral_auction(
@@ -710,11 +709,11 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 		target: Self::Balance,
 	) {
 		if Self::total_collateral_in_auction(currency_id)
-			.checked_add(&amount)
-			.is_some() && Self::total_target_in_auction().checked_add(&target).is_some()
+			.checked_add(amount)
+			.is_some() && Self::total_target_in_auction().checked_add(target).is_some()
 		{
-			<TotalCollateralInAuction<T>>::mutate(currency_id, |balance| *balance += amount);
-			<TotalTargetInAuction<T>>::mutate(|balance| *balance += target);
+			TotalCollateralInAuction::mutate(currency_id, |balance| *balance += amount);
+			TotalTargetInAuction::mutate(|balance| *balance += target);
 
 			let block_number = <system::Module<T>>::block_number();
 			let auction_id: AuctionIdOf<T> = T::Auction::new_auction(block_number, None); // do not set endtime for collateral auction
@@ -735,8 +734,8 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 	}
 
 	fn new_debit_auction(initial_amount: Self::Balance, fix_debit: Self::Balance) {
-		if Self::total_debit_in_auction().checked_add(&fix_debit).is_some() {
-			<TotalDebitInAuction<T>>::mutate(|balance| *balance += fix_debit);
+		if Self::total_debit_in_auction().checked_add(fix_debit).is_some() {
+			TotalDebitInAuction::mutate(|balance| *balance += fix_debit);
 			let start_block = <system::Module<T>>::block_number();
 			let end_block = start_block + T::AuctionTimeToClose::get();
 			// set close time for initial debit auction
@@ -752,8 +751,8 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 	}
 
 	fn new_surplus_auction(amount: Self::Balance) {
-		if Self::total_surplus_in_auction().checked_add(&amount).is_some() {
-			<TotalSurplusInAuction<T>>::mutate(|balance| *balance += amount);
+		if Self::total_surplus_in_auction().checked_add(amount).is_some() {
+			TotalSurplusInAuction::mutate(|balance| *balance += amount);
 			let auction_id: AuctionIdOf<T> = T::Auction::new_auction(<system::Module<T>>::block_number(), None); // do not set endtime for surplus auction
 			let surplus_auction = SurplusAuctionItem {
 				amount: amount,

--- a/modules/cdp_engine/Cargo.toml
+++ b/modules/cdp_engine/Cargo.toml
@@ -8,22 +8,22 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
-orml-traits = { path = "../../orml/traits", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
 loans = { package = "module-loans", path = "../loans", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 utilities = { path = "../../utilities", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
+orml-traits = { path = "../../orml/traits", default-features = false }
 dex = { package = "module-dex", path = "../dex", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
 
@@ -33,14 +33,14 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
+	"sp-std/std",
+	"sp-io/std",
+	"sp-application-crypto/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
-	"orml-traits/std",
+	"frame-system/std",
 	"orml-tokens/std",
 	"support/std",
 	"loans/std",
-	"sp-application-crypto/std",
-	"runtime-io/std",
+	"primitives/std",
 	"utilities/std",
 ]

--- a/modules/cdp_engine/src/debit_exchange_rate_convertor.rs
+++ b/modules/cdp_engine/src/debit_exchange_rate_convertor.rs
@@ -3,14 +3,14 @@ use sp_runtime::traits::Convert;
 
 pub struct DebitExchangeRateConvertor<T>(marker::PhantomData<T>);
 
-impl<T> Convert<(CurrencyIdOf<T>, T::DebitBalance), BalanceOf<T>> for DebitExchangeRateConvertor<T>
+impl<T> Convert<(CurrencyId, T::DebitBalance), Balance> for DebitExchangeRateConvertor<T>
 where
 	T: Trait,
 {
-	fn convert(a: (CurrencyIdOf<T>, T::DebitBalance)) -> BalanceOf<T> {
+	fn convert(a: (CurrencyId, T::DebitBalance)) -> Balance {
 		let (currency_id, balance) = a;
 		let balance: u128 = balance.unique_saturated_into();
-		let balance: BalanceOf<T> = balance.unique_saturated_into();
+		let balance: Balance = balance.unique_saturated_into();
 		<Module<T>>::debit_exchange_rate(currency_id)
 			.unwrap_or(T::DefaultDebitExchangeRate::get())
 			.saturating_mul_int(&balance)

--- a/modules/cdp_engine/src/mock.rs
+++ b/modules/cdp_engine/src/mock.rs
@@ -4,14 +4,32 @@
 
 use super::*;
 use frame_support::{impl_outer_dispatch, impl_outer_event, impl_outer_origin, ord_parameter_types, parameter_types};
-use primitives::H256;
+use frame_system::EnsureSignedBy;
+use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
 	traits::IdentityLookup,
 	Perbill,
 };
 use support::AuctionManager;
-use system::EnsureSignedBy;
+
+pub type AccountId = u64;
+pub type BlockNumber = u64;
+pub type DebitBalance = Balance;
+pub type DebitAmount = Amount;
+pub type Share = u64;
+pub type AuctionId = u64;
+
+pub const ALICE: AccountId = 1;
+pub const BOB: AccountId = 2;
+pub const CAROL: AccountId = 3;
+pub const ACA: CurrencyId = CurrencyId::ACA;
+pub const AUSD: CurrencyId = CurrencyId::AUSD;
+pub const BTC: CurrencyId = CurrencyId::XBTC;
+pub const DOT: CurrencyId = CurrencyId::DOT;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Runtime;
 
 mod cdp_engine {
 	pub use super::super::*;
@@ -26,7 +44,7 @@ impl_outer_event! {
 		pallet_balances<T>,
 		orml_currencies<T>,
 		dex<T>,
-		cdp_treasury<T>,
+		cdp_treasury,
 	}
 }
 
@@ -45,37 +63,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: u32 = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
-	pub const ExistentialDeposit: u64 = 1;
-	pub const CreationFee: u64 = 2;
-	pub const CollateralCurrencyIds: Vec<CurrencyId> = vec![BTC, DOT];
-	pub const DefaultLiquidationRatio: Ratio = Ratio::from_rational(3, 2);
-	pub const DefaultDebitExchangeRate: ExchangeRate = ExchangeRate::from_natural(1);
-	pub const DefaultLiquidationPenalty: Rate = Rate::from_rational(10, 100);
-	pub const MinimumDebitValue: Balance = 2;
-	pub const GetStableCurrencyId: CurrencyId = AUSD;
-	pub const GetNativeCurrencyId: CurrencyId = ACA;
 }
-
-pub type AccountId = u64;
-pub type BlockNumber = u64;
-pub type Balance = u64;
-pub type Amount = i64;
-pub type DebitBalance = u64;
-pub type DebitAmount = i64;
-pub type CurrencyId = u32;
-pub type Share = u64;
-pub type AuctionId = u64;
-pub const ALICE: AccountId = 1;
-pub const BOB: AccountId = 2;
-pub const CAROL: AccountId = 3;
-
-pub const ACA: CurrencyId = 0;
-pub const AUSD: CurrencyId = 1;
-pub const BTC: CurrencyId = 2;
-pub const DOT: CurrencyId = 3;
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Runtime;
 
 impl system::Trait for Runtime {
 	type Origin = Origin;
@@ -100,6 +88,10 @@ impl system::Trait for Runtime {
 }
 pub type System = system::Module<Runtime>;
 
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1;
+}
+
 impl orml_tokens::Trait for Runtime {
 	type Event = TestEvent;
 	type Balance = Balance;
@@ -118,8 +110,11 @@ impl pallet_balances::Trait for Runtime {
 	type AccountStore = system::Module<Runtime>;
 }
 pub type PalletBalances = pallet_balances::Module<Runtime>;
-
 pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Runtime, PalletBalances, Balance>;
+
+parameter_types! {
+	pub const GetNativeCurrencyId: CurrencyId = ACA;
+}
 
 impl orml_currencies::Trait for Runtime {
 	type Event = TestEvent;
@@ -198,6 +193,10 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 	}
 }
 
+parameter_types! {
+	pub const GetStableCurrencyId: CurrencyId = AUSD;
+}
+
 impl cdp_treasury::Trait for Runtime {
 	type Event = TestEvent;
 	type Currency = Currencies;
@@ -210,6 +209,7 @@ pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 
 parameter_types! {
 	pub const GetExchangeFee: Rate = Rate::from_natural(0);
+	pub const CollateralCurrencyIds: Vec<CurrencyId> = vec![BTC, DOT];
 }
 
 impl dex::Trait for Runtime {
@@ -233,6 +233,10 @@ ord_parameter_types! {
 }
 
 parameter_types! {
+	pub const DefaultLiquidationRatio: Ratio = Ratio::from_rational(3, 2);
+	pub const DefaultDebitExchangeRate: ExchangeRate = ExchangeRate::from_natural(1);
+	pub const DefaultLiquidationPenalty: Rate = Rate::from_rational(10, 100);
+	pub const MinimumDebitValue: Balance = 2;
 	pub const MaxSlippageSwapWithDEX: Ratio = Ratio::from_rational(50, 100);
 	pub const UnsignedPriority: u64 = 1 << 20;
 }
@@ -249,7 +253,6 @@ impl Trait for Runtime {
 	type CDPTreasury = CDPTreasuryModule;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
 	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
-	type Currency = Currencies;
 	type DEX = DEXModule;
 	type Call = Call;
 	type SubmitTransaction = SubmitTransaction;
@@ -277,7 +280,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
 		orml_tokens::GenesisConfig::<Runtime> {

--- a/modules/cdp_engine/src/tests.rs
+++ b/modules/cdp_engine/src/tests.rs
@@ -8,6 +8,7 @@ use mock::{
 	CDPEngineModule, CDPTreasuryModule, Currencies, DefaultDebitExchangeRate, DefaultLiquidationPenalty,
 	DefaultLiquidationRatio, ExtBuilder, LoansModule, Origin, Runtime, System, TestEvent, ACA, ALICE, AUSD, BTC, DOT,
 };
+use orml_traits::MultiCurrency;
 use sp_runtime::traits::BadOrigin;
 
 #[test]

--- a/modules/cdp_treasury/Cargo.toml
+++ b/modules/cdp_treasury/Cargo.toml
@@ -9,16 +9,16 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 orml-auction = { path = "../../orml/auction", default-features = false }
@@ -31,9 +31,10 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-traits/std",
 	"orml-tokens/std",
 	"support/std",
+	"primitives/std",
 ]

--- a/modules/cdp_treasury/src/tests.rs
+++ b/modules/cdp_treasury/src/tests.rs
@@ -25,7 +25,7 @@ fn set_collateral_auction_maximum_size_work() {
 		));
 
 		let update_collateral_auction_maximum_size_event =
-			TestEvent::cdp_treasury(RawEvent::UpdateCollateralAuctionMaximumSize(BTC, 200));
+			TestEvent::cdp_treasury(Event::UpdateCollateralAuctionMaximumSize(BTC, 200));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_collateral_auction_maximum_size_event));
@@ -62,20 +62,20 @@ fn set_debit_and_surplus_handle_params_work() {
 		));
 
 		let update_surplus_auction_fixed_size_event =
-			TestEvent::cdp_treasury(RawEvent::UpdateSurplusAuctionFixedSize(100));
+			TestEvent::cdp_treasury(Event::UpdateSurplusAuctionFixedSize(100));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_surplus_auction_fixed_size_event));
-		let update_surplus_buffer_size_event = TestEvent::cdp_treasury(RawEvent::UpdateSurplusBufferSize(1000));
+		let update_surplus_buffer_size_event = TestEvent::cdp_treasury(Event::UpdateSurplusBufferSize(1000));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_surplus_buffer_size_event));
 		let update_initial_amount_per_debit_auction_event =
-			TestEvent::cdp_treasury(RawEvent::UpdateInitialAmountPerDebitAuction(200));
+			TestEvent::cdp_treasury(Event::UpdateInitialAmountPerDebitAuction(200));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_initial_amount_per_debit_auction_event));
-		let update_debit_auction_fixed_size_event = TestEvent::cdp_treasury(RawEvent::UpdateDebitAuctionFixedSize(100));
+		let update_debit_auction_fixed_size_event = TestEvent::cdp_treasury(Event::UpdateDebitAuctionFixedSize(100));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_debit_auction_fixed_size_event));

--- a/modules/dex/Cargo.toml
+++ b/modules/dex/Cargo.toml
@@ -9,17 +9,17 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 orml-utilities = { path = "../../orml/utilities", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
@@ -31,10 +31,11 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-traits/std",
 	"orml-utilities/std",
 	"orml-tokens/std",
 	"support/std",
+	"primitives/std",
 ]

--- a/modules/dex/rpc/runtime-api/Cargo.toml
+++ b/modules/dex/rpc/runtime-api/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-api = { version = "2.0.0-alpha.6", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 
 [features]
 default = ["std"]
@@ -18,5 +18,5 @@ std = [
 	"codec/std",
 	"sp-api/std",
 	"sp-runtime/std",
-	"rstd/std",
+	"sp-std/std",
 ]

--- a/modules/dex/rpc/runtime-api/src/lib.rs
+++ b/modules/dex/rpc/runtime-api/src/lib.rs
@@ -3,10 +3,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode};
-use rstd::prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sp_runtime::traits::{MaybeDisplay, MaybeFromStr};
+use sp_std::prelude::*;
 
 #[derive(Eq, PartialEq, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -32,7 +32,7 @@ fn set_liquidity_incentive_rate_work() {
 #[test]
 fn accumulate_interest_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		<LiquidityPool<Runtime>>::insert(BTC, (100, 10000));
+		LiquidityPool::insert(BTC, (100, 10000));
 		assert_eq!(DexModule::total_interest(BTC), 0);
 		DexModule::accumulate_interest(BTC);
 		assert_eq!(DexModule::total_interest(BTC), 100);
@@ -44,8 +44,8 @@ fn claim_interest_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		<Shares<Runtime>>::insert(BTC, ALICE, 2000);
 		<TotalShares<Runtime>>::insert(BTC, 10000);
-		<TotalInterest<Runtime>>::insert(BTC, 25000);
-		<TotalWithdrawnInterest<Runtime>>::insert(BTC, 20000);
+		TotalInterest::insert(BTC, 25000);
+		TotalWithdrawnInterest::insert(BTC, 20000);
 		<WithdrawnInterest<Runtime>>::insert(BTC, ALICE, 2000);
 		assert_ok!(Tokens::deposit(AUSD, &DexModule::account_id(), 5000));
 		let alice_former_balance = Tokens::free_balance(AUSD, &ALICE);
@@ -63,8 +63,8 @@ fn withdraw_calculate_interest_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		<Shares<Runtime>>::insert(BTC, ALICE, 2000);
 		<TotalShares<Runtime>>::insert(BTC, 10000);
-		<TotalInterest<Runtime>>::insert(BTC, 25000);
-		<TotalWithdrawnInterest<Runtime>>::insert(BTC, 25000);
+		TotalInterest::insert(BTC, 25000);
+		TotalWithdrawnInterest::insert(BTC, 25000);
 		<WithdrawnInterest<Runtime>>::insert(BTC, ALICE, 10000);
 		assert_ok!(DexModule::withdraw_calculate_interest(BTC, &ALICE, 1000));
 		assert_eq!(DexModule::total_withdrawn_interest(BTC), 20000);
@@ -77,8 +77,8 @@ fn withdraw_calculate_interest_work() {
 fn deposit_calculate_interest_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		<TotalShares<Runtime>>::insert(BTC, 5000);
-		<TotalInterest<Runtime>>::insert(BTC, 10000);
-		<TotalWithdrawnInterest<Runtime>>::insert(BTC, 2000);
+		TotalInterest::insert(BTC, 10000);
+		TotalWithdrawnInterest::insert(BTC, 2000);
 		DexModule::deposit_calculate_interest(BTC, &ALICE, 4000);
 		assert_eq!(DexModule::total_interest(BTC), 18000);
 		assert_eq!(DexModule::total_withdrawn_interest(BTC), 10000);

--- a/modules/emergency_shutdown/Cargo.toml
+++ b/modules/emergency_shutdown/Cargo.toml
@@ -9,17 +9,16 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
-orml-traits = { path = "../../orml/traits", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
 loans = { package = "module-loans", path = "../loans", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances= { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
@@ -31,10 +30,10 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
-	"orml-traits/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-tokens/std",
 	"support/std",
 	"loans/std",
+	"primitives/std",
 ]

--- a/modules/homa/Cargo.toml
+++ b/modules/homa/Cargo.toml
@@ -9,16 +9,10 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
-orml-traits = { package = "orml-traits", path = "../../orml/traits", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
 staking-pool = { package = "module-staking-pool", path = "../staking_pool", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
-
-[dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [features]
 default = ["std"]
@@ -27,9 +21,8 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
-	"orml-traits/std",
+	"frame-system/std",
 	"staking-pool/std",
 	"support/std",
+	"primitives/std",
 ]

--- a/modules/homa/src/lib.rs
+++ b/modules/homa/src/lib.rs
@@ -2,9 +2,10 @@
 
 use codec::{Decode, Encode};
 use frame_support::decl_module;
+use frame_system::{self as system, ensure_signed};
+use primitives::{Balance, EraIndex};
 use sp_runtime::RuntimeDebug;
-use support::{EraIndex, HomaProtocol};
-use system::{self as system, ensure_signed};
+use support::HomaProtocol;
 
 #[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq)]
 pub enum RedeemStrategy {
@@ -13,22 +14,20 @@ pub enum RedeemStrategy {
 	WaitForUnbonding,
 }
 
-type BalanceOf<T> = <<T as Trait>::Homa as HomaProtocol<<T as system::Trait>::AccountId>>::Balance;
-
 pub trait Trait: system::Trait {
-	type Homa: HomaProtocol<Self::AccountId>;
+	type Homa: HomaProtocol<Self::AccountId, Balance, EraIndex>;
 }
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		#[weight = frame_support::weights::SimpleDispatchInfo::default()]
-		pub fn mint(origin, #[compact] amount: BalanceOf<T>) {
+		pub fn mint(origin, #[compact] amount: Balance) {
 			let who = ensure_signed(origin)?;
 			T::Homa::mint(&who, amount)?;
 		}
 
 		#[weight = frame_support::weights::SimpleDispatchInfo::default()]
-		pub fn redeem(origin, #[compact] amount: BalanceOf<T>, strategy: RedeemStrategy) {
+		pub fn redeem(origin, #[compact] amount: Balance, strategy: RedeemStrategy) {
 			let who = ensure_signed(origin)?;
 			match strategy {
 				RedeemStrategy::Immediately => {

--- a/modules/homa_treasury/Cargo.toml
+++ b/modules/homa_treasury/Cargo.toml
@@ -9,15 +9,15 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
-support = { package = "module-support", path = "../support", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { package = "orml-traits", path = "../../orml/traits", default-features = false }
+support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 
 [features]
 default = ["std"]
@@ -26,8 +26,9 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"support/std",
 	"orml-traits/std",
+	"primitives/std",
 ]

--- a/modules/homa_treasury/src/lib.rs
+++ b/modules/homa_treasury/src/lib.rs
@@ -1,24 +1,23 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{decl_module, traits::Get};
+use frame_system::{self as system};
 use orml_traits::MultiCurrency;
+use primitives::{Balance, CurrencyId, EraIndex};
 use sp_runtime::{traits::AccountIdConversion, ModuleId};
 use support::{HomaProtocol, OnCommission};
 
 const MODULE_ID: ModuleId = ModuleId(*b"aca/hmts");
 
-type CurrencyIdOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::CurrencyId;
-type BalanceOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::Balance;
-
 pub trait Trait: system::Trait {
-	type Currency: MultiCurrency<Self::AccountId>;
-	type Homa: HomaProtocol<Self::AccountId, Balance = BalanceOf<Self>>;
-	type StakingCurrencyId: Get<CurrencyIdOf<Self>>;
+	type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>;
+	type Homa: HomaProtocol<Self::AccountId, Balance, EraIndex>;
+	type StakingCurrencyId: Get<CurrencyId>;
 }
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-		const StakingCurrencyId: CurrencyIdOf<T> = T::StakingCurrencyId::get();
+		const StakingCurrencyId: CurrencyId = T::StakingCurrencyId::get();
 	}
 }
 
@@ -28,8 +27,8 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-impl<T: Trait> OnCommission<BalanceOf<T>, CurrencyIdOf<T>> for Module<T> {
-	fn on_commission(currency_id: CurrencyIdOf<T>, amount: BalanceOf<T>) {
+impl<T: Trait> OnCommission<Balance, CurrencyId> for Module<T> {
+	fn on_commission(currency_id: CurrencyId, amount: Balance) {
 		let module_account = Self::account_id();
 		if T::Currency::deposit(currency_id, &module_account, amount).is_ok() {
 			if currency_id == T::StakingCurrencyId::get() {

--- a/modules/honzon/Cargo.toml
+++ b/modules/honzon/Cargo.toml
@@ -5,23 +5,21 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
 frame-system = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
-orml-traits = { path = "../../orml/traits", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 cdp-engine = { package = "module-cdp-engine", path = "../cdp_engine", default-features = false }
 loans = { package = "module-loans", path = "../loans", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
@@ -34,10 +32,10 @@ std = [
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",
-	"rstd/std",
-	"orml-traits/std",
+	"sp-std/std",
 	"orml-tokens/std",
 	"loans/std",
 	"cdp-engine/std",
 	"support/std",
+	"primitives/std",
 ]

--- a/modules/loans/Cargo.toml
+++ b/modules/loans/Cargo.toml
@@ -7,19 +7,18 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-
 orml-traits = { path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
 
 [dev-dependencies]
-su-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 cdp-treasury = { package = "module-cdp-treasury", path = "../cdp_treasury", default-features = false }
@@ -29,9 +28,9 @@ default = ["std"]
 std = [
 	"serde",
 	"codec/std",
-	"system/std",
+	"frame-system/std",
 	"frame-support/std",
-	"rstd/std",
+	"sp-std/std",
 	"sp-runtime/std",
 	"orml-traits/std",
 	"primitives/std",

--- a/modules/loans/src/lib.rs
+++ b/modules/loans/src/lib.rs
@@ -1,17 +1,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, Parameter};
+use frame_system::{self as system};
 use orml_traits::{
 	arithmetic::{self, Signed},
 	MultiCurrency, MultiCurrencyExtended,
 };
-use rstd::convert::{TryFrom, TryInto};
+use primitives::{Amount, Balance, CurrencyId};
 use sp_runtime::{
 	traits::{
 		AccountIdConversion, AtLeast32Bit, CheckedAdd, CheckedSub, Convert, MaybeSerializeDeserialize, Member, Zero,
 	},
 	DispatchResult, ModuleId,
 };
+use sp_std::convert::{TryFrom, TryInto};
 use support::{CDPTreasury, RiskManager};
 
 mod mock;
@@ -19,15 +21,11 @@ mod tests;
 
 const MODULE_ID: ModuleId = ModuleId(*b"aca/loan");
 
-type CurrencyIdOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::CurrencyId;
-type BalanceOf<T> = <<T as Trait>::Currency as MultiCurrency<<T as system::Trait>::AccountId>>::Balance;
-type AmountOf<T> = <<T as Trait>::Currency as MultiCurrencyExtended<<T as system::Trait>::AccountId>>::Amount;
-
 pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-	type Convert: Convert<(CurrencyIdOf<Self>, Self::DebitBalance), BalanceOf<Self>>;
-	type Currency: MultiCurrencyExtended<Self::AccountId>;
-	type RiskManager: RiskManager<Self::AccountId, CurrencyIdOf<Self>, BalanceOf<Self>, Self::DebitBalance>;
+	type Convert: Convert<(CurrencyId, Self::DebitBalance), Balance>;
+	type Currency: MultiCurrencyExtended<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance, Amount = Amount>;
+	type RiskManager: RiskManager<Self::AccountId, CurrencyId, Balance, Self::DebitBalance>;
 	type DebitBalance: Parameter + Member + AtLeast32Bit + Default + Copy + MaybeSerializeDeserialize;
 	type DebitAmount: Signed
 		+ TryInto<Self::DebitBalance>
@@ -38,26 +36,26 @@ pub trait Trait: system::Trait {
 		+ Default
 		+ Copy
 		+ MaybeSerializeDeserialize;
-	type CDPTreasury: CDPTreasury<Self::AccountId, Balance = BalanceOf<Self>, CurrencyId = CurrencyIdOf<Self>>;
+	type CDPTreasury: CDPTreasury<Self::AccountId, Balance = Balance, CurrencyId = CurrencyId>;
 }
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Loans {
-		pub Debits get(fn debits): double_map hasher(twox_64_concat) CurrencyIdOf<T>, hasher(twox_64_concat) T::AccountId => T::DebitBalance;
-		pub Collaterals get(fn collaterals): double_map hasher(twox_64_concat) T::AccountId, hasher(twox_64_concat) CurrencyIdOf<T> => BalanceOf<T>;
-		pub TotalDebits get(fn total_debits): map hasher(twox_64_concat) CurrencyIdOf<T> => T::DebitBalance;
-		pub TotalCollaterals get(fn total_collaterals): map hasher(twox_64_concat) CurrencyIdOf<T> => BalanceOf<T>;
+		pub Debits get(fn debits): double_map hasher(twox_64_concat) CurrencyId, hasher(twox_64_concat) T::AccountId => T::DebitBalance;
+		pub Collaterals get(fn collaterals): double_map hasher(twox_64_concat) T::AccountId, hasher(twox_64_concat) CurrencyId => Balance;
+		pub TotalDebits get(fn total_debits): map hasher(twox_64_concat) CurrencyId => T::DebitBalance;
+		pub TotalCollaterals get(fn total_collaterals): map hasher(twox_64_concat) CurrencyId => Balance;
 	}
 }
 
 decl_event!(
 	pub enum Event<T> where
 		<T as system::Trait>::AccountId,
-		CurrencyId = CurrencyIdOf<T>,
 		<T as Trait>::DebitAmount,
-		Amount = AmountOf<T>,
 		<T as Trait>::DebitBalance,
-		Balance = BalanceOf<T>,
+		Amount = Amount,
+		Balance = Balance,
+		CurrencyId = CurrencyId,
 	{
 		/// Update Position success (account, currency_id, collaterals, debits)
 		UpdatePosition(AccountId, CurrencyId, Amount, DebitAmount),
@@ -93,13 +91,13 @@ impl<T: Trait> Module<T> {
 	// confiscate collateral and debit to cdp treasury
 	pub fn confiscate_collateral_and_debit(
 		who: &T::AccountId,
-		currency_id: CurrencyIdOf<T>,
-		collateral_confiscate: BalanceOf<T>,
+		currency_id: CurrencyId,
+		collateral_confiscate: Balance,
 		debit_decrease: T::DebitBalance,
 	) -> DispatchResult {
 		// balance -> amount
 		let collateral_adjustment =
-			TryInto::<AmountOf<T>>::try_into(collateral_confiscate).map_err(|_| Error::<T>::AmountConvertFailed)?;
+			TryInto::<Amount>::try_into(collateral_confiscate).map_err(|_| Error::<T>::AmountConvertFailed)?;
 		let debit_adjustment =
 			TryInto::<T::DebitAmount>::try_into(debit_decrease).map_err(|_| Error::<T>::AmountConvertFailed)?;
 
@@ -129,14 +127,14 @@ impl<T: Trait> Module<T> {
 	// mutate collaterals and debits and then mutate stable coin
 	pub fn adjust_position(
 		who: &T::AccountId,
-		currency_id: CurrencyIdOf<T>,
-		collateral_adjustment: AmountOf<T>,
+		currency_id: CurrencyId,
+		collateral_adjustment: Amount,
 		debit_adjustment: T::DebitAmount,
 	) -> DispatchResult {
 		Self::check_update_loan_overflow(who, currency_id, collateral_adjustment, debit_adjustment)?;
 
-		let collateral_balance_adjustment = TryInto::<BalanceOf<T>>::try_into(collateral_adjustment.abs())
-			.map_err(|_| Error::<T>::AmountConvertFailed)?;
+		let collateral_balance_adjustment =
+			TryInto::<Balance>::try_into(collateral_adjustment.abs()).map_err(|_| Error::<T>::AmountConvertFailed)?;
 		let debit_balance_adjustment = TryInto::<T::DebitBalance>::try_into(debit_adjustment.abs())
 			.map_err(|_| Error::<T>::AmountConvertFailed)?;
 
@@ -197,7 +195,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	// transfer whole loan of `from` to `to`
-	pub fn transfer_loan(from: &T::AccountId, to: &T::AccountId, currency_id: CurrencyIdOf<T>) -> DispatchResult {
+	pub fn transfer_loan(from: &T::AccountId, to: &T::AccountId, currency_id: CurrencyId) -> DispatchResult {
 		// get `from` position data
 		let collateral_balance = Self::collaterals(from, currency_id);
 		let debit_balance = Self::debits(currency_id, from);
@@ -210,7 +208,7 @@ impl<T: Trait> Module<T> {
 
 		// balance -> amount
 		let collateral_adjustment =
-			TryInto::<AmountOf<T>>::try_into(collateral_balance).map_err(|_| Error::<T>::AmountConvertFailed)?;
+			TryInto::<Amount>::try_into(collateral_balance).map_err(|_| Error::<T>::AmountConvertFailed)?;
 		let debit_adjustment =
 			TryInto::<T::DebitAmount>::try_into(debit_balance).map_err(|_| Error::<T>::AmountConvertFailed)?;
 
@@ -224,22 +222,22 @@ impl<T: Trait> Module<T> {
 	// check overflow for update_loan function
 	pub fn check_update_loan_overflow(
 		who: &T::AccountId,
-		currency_id: CurrencyIdOf<T>,
-		collateral_adjustment: AmountOf<T>,
+		currency_id: CurrencyId,
+		collateral_adjustment: Amount,
 		debit_adjustment: T::DebitAmount,
 	) -> DispatchResult {
-		let collateral_balance = TryInto::<BalanceOf<T>>::try_into(collateral_adjustment.abs())
-			.map_err(|_| Error::<T>::AmountConvertFailed)?;
+		let collateral_balance =
+			TryInto::<Balance>::try_into(collateral_adjustment.abs()).map_err(|_| Error::<T>::AmountConvertFailed)?;
 		let debit_balance = TryInto::<T::DebitBalance>::try_into(debit_adjustment.abs())
 			.map_err(|_| Error::<T>::AmountConvertFailed)?;
 
 		if collateral_adjustment.is_positive() {
 			Self::total_collaterals(currency_id)
-				.checked_add(&collateral_balance)
+				.checked_add(collateral_balance)
 				.ok_or(Error::<T>::CollateralOverflow)?;
 		} else if collateral_adjustment.is_negative() {
 			Self::collaterals(who, currency_id)
-				.checked_sub(&collateral_balance)
+				.checked_sub(collateral_balance)
 				.ok_or(Error::<T>::CollateralTooLow)?;
 		}
 
@@ -258,15 +256,15 @@ impl<T: Trait> Module<T> {
 
 	fn update_loan(
 		who: &T::AccountId,
-		currency_id: CurrencyIdOf<T>,
-		collateral_adjustment: AmountOf<T>,
+		currency_id: CurrencyId,
+		collateral_adjustment: Amount,
 		debit_adjustment: T::DebitAmount,
 	) -> DispatchResult {
 		// check overflow first
 		Self::check_update_loan_overflow(who, currency_id, collateral_adjustment, debit_adjustment)?;
 
-		let collateral_balance = TryInto::<BalanceOf<T>>::try_into(collateral_adjustment.abs())
-			.map_err(|_| Error::<T>::AmountConvertFailed)?;
+		let collateral_balance =
+			TryInto::<Balance>::try_into(collateral_adjustment.abs()).map_err(|_| Error::<T>::AmountConvertFailed)?;
 		let debit_balance = TryInto::<T::DebitBalance>::try_into(debit_adjustment.abs())
 			.map_err(|_| Error::<T>::AmountConvertFailed)?;
 
@@ -279,7 +277,7 @@ impl<T: Trait> Module<T> {
 				}
 				*balance += collateral_balance;
 			});
-			<TotalCollaterals<T>>::mutate(currency_id, |balance| *balance += collateral_balance);
+			TotalCollaterals::mutate(currency_id, |balance| *balance += collateral_balance);
 		} else if collateral_adjustment.is_negative() {
 			<Collaterals<T>>::mutate(who, currency_id, |balance| {
 				*balance -= collateral_balance;
@@ -288,7 +286,7 @@ impl<T: Trait> Module<T> {
 					system::Module::<T>::dec_ref(who);
 				}
 			});
-			<TotalCollaterals<T>>::mutate(currency_id, |balance| *balance -= collateral_balance);
+			TotalCollaterals::mutate(currency_id, |balance| *balance -= collateral_balance);
 		}
 
 		// update debit record

--- a/modules/loans/src/tests.rs
+++ b/modules/loans/src/tests.rs
@@ -5,18 +5,17 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{
-	CDPTreasuryModule, Currencies, ExtBuilder, LoansModule, Runtime, System, TestEvent, ALICE, AUSD, BOB, X_TOKEN_ID,
-	Y_TOKEN_ID,
+	CDPTreasuryModule, Currencies, ExtBuilder, LoansModule, Runtime, System, TestEvent, ALICE, AUSD, BOB, BTC, DOT,
 };
 
 #[test]
 fn debits_key() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, ALICE), 0);
-		assert_ok!(LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, 100, 100));
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, ALICE), 100);
-		assert_ok!(LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, -100, -100));
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, ALICE), 0);
+		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
+		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, 100, 100));
+		assert_eq!(LoansModule::debits(BTC, ALICE), 100);
+		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, -100, -100));
+		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
 	});
 }
 
@@ -25,13 +24,13 @@ fn check_update_loan_overflow_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// collateral underflow
 		assert_noop!(
-			LoansModule::check_update_loan_overflow(&ALICE, Y_TOKEN_ID, -100, 0),
+			LoansModule::check_update_loan_overflow(&ALICE, BTC, -100, 0),
 			Error::<Runtime>::CollateralTooLow,
 		);
 
 		// debit underflow
 		assert_noop!(
-			LoansModule::check_update_loan_overflow(&ALICE, Y_TOKEN_ID, 0, -100),
+			LoansModule::check_update_loan_overflow(&ALICE, BTC, 0, -100),
 			Error::<Runtime>::DebitTooLow,
 		);
 	});
@@ -41,39 +40,36 @@ fn check_update_loan_overflow_work() {
 fn adjust_position_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &ALICE), 1000);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
 
 		// balance too low
-		assert_eq!(LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, 2000, 0).is_ok(), false);
+		assert_eq!(LoansModule::adjust_position(&ALICE, BTC, 2000, 0).is_ok(), false);
 
 		// mock can't pass position valid check
-		assert_eq!(LoansModule::adjust_position(&ALICE, X_TOKEN_ID, 500, 0).is_ok(), false);
+		assert_eq!(LoansModule::adjust_position(&ALICE, DOT, 500, 0).is_ok(), false);
 
 		// mock exceed debit value cap
-		assert_eq!(
-			LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, 1000, 1000).is_ok(),
-			false
-		);
+		assert_eq!(LoansModule::adjust_position(&ALICE, BTC, 1000, 1000).is_ok(), false);
 
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &ALICE), 1000);
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &LoansModule::account_id()), 0);
-		assert_eq!(LoansModule::total_debits(Y_TOKEN_ID), 0);
-		assert_eq!(LoansModule::total_collaterals(Y_TOKEN_ID), 0);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 0);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 0);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
+		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
+		assert_eq!(LoansModule::total_debits(BTC), 0);
+		assert_eq!(LoansModule::total_collaterals(BTC), 0);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 0);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 0);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 0);
 
 		// success
-		assert_ok!(LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, 500, 300));
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &ALICE), 500);
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &LoansModule::account_id()), 500);
-		assert_eq!(LoansModule::total_debits(Y_TOKEN_ID), 300);
-		assert_eq!(LoansModule::total_collaterals(Y_TOKEN_ID), 500);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 300);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 500);
+		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, 500, 300));
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 500);
+		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 500);
+		assert_eq!(LoansModule::total_debits(BTC), 300);
+		assert_eq!(LoansModule::total_collaterals(BTC), 500);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 300);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 500);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 150);
 
-		let update_position_event = TestEvent::loans(RawEvent::UpdatePosition(ALICE, Y_TOKEN_ID, 500, 300));
+		let update_position_event = TestEvent::loans(RawEvent::UpdatePosition(ALICE, BTC, 500, 300));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == update_position_event));
@@ -83,24 +79,24 @@ fn adjust_position_should_work() {
 #[test]
 fn update_loan_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &LoansModule::account_id()), 0);
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &ALICE), 1000);
-		assert_eq!(LoansModule::total_debits(Y_TOKEN_ID), 0);
-		assert_eq!(LoansModule::total_collaterals(Y_TOKEN_ID), 0);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 0);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 0);
+		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
+		assert_eq!(LoansModule::total_debits(BTC), 0);
+		assert_eq!(LoansModule::total_collaterals(BTC), 0);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 0);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 0);
 
-		assert_ok!(LoansModule::update_loan(&ALICE, Y_TOKEN_ID, 3000, 2000));
+		assert_ok!(LoansModule::update_loan(&ALICE, BTC, 3000, 2000));
 
 		// just update records
-		assert_eq!(LoansModule::total_debits(Y_TOKEN_ID), 2000);
-		assert_eq!(LoansModule::total_collaterals(Y_TOKEN_ID), 3000);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 2000);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 3000);
+		assert_eq!(LoansModule::total_debits(BTC), 2000);
+		assert_eq!(LoansModule::total_collaterals(BTC), 3000);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 2000);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 3000);
 
 		// dot not manipulate balance
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &LoansModule::account_id()), 0);
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &ALICE), 1000);
+		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
 	});
 }
 
@@ -108,20 +104,20 @@ fn update_loan_should_work() {
 fn transfer_loan_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		assert_ok!(LoansModule::update_loan(&ALICE, Y_TOKEN_ID, 400, 500));
-		assert_ok!(LoansModule::update_loan(&BOB, Y_TOKEN_ID, 100, 600));
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 500);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 400);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &BOB), 600);
-		assert_eq!(LoansModule::collaterals(&BOB, Y_TOKEN_ID), 100);
+		assert_ok!(LoansModule::update_loan(&ALICE, BTC, 400, 500));
+		assert_ok!(LoansModule::update_loan(&BOB, BTC, 100, 600));
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 500);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 400);
+		assert_eq!(LoansModule::debits(BTC, &BOB), 600);
+		assert_eq!(LoansModule::collaterals(&BOB, BTC), 100);
 
-		assert_ok!(LoansModule::transfer_loan(&ALICE, &BOB, Y_TOKEN_ID));
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 0);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 0);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &BOB), 1100);
-		assert_eq!(LoansModule::collaterals(&BOB, Y_TOKEN_ID), 500);
+		assert_ok!(LoansModule::transfer_loan(&ALICE, &BOB, BTC));
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 0);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 0);
+		assert_eq!(LoansModule::debits(BTC, &BOB), 1100);
+		assert_eq!(LoansModule::collaterals(&BOB, BTC), 500);
 
-		let transfer_loan_event = TestEvent::loans(RawEvent::TransferLoan(ALICE, BOB, Y_TOKEN_ID));
+		let transfer_loan_event = TestEvent::loans(RawEvent::TransferLoan(ALICE, BOB, BTC));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == transfer_loan_event));
@@ -132,30 +128,28 @@ fn transfer_loan_should_work() {
 fn confiscate_collateral_and_debit_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		assert_ok!(LoansModule::update_loan(&BOB, Y_TOKEN_ID, 5000, 1000));
-		assert_eq!(Currencies::free_balance(Y_TOKEN_ID, &LoansModule::account_id()), 0);
+		assert_ok!(LoansModule::update_loan(&BOB, BTC, 5000, 1000));
+		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
 
 		// have no sufficient balance
 		assert_eq!(
-			LoansModule::confiscate_collateral_and_debit(&BOB, Y_TOKEN_ID, 5000, 1000).is_ok(),
+			LoansModule::confiscate_collateral_and_debit(&BOB, BTC, 5000, 1000).is_ok(),
 			false,
 		);
 
-		assert_ok!(LoansModule::adjust_position(&ALICE, Y_TOKEN_ID, 500, 300));
-		assert_eq!(CDPTreasuryModule::get_total_collaterals(Y_TOKEN_ID), 0);
+		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, 500, 300));
+		assert_eq!(CDPTreasuryModule::get_total_collaterals(BTC), 0);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 300);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 500);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 300);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 500);
 
-		assert_ok!(LoansModule::confiscate_collateral_and_debit(
-			&ALICE, Y_TOKEN_ID, 300, 200
-		));
-		assert_eq!(CDPTreasuryModule::get_total_collaterals(Y_TOKEN_ID), 300);
+		assert_ok!(LoansModule::confiscate_collateral_and_debit(&ALICE, BTC, 300, 200));
+		assert_eq!(CDPTreasuryModule::get_total_collaterals(BTC), 300);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 100);
-		assert_eq!(LoansModule::debits(Y_TOKEN_ID, &ALICE), 100);
-		assert_eq!(LoansModule::collaterals(&ALICE, Y_TOKEN_ID), 200);
+		assert_eq!(LoansModule::debits(BTC, &ALICE), 100);
+		assert_eq!(LoansModule::collaterals(&ALICE, BTC), 200);
 
-		let confiscate_event = TestEvent::loans(RawEvent::ConfiscateCollateralAndDebit(ALICE, Y_TOKEN_ID, 300, 200));
+		let confiscate_event = TestEvent::loans(RawEvent::ConfiscateCollateralAndDebit(ALICE, BTC, 300, 200));
 		assert!(System::events().iter().any(|record| record.event == confiscate_event));
 	});
 }

--- a/modules/nominees_election/Cargo.toml
+++ b/modules/nominees_election/Cargo.toml
@@ -9,16 +9,16 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 
@@ -29,9 +29,10 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"support/std",
 	"orml-traits/std",
 	"orml-tokens/std",
+	"primitives/std",
 ]

--- a/modules/nominees_election/src/mock.rs
+++ b/modules/nominees_election/src/mock.rs
@@ -4,8 +4,20 @@
 
 use super::*;
 use frame_support::{impl_outer_origin, parameter_types};
-use primitives::H256;
+use primitives::{Amount, CurrencyId};
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
+
+pub type AccountId = u64;
+pub type BlockNumber = u64;
+
+pub const ALICE: AccountId = 0;
+pub const BOB: AccountId = 1;
+pub const ACA: CurrencyId = CurrencyId::ACA;
+pub const LDOT: CurrencyId = CurrencyId::LDOT;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Runtime;
 
 impl_outer_origin! {
 	pub enum Origin for Runtime {}
@@ -16,22 +28,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: u32 = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
-	pub const ExistentialDeposit: u64 = 1;
 }
-
-pub type AccountId = u64;
-pub type BlockNumber = u64;
-pub type Balance = u64;
-pub type Amount = i64;
-pub type CurrencyId = u32;
-
-pub const ALICE: AccountId = 0;
-pub const BOB: AccountId = 1;
-pub const ACA: CurrencyId = 0;
-pub const LDOT: CurrencyId = 1;
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Runtime;
 
 impl system::Trait for Runtime {
 	type Origin = Origin;
@@ -55,6 +52,10 @@ impl system::Trait for Runtime {
 	type OnKilledAccount = ();
 }
 pub type System = system::Module<Runtime>;
+
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1;
+}
 
 impl orml_tokens::Trait for Runtime {
 	type Event = ();
@@ -120,7 +121,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
 		orml_tokens::GenesisConfig::<Runtime> {

--- a/modules/polkadot_bridge/Cargo.toml
+++ b/modules/polkadot_bridge/Cargo.toml
@@ -9,15 +9,15 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 
 [features]
 default = ["std"]
@@ -26,8 +26,9 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"support/std",
 	"orml-traits/std",
+	"primitives/std",
 ]

--- a/modules/prices/Cargo.toml
+++ b/modules/prices/Cargo.toml
@@ -9,15 +9,15 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { package = "orml-traits", path = "../../orml/traits", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 
 [features]
 default = ["std"]
@@ -26,8 +26,9 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-traits/std",
 	"support/std",
+	"primitives/std",
 ]

--- a/modules/prices/src/lib.rs
+++ b/modules/prices/src/lib.rs
@@ -3,32 +3,28 @@
 use frame_support::{
 	decl_event, decl_module, decl_storage,
 	traits::{EnsureOrigin, Get},
-	Parameter,
 };
+use frame_system::{self as system, ensure_root};
 use orml_traits::DataProvider;
-use sp_runtime::traits::{MaybeSerializeDeserialize, Member};
+use primitives::CurrencyId;
 use support::{ExchangeRateProvider, Price, PriceProvider};
-use system::ensure_root;
 
 mod mock;
 mod tests;
 
 pub trait Trait: system::Trait {
-	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-	type CurrencyId: Parameter + Member + Copy + MaybeSerializeDeserialize;
-	type Source: DataProvider<Self::CurrencyId, Price>;
-	type GetStableCurrencyId: Get<Self::CurrencyId>;
+	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
+	type Source: DataProvider<CurrencyId, Price>;
+	type GetStableCurrencyId: Get<CurrencyId>;
 	type StableCurrencyFixedPrice: Get<Price>;
-	type GetStakingCurrencyId: Get<Self::CurrencyId>;
-	type GetLiquidCurrencyId: Get<Self::CurrencyId>;
+	type GetStakingCurrencyId: Get<CurrencyId>;
+	type GetLiquidCurrencyId: Get<CurrencyId>;
 	type LockOrigin: EnsureOrigin<Self::Origin>;
 	type LiquidStakingExchangeRateProvider: ExchangeRateProvider;
 }
 
 decl_event!(
-	pub enum Event<T> where
-		<T as Trait>::CurrencyId,
-	{
+	pub enum Event {
 		LockPrice(CurrencyId, Price),
 		UnlockPrice(CurrencyId),
 	}
@@ -36,7 +32,7 @@ decl_event!(
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Prices {
-		LockedPrice get(fn locked_price): map hasher(twox_64_concat) T::CurrencyId => Option<Price>;
+		LockedPrice get(fn locked_price): map hasher(twox_64_concat) CurrencyId => Option<Price>;
 	}
 }
 
@@ -44,33 +40,33 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
-		const GetStableCurrencyId: T::CurrencyId = T::GetStableCurrencyId::get();
+		const GetStableCurrencyId: CurrencyId = T::GetStableCurrencyId::get();
 		const StableCurrencyFixedPrice: Price = T::StableCurrencyFixedPrice::get();
 
 		#[weight = frame_support::weights::SimpleDispatchInfo::default()]
-		fn lock_price(origin, currency_id: T::CurrencyId) {
+		fn lock_price(origin, currency_id: CurrencyId) {
 			T::LockOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
 
-			<Module<T> as PriceProvider<T::CurrencyId>>::lock_price(currency_id);
+			<Module<T> as PriceProvider<CurrencyId>>::lock_price(currency_id);
 		}
 
 		#[weight = frame_support::weights::SimpleDispatchInfo::default()]
-		fn unlock_price(origin, currency_id: T::CurrencyId) {
+		fn unlock_price(origin, currency_id: CurrencyId) {
 			T::LockOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
 
-			<Module<T> as PriceProvider<T::CurrencyId>>::unlock_price(currency_id);
+			<Module<T> as PriceProvider<CurrencyId>>::unlock_price(currency_id);
 		}
 	}
 }
 
 impl<T: Trait> Module<T> {}
 
-impl<T: Trait> PriceProvider<T::CurrencyId> for Module<T> {
-	fn get_relative_price(base_currency_id: T::CurrencyId, quote_currency_id: T::CurrencyId) -> Option<Price> {
+impl<T: Trait> PriceProvider<CurrencyId> for Module<T> {
+	fn get_relative_price(base_currency_id: CurrencyId, quote_currency_id: CurrencyId) -> Option<Price> {
 		if let (Some(base_price), Some(quote_price)) =
 			(Self::get_price(base_currency_id), Self::get_price(quote_currency_id))
 		{
@@ -80,7 +76,7 @@ impl<T: Trait> PriceProvider<T::CurrencyId> for Module<T> {
 		}
 	}
 
-	fn get_price(currency_id: T::CurrencyId) -> Option<Price> {
+	fn get_price(currency_id: CurrencyId) -> Option<Price> {
 		if currency_id == T::GetStableCurrencyId::get() {
 			// if is stable currency, return fix price
 			Some(T::StableCurrencyFixedPrice::get())
@@ -106,16 +102,16 @@ impl<T: Trait> PriceProvider<T::CurrencyId> for Module<T> {
 		}
 	}
 
-	fn lock_price(currency_id: T::CurrencyId) {
+	fn lock_price(currency_id: CurrencyId) {
 		// lock price when get valid price from source
 		if let Some(val) = T::Source::get(&currency_id) {
-			<LockedPrice<T>>::insert(currency_id, val);
-			<Module<T>>::deposit_event(RawEvent::LockPrice(currency_id, val));
+			LockedPrice::insert(currency_id, val);
+			<Module<T>>::deposit_event(Event::LockPrice(currency_id, val));
 		}
 	}
 
-	fn unlock_price(currency_id: T::CurrencyId) {
-		<LockedPrice<T>>::remove(currency_id);
-		<Module<T>>::deposit_event(RawEvent::UnlockPrice(currency_id));
+	fn unlock_price(currency_id: CurrencyId) {
+		LockedPrice::remove(currency_id);
+		<Module<T>>::deposit_event(Event::UnlockPrice(currency_id));
 	}
 }

--- a/modules/primitives/src/lib.rs
+++ b/modules/primitives/src/lib.rs
@@ -25,3 +25,9 @@ pub enum AirDropCurrencyId {
 
 /// Counter for the number of eras that have passed.
 pub type EraIndex = u32;
+
+/// Balance of an account.
+pub type Balance = u128;
+
+/// Signed version of Balance
+pub type Amount = i128;

--- a/modules/staking_pool/Cargo.toml
+++ b/modules/staking_pool/Cargo.toml
@@ -7,17 +7,17 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-frame-support = { package = "frame-support", version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+frame-support = { version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-traits = { package = "orml-traits", path = "../../orml/traits", default-features = false }
 orml-tokens = { path = "../../orml/tokens", default-features = false }
 support = { package = "module-support", path = "../support", default-features = false }
+primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.6", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.6", default-features = false }
+sp-core = { version = "2.0.0-alpha.6", default-features = false }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 orml-currencies = { path = "../../orml/currencies", default-features = false }
 
@@ -27,9 +27,10 @@ std = [
 	"codec/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"system/std",
-	"rstd/std",
+	"frame-system/std",
+	"sp-std/std",
 	"orml-traits/std",
 	"support/std",
 	"orml-tokens/std",
+	"primitives/std",
 ]

--- a/modules/staking_pool/rpc/runtime-api/Cargo.toml
+++ b/modules/staking_pool/rpc/runtime-api/Cargo.toml
@@ -9,8 +9,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-api = { version = "2.0.0-alpha.6", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 support = { package = "module-support", path = "../../../support", default-features = false }
 
 [features]
@@ -20,6 +19,6 @@ std = [
 	"codec/std",
 	"sp-api/std",
 	"sp-runtime/std",
-	"rstd/std",
+	"sp-std/std",
 	"support/std",
 ]

--- a/modules/staking_pool/rpc/runtime-api/src/lib.rs
+++ b/modules/staking_pool/rpc/runtime-api/src/lib.rs
@@ -3,10 +3,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode};
-use rstd::prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sp_runtime::traits::{MaybeDisplay, MaybeFromStr};
+use sp_std::prelude::*;
 
 #[derive(Eq, PartialEq, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]

--- a/modules/staking_pool/src/tests.rs
+++ b/modules/staking_pool/src/tests.rs
@@ -33,7 +33,7 @@ fn claim_period_percent_work() {
 #[test]
 fn withdraw_unbonded_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		<TotalClaimedUnbonded<Runtime>>::put(500);
+		TotalClaimedUnbonded::put(500);
 		<ClaimedUnbond<Runtime>>::insert(ALICE, StakingPoolModule::current_era(), 200);
 		assert_ok!(CurrenciesModule::deposit(DOT, &StakingPoolModule::account_id(), 500));
 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
@@ -96,8 +96,8 @@ fn redeem_by_free_unbonded_work() {
 		System::set_block_number(1);
 		assert_eq!(StakingPoolModule::bond(&ALICE, 1000), Ok(10000));
 		assert_eq!(StakingPoolModule::bond(&BOB, 1000), Ok(10000));
-		<TotalBonded<Runtime>>::mutate(|bonded| *bonded -= 1500);
-		<FreeUnbonded<Runtime>>::put(1500);
+		TotalBonded::mutate(|bonded| *bonded -= 1500);
+		FreeUnbonded::put(1500);
 		assert_ok!(CurrenciesModule::deposit(DOT, &StakingPoolModule::account_id(), 1500));
 		assert_eq!(StakingPoolModule::total_bonded(), 500);
 		assert_eq!(StakingPoolModule::free_unbonded(), 1500);
@@ -137,9 +137,9 @@ fn redeem_by_claim_unbonding_work() {
 		System::set_block_number(1);
 		assert_eq!(StakingPoolModule::bond(&ALICE, 1000), Ok(10000));
 		assert_eq!(StakingPoolModule::bond(&BOB, 1000), Ok(10000));
-		<TotalBonded<Runtime>>::mutate(|bonded| *bonded -= 1500);
-		<Unbonding<Runtime>>::insert(2, (1500, 0));
-		<UnbondingToFree<Runtime>>::put(1500);
+		TotalBonded::mutate(|bonded| *bonded -= 1500);
+		Unbonding::insert(2, (1500, 0));
+		UnbondingToFree::put(1500);
 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
 		assert_eq!(StakingPoolModule::total_bonded(), 500);
 		assert_eq!(StakingPoolModule::unbonding(2), (1500, 0));
@@ -178,10 +178,10 @@ fn redeem_by_claim_unbonding_work() {
 #[test]
 fn rebalance_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		<TotalBonded<Runtime>>::put(20000);
-		<Unbonding<Runtime>>::insert(1, (20000, 10000));
-		<UnbondingToFree<Runtime>>::put(10000);
-		<NextEraUnbond<Runtime>>::put((5000, 5000));
+		TotalBonded::put(20000);
+		Unbonding::insert(1, (20000, 10000));
+		UnbondingToFree::put(10000);
+		NextEraUnbond::put((5000, 5000));
 
 		assert_eq!(StakingPoolModule::current_era(), 0);
 		assert_eq!(StakingPoolModule::total_bonded(), 20000);

--- a/modules/support/Cargo.toml
+++ b/modules/support/Cargo.toml
@@ -9,16 +9,15 @@ impl-trait-for-tuples = "0.1.3"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
 frame-support = { version = "2.0.0-alpha.6", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.6", default-features = false }
-
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 orml-utilities = { path = "../../orml/utilities", default-features = false }
-primitives = { package = "module-primitives", path = "../primitives", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"codec/std",
 	"orml-utilities/std",
 	"sp-runtime/std",
 	"frame-support/std",
-	"primitives/std",
+	"sp-std/std",
 ]

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -1,18 +1,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::FullCodec;
+use codec::{Decode, Encode, FullCodec, HasCompact};
 use orml_utilities::FixedU128;
-use rstd::{
+use sp_runtime::{DispatchError, DispatchResult};
+use sp_std::{
 	cmp::{Eq, PartialEq},
 	fmt::Debug,
+	prelude::*,
 };
-use sp_runtime::{DispatchError, DispatchResult};
 
 pub mod homa;
-
 pub use homa::{
-	EraIndex, HomaProtocol, NomineesProvider, OnCommission, OnNewEra, PolkadotBridge, PolkadotBridgeCall,
-	PolkadotBridgeState, PolkadotBridgeType, PolkadotStakingLedger, PolkadotUnlockChunk,
+	HomaProtocol, NomineesProvider, OnCommission, OnNewEra, PolkadotBridge, PolkadotBridgeCall, PolkadotBridgeState,
+	PolkadotBridgeType, PolkadotStakingLedger, PolkadotUnlockChunk,
 };
 
 pub type Price = FixedU128;
@@ -92,7 +92,7 @@ pub trait DEXManager<AccountId, CurrencyId, Balance> {
 		supply_amount: Balance,
 		target_currency_id: CurrencyId,
 		acceptable_target_amount: Balance,
-	) -> rstd::result::Result<Balance, DispatchError>;
+	) -> sp_std::result::Result<Balance, DispatchError>;
 
 	fn get_exchange_slippage(
 		supply_currency_id: CurrencyId,
@@ -127,7 +127,7 @@ where
 		_supply_amount: Balance,
 		_target_currency_id: CurrencyId,
 		_acceptable_target_amount: Balance,
-	) -> rstd::result::Result<Balance, DispatchError> {
+	) -> sp_std::result::Result<Balance, DispatchError> {
 		Ok(Default::default())
 	}
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,7 +41,7 @@ sp-staking = { version = "2.0.0-alpha.6", default-features = false }
 sp-std = { version = "2.0.0-alpha.6", default-features = false }
 sp-transaction-pool = { version = "2.0.0-alpha.6", default-features = false }
 sp-version = { version = "2.0.0-alpha.6", default-features = false }
-system = { package = "frame-system", version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
 
 orml-auction = { path = "../orml/auction", default-features = false }
 orml-currencies = { path = "../orml/currencies", default-features = false }
@@ -83,6 +83,7 @@ std = [
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
+	"frame-system/std",
 	"pallet-babe/std",
 	"pallet-balances/std",
 	"pallet-collective/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,11 +27,11 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+use frame_system::{self as system, offchain::TransactionSubmitter};
 use orml_currencies::{BasicCurrencyAdapter, Currency};
 use orml_oracle::OperatorProvider;
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::AuthorityList as GrandpaAuthorityList;
-use system::offchain::TransactionSubmitter;
 
 // A few exports that help ease life for downstream crates.
 
@@ -541,7 +541,6 @@ parameter_types! {
 
 impl module_prices::Trait for Runtime {
 	type Event = Event;
-	type CurrencyId = CurrencyId;
 	type Source = Oracle;
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type StableCurrencyFixedPrice = StableCurrencyFixedPrice;
@@ -630,7 +629,6 @@ impl module_cdp_engine::Trait for Runtime {
 	type CDPTreasury = CdpTreasury;
 	type UpdateOrigin = pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, HonzonCouncilInstance>;
 	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
-	type Currency = Currencies;
 	type DEX = Dex;
 	type Call = Call;
 	type SubmitTransaction = TransactionSubmitterOf<()>;
@@ -687,14 +685,11 @@ impl module_accounts::Trait for Runtime {
 	type FreeTransferPeriod = FreeTransferPeriod;
 	type FreeTransferDeposit = FreeTransferDeposit;
 	type Time = Timestamp;
-	type Currency = Currencies;
 	type DepositCurrency = Balances;
 }
 
 impl module_airdrop::Trait for Runtime {
 	type Event = Event;
-	type AirDropCurrencyId = AirDropCurrencyId;
-	type Balance = Balance;
 }
 
 parameter_types! {
@@ -799,15 +794,15 @@ construct_runtime!(
 		// acala modules
 		Currencies: orml_currencies::{Module, Call, Event<T>},
 		Oracle: orml_oracle::{Module, Storage, Call, Event<T>},
-		Prices: module_prices::{Module, Storage, Call, Event<T>},
+		Prices: module_prices::{Module, Storage, Call, Event},
 		Tokens: orml_tokens::{Module, Storage, Event<T>, Config<T>},
 		Auction: orml_auction::{Module, Storage, Call, Event<T>},
 		AuctionManager: module_auction_manager::{Module, Storage, Call, Event<T>, ValidateUnsigned},
 		Loans: module_loans::{Module, Storage, Call, Event<T>},
 		Honzon: module_honzon::{Module, Storage, Call, Event<T>},
-		Dex: module_dex::{Module, Storage, Call, Config<T>, Event<T>},
-		CdpTreasury: module_cdp_treasury::{Module, Storage, Call, Config<T>, Event<T>},
-		CdpEngine: module_cdp_engine::{Module, Storage, Call, Event<T>, Config<T>, ValidateUnsigned},
+		Dex: module_dex::{Module, Storage, Call, Config, Event<T>},
+		CdpTreasury: module_cdp_treasury::{Module, Storage, Call, Config, Event},
+		CdpEngine: module_cdp_engine::{Module, Storage, Call, Event<T>, Config, ValidateUnsigned},
 		EmergencyShutdown: module_emergency_shutdown::{Module, Storage, Call, Event<T>},
 		Accounts: module_accounts::{Module, Call, Storage},
 		AirDrop: module_airdrop::{Module, Call, Storage, Event<T>, Config<T>},

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -4,8 +4,8 @@ use sp_runtime::{
 	MultiSignature,
 };
 
-pub use module_primitives::{AirDropCurrencyId, CurrencyId};
-pub use module_support::{EraIndex, ExchangeRate, Price, Rate, Ratio};
+pub use module_primitives::{AirDropCurrencyId, Amount, Balance, CurrencyId, EraIndex};
+pub use module_support::{ExchangeRate, Price, Rate, Ratio};
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -20,12 +20,6 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 /// The type for looking up accounts. We don't expect more than 4 billion of them, but you
 /// never know...
 pub type AccountIndex = u32;
-
-/// Balance of an account.
-pub type Balance = u128;
-
-/// Signed version of Balance
-pub type Amount = i128;
 
 /// Index of a transaction in the chain.
 pub type Index = u32;

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -1,11 +1,7 @@
 #[cfg(test)]
 
 mod tests {
-	use acala_runtime::{
-		AccountId, Balance, CurrencyId,
-		CurrencyId::{AUSD, DOT, LDOT, XBTC},
-		Runtime,
-	};
+	use acala_runtime::{AccountId, Balance, CurrencyId, Runtime};
 	use frame_support::{
 		assert_noop, assert_ok,
 		traits::{OnFinalize, OnInitialize},
@@ -28,7 +24,7 @@ mod tests {
 	pub type CdpEngineModule = module_cdp_engine::Module<Runtime>;
 	pub type LoansModule = module_loans::Module<Runtime>;
 	pub type CdpTreasuryModule = module_cdp_treasury::Module<Runtime>;
-	pub type SystemModule = system::Module<Runtime>;
+	pub type SystemModule = frame_system::Module<Runtime>;
 	pub type EmergencyShutdownModule = module_emergency_shutdown::Module<Runtime>;
 	pub type AuctionManagerModule = module_auction_manager::Module<Runtime>;
 	pub type Currencies = orml_currencies::Module<Runtime>;
@@ -52,7 +48,9 @@ mod tests {
 		}
 
 		pub fn build(self) -> sp_io::TestExternalities {
-			let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+			let mut t = frame_system::GenesisConfig::default()
+				.build_storage::<Runtime>()
+				.unwrap();
 
 			orml_tokens::GenesisConfig::<Runtime> {
 				endowed_accounts: self.endowed_accounts,
@@ -60,8 +58,8 @@ mod tests {
 			.assimilate_storage(&mut t)
 			.unwrap();
 
-			module_dex::GenesisConfig::<Runtime> {
-				liquidity_incentive_rate: vec![(XBTC, Rate::from_rational(1, 100))],
+			module_dex::GenesisConfig {
+				liquidity_incentive_rate: vec![(CurrencyId::XBTC, Rate::from_rational(1, 100))],
 			}
 			.assimilate_storage(&mut t)
 			.unwrap();
@@ -81,8 +79,8 @@ mod tests {
 		}
 	}
 
-	pub fn origin_of(account_id: AccountId) -> <Runtime as system::Trait>::Origin {
-		<Runtime as system::Trait>::Origin::signed(account_id)
+	pub fn origin_of(account_id: AccountId) -> <Runtime as frame_system::Trait>::Origin {
+		<Runtime as frame_system::Trait>::Origin::signed(account_id)
 	}
 
 	fn set_oracle_price(prices: Vec<(CurrencyId, Price)>) -> DispatchResult {
@@ -107,55 +105,67 @@ mod tests {
 	fn emergency_shutdown_and_cdp_treasury() {
 		ExtBuilder::default()
 			.balances(vec![
-				(AccountId::from(ALICE), AUSD, 2_000_000u128),
-				(AccountId::from(BOB), AUSD, 8_000_000u128),
-				(AccountId::from(BOB), XBTC, 1_000_000u128),
-				(AccountId::from(BOB), DOT, 200_000_000u128),
-				(AccountId::from(BOB), LDOT, 40_000_000u128),
+				(AccountId::from(ALICE), CurrencyId::AUSD, 2_000_000u128),
+				(AccountId::from(BOB), CurrencyId::AUSD, 8_000_000u128),
+				(AccountId::from(BOB), CurrencyId::XBTC, 1_000_000u128),
+				(AccountId::from(BOB), CurrencyId::DOT, 200_000_000u128),
+				(AccountId::from(BOB), CurrencyId::LDOT, 40_000_000u128),
 			])
 			.build()
 			.execute_with(|| {
 				assert_ok!(CdpTreasuryModule::transfer_collateral_from(
-					XBTC,
+					CurrencyId::XBTC,
 					&AccountId::from(BOB),
 					1_000_000
 				));
 				assert_ok!(CdpTreasuryModule::transfer_collateral_from(
-					DOT,
+					CurrencyId::DOT,
 					&AccountId::from(BOB),
 					200_000_000
 				));
 				assert_ok!(CdpTreasuryModule::transfer_collateral_from(
-					LDOT,
+					CurrencyId::LDOT,
 					&AccountId::from(BOB),
 					40_000_000
 				));
-				assert_eq!(CdpTreasuryModule::total_collaterals(XBTC), 1_000_000);
-				assert_eq!(CdpTreasuryModule::total_collaterals(DOT), 200_000_000);
-				assert_eq!(CdpTreasuryModule::total_collaterals(LDOT), 40_000_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::XBTC), 1_000_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::DOT), 200_000_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::LDOT), 40_000_000);
 
 				assert_noop!(
 					EmergencyShutdownModule::refund_collaterals(origin_of(AccountId::from(ALICE)), 1_000_000),
 					module_emergency_shutdown::Error::<Runtime>::CanNotRefund,
 				);
 				assert_ok!(EmergencyShutdownModule::emergency_shutdown(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT
 				));
 				assert_ok!(EmergencyShutdownModule::open_collateral_refund(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT
 				));
 				assert_ok!(EmergencyShutdownModule::refund_collaterals(
 					origin_of(AccountId::from(ALICE)),
 					1_000_000
 				));
 
-				assert_eq!(CdpTreasuryModule::total_collaterals(XBTC), 900_000);
-				assert_eq!(CdpTreasuryModule::total_collaterals(DOT), 180_000_000);
-				assert_eq!(CdpTreasuryModule::total_collaterals(LDOT), 36_000_000);
-				assert_eq!(Currencies::free_balance(AUSD, &AccountId::from(ALICE)), 1_000_000);
-				assert_eq!(Currencies::free_balance(XBTC, &AccountId::from(ALICE)), 100_000);
-				assert_eq!(Currencies::free_balance(DOT, &AccountId::from(ALICE)), 20_000_000);
-				assert_eq!(Currencies::free_balance(LDOT, &AccountId::from(ALICE)), 4_000_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::XBTC), 900_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::DOT), 180_000_000);
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::LDOT), 36_000_000);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::AUSD, &AccountId::from(ALICE)),
+					1_000_000
+				);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::XBTC, &AccountId::from(ALICE)),
+					100_000
+				);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::DOT, &AccountId::from(ALICE)),
+					20_000_000
+				);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::LDOT, &AccountId::from(ALICE)),
+					4_000_000
+				);
 			});
 	}
 
@@ -163,25 +173,28 @@ mod tests {
 	fn liquidate_cdp() {
 		ExtBuilder::default()
 			.balances(vec![
-				(AccountId::from(BOB), AUSD, amount(1_000_000)),
-				(AccountId::from(ALICE), XBTC, amount(10)),
-				(AccountId::from(BOB), XBTC, amount(101)),
+				(AccountId::from(BOB), CurrencyId::AUSD, amount(1_000_000)),
+				(AccountId::from(ALICE), CurrencyId::XBTC, amount(10)),
+				(AccountId::from(BOB), CurrencyId::XBTC, amount(101)),
 			])
 			.build()
 			.execute_with(|| {
 				SystemModule::set_block_number(1);
-				assert_ok!(set_oracle_price(vec![(XBTC, Price::from_rational(10000, 1))])); // 10000 usd
+				assert_ok!(set_oracle_price(vec![(
+					CurrencyId::XBTC,
+					Price::from_rational(10000, 1)
+				)])); // 10000 usd
 
 				assert_ok!(DexModule::add_liquidity(
 					origin_of(AccountId::from(BOB)),
-					XBTC,
+					CurrencyId::XBTC,
 					amount(100),
 					amount(1_000_000)
 				));
 
 				assert_ok!(CdpEngineModule::set_collateral_params(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT,
-					XBTC,
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT,
+					CurrencyId::XBTC,
 					Some(Some(Rate::from_natural(0))),
 					Some(Some(Ratio::from_rational(200, 100))),
 					Some(Some(Rate::from_rational(20, 100))),
@@ -191,28 +204,40 @@ mod tests {
 
 				assert_ok!(CdpEngineModule::adjust_position(
 					&AccountId::from(ALICE),
-					XBTC,
+					CurrencyId::XBTC,
 					amount(10) as i128,
 					amount(500_000) as i128
 				));
 
 				assert_ok!(CdpEngineModule::adjust_position(
 					&AccountId::from(BOB),
-					XBTC,
+					CurrencyId::XBTC,
 					amount(1) as i128,
 					amount(50_000) as i128
 				));
 
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), amount(500_000));
-				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), XBTC), amount(10));
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(BOB)), amount(50_000));
-				assert_eq!(LoansModule::collaterals(AccountId::from(BOB), XBTC), amount(1));
+				assert_eq!(
+					LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+					amount(500_000)
+				);
+				assert_eq!(
+					LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+					amount(10)
+				);
+				assert_eq!(
+					LoansModule::debits(CurrencyId::XBTC, AccountId::from(BOB)),
+					amount(50_000)
+				);
+				assert_eq!(
+					LoansModule::collaterals(AccountId::from(BOB), CurrencyId::XBTC),
+					amount(1)
+				);
 				assert_eq!(CdpTreasuryModule::debit_pool(), 0);
 				assert_eq!(AuctionManagerModule::collateral_auctions(0), None);
 
 				assert_ok!(CdpEngineModule::set_collateral_params(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT,
-					XBTC,
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT,
+					CurrencyId::XBTC,
 					None,
 					Some(Some(Ratio::from_rational(400, 100))),
 					None,
@@ -220,11 +245,14 @@ mod tests {
 					None,
 				));
 
-				assert_ok!(CdpEngineModule::liquidate_unsafe_cdp(AccountId::from(ALICE), XBTC));
+				assert_ok!(CdpEngineModule::liquidate_unsafe_cdp(
+					AccountId::from(ALICE),
+					CurrencyId::XBTC
+				));
 
 				let liquidate_alice_xbtc_cdp_event =
 					acala_runtime::Event::module_cdp_engine(module_cdp_engine::RawEvent::LiquidateUnsafeCDP(
-						XBTC,
+						CurrencyId::XBTC,
 						AccountId::from(ALICE),
 						amount(10),
 						amount(50_000),
@@ -234,16 +262,19 @@ mod tests {
 					.iter()
 					.any(|record| record.event == liquidate_alice_xbtc_cdp_event));
 
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), 0);
-				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), XBTC), 0);
+				assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
+				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC), 0);
 				assert_eq!(AuctionManagerModule::collateral_auctions(0).is_some(), true);
 				assert_eq!(CdpTreasuryModule::debit_pool(), amount(50_000));
 
-				assert_ok!(CdpEngineModule::liquidate_unsafe_cdp(AccountId::from(BOB), XBTC));
+				assert_ok!(CdpEngineModule::liquidate_unsafe_cdp(
+					AccountId::from(BOB),
+					CurrencyId::XBTC
+				));
 
 				let liquidate_bob_xbtc_cdp_event =
 					acala_runtime::Event::module_cdp_engine(module_cdp_engine::RawEvent::LiquidateUnsafeCDP(
-						XBTC,
+						CurrencyId::XBTC,
 						AccountId::from(BOB),
 						amount(1),
 						amount(5_000),
@@ -253,8 +284,8 @@ mod tests {
 					.iter()
 					.any(|record| record.event == liquidate_bob_xbtc_cdp_event));
 
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(BOB)), 0);
-				assert_eq!(LoansModule::collaterals(AccountId::from(BOB), XBTC), 0);
+				assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(BOB)), 0);
+				assert_eq!(LoansModule::collaterals(AccountId::from(BOB), CurrencyId::XBTC), 0);
 				assert_eq!(CdpTreasuryModule::debit_pool(), amount(55_000));
 				assert!(CdpTreasuryModule::surplus_pool() >= amount(5_000));
 			});
@@ -264,10 +295,18 @@ mod tests {
 	fn test_dex_module() {
 		ExtBuilder::default()
 			.balances(vec![
-				(AccountId::from(ALICE), AUSD, (1_000_000_000_000_000_000u128)),
-				(AccountId::from(ALICE), XBTC, (1_000_000_000_000_000_000u128)),
-				(AccountId::from(BOB), AUSD, (1_000_000_000_000_000_000u128)),
-				(AccountId::from(BOB), XBTC, (1_000_000_000_000_000_000u128)),
+				(
+					AccountId::from(ALICE),
+					CurrencyId::AUSD,
+					(1_000_000_000_000_000_000u128),
+				),
+				(
+					AccountId::from(ALICE),
+					CurrencyId::XBTC,
+					(1_000_000_000_000_000_000u128),
+				),
+				(AccountId::from(BOB), CurrencyId::AUSD, (1_000_000_000_000_000_000u128)),
+				(AccountId::from(BOB), CurrencyId::XBTC, (1_000_000_000_000_000_000u128)),
 			])
 			.build()
 			.execute_with(|| {
@@ -275,25 +314,25 @@ mod tests {
 				assert_eq!(DexModule::calculate_swap_target_amount(10000, 10000, 10000), 4995);
 				assert!(DexModule::calculate_swap_supply_amount(10000, 10000, 4995) >= 9996);
 
-				assert_eq!(DexModule::liquidity_pool(XBTC), (0, 0));
-				assert_eq!(DexModule::total_shares(XBTC), 0);
-				assert_eq!(DexModule::shares(XBTC, AccountId::from(ALICE)), 0);
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (0, 0));
+				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 0);
+				assert_eq!(DexModule::shares(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
 
 				assert_noop!(
-					DexModule::add_liquidity(origin_of(AccountId::from(ALICE)), XBTC, 0, 10000000),
+					DexModule::add_liquidity(origin_of(AccountId::from(ALICE)), CurrencyId::XBTC, 0, 10000000),
 					module_dex::Error::<Runtime>::InvalidBalance,
 				);
 
 				assert_ok!(DexModule::add_liquidity(
 					origin_of(AccountId::from(ALICE)),
-					XBTC,
+					CurrencyId::XBTC,
 					10000,
 					10000000
 				));
 
 				let add_liquidity_event = acala_runtime::Event::module_dex(module_dex::RawEvent::AddLiquidity(
 					AccountId::from(ALICE),
-					XBTC,
+					CurrencyId::XBTC,
 					10000,
 					10000000,
 					10000000,
@@ -302,45 +341,60 @@ mod tests {
 					.iter()
 					.any(|record| record.event == add_liquidity_event));
 
-				assert_eq!(DexModule::liquidity_pool(XBTC), (10000, 10000000));
-				assert_eq!(DexModule::total_shares(XBTC), 10000000);
-				assert_eq!(DexModule::shares(XBTC, AccountId::from(ALICE)), 10000000);
-				assert_ok!(DexModule::add_liquidity(origin_of(AccountId::from(BOB)), XBTC, 1, 1000));
-				assert_eq!(DexModule::liquidity_pool(XBTC), (10001, 10001000));
-				assert_eq!(DexModule::total_shares(XBTC), 10001000);
-				assert_eq!(DexModule::shares(XBTC, AccountId::from(BOB)), 1000);
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10000, 10000000));
+				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 10000000);
+				assert_eq!(DexModule::shares(CurrencyId::XBTC, AccountId::from(ALICE)), 10000000);
+				assert_ok!(DexModule::add_liquidity(
+					origin_of(AccountId::from(BOB)),
+					CurrencyId::XBTC,
+					1,
+					1000
+				));
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10001, 10001000));
+				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 10001000);
+				assert_eq!(DexModule::shares(CurrencyId::XBTC, AccountId::from(BOB)), 1000);
 				assert_noop!(
-					DexModule::add_liquidity(origin_of(AccountId::from(BOB)), XBTC, 1, 999),
+					DexModule::add_liquidity(origin_of(AccountId::from(BOB)), CurrencyId::XBTC, 1, 999),
 					module_dex::Error::<Runtime>::InvalidLiquidityIncrement,
 				);
-				assert_eq!(DexModule::liquidity_pool(XBTC), (10001, 10001000));
-				assert_eq!(DexModule::total_shares(XBTC), 10001000);
-				assert_eq!(DexModule::shares(XBTC, AccountId::from(BOB)), 1000);
-				assert_ok!(DexModule::add_liquidity(origin_of(AccountId::from(BOB)), XBTC, 2, 1000));
-				assert_eq!(DexModule::liquidity_pool(XBTC), (10002, 10002000));
-				assert_ok!(DexModule::add_liquidity(origin_of(AccountId::from(BOB)), XBTC, 1, 1001));
-				assert_eq!(DexModule::liquidity_pool(XBTC), (10003, 10003000));
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10001, 10001000));
+				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 10001000);
+				assert_eq!(DexModule::shares(CurrencyId::XBTC, AccountId::from(BOB)), 1000);
+				assert_ok!(DexModule::add_liquidity(
+					origin_of(AccountId::from(BOB)),
+					CurrencyId::XBTC,
+					2,
+					1000
+				));
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10002, 10002000));
+				assert_ok!(DexModule::add_liquidity(
+					origin_of(AccountId::from(BOB)),
+					CurrencyId::XBTC,
+					1,
+					1001
+				));
+				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10003, 10003000));
 
-				assert_eq!(DexModule::total_shares(XBTC), 10002998);
-				assert_eq!(DexModule::total_interest(XBTC), 0);
+				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 10002998);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 0);
 				DexModule::on_initialize(0);
-				assert_eq!(DexModule::total_interest(XBTC), 100030);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 100030);
 				DexModule::on_initialize(0);
-				assert_eq!(DexModule::total_interest(XBTC), 200060);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 200060);
 			});
 	}
 
 	#[test]
 	fn test_honzon_module() {
 		ExtBuilder::default()
-			.balances(vec![(AccountId::from(ALICE), XBTC, amount(1_000))])
+			.balances(vec![(AccountId::from(ALICE), CurrencyId::XBTC, amount(1_000))])
 			.build()
 			.execute_with(|| {
-				assert_ok!(set_oracle_price(vec![(XBTC, Price::from_rational(1, 1))]));
+				assert_ok!(set_oracle_price(vec![(CurrencyId::XBTC, Price::from_rational(1, 1))]));
 
 				assert_ok!(CdpEngineModule::set_collateral_params(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT,
-					XBTC,
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT,
+					CurrencyId::XBTC,
 					Some(Some(Rate::from_rational(1, 100000))),
 					Some(Some(Ratio::from_rational(3, 2))),
 					Some(Some(Rate::from_rational(2, 10))),
@@ -349,22 +403,38 @@ mod tests {
 				));
 				assert_ok!(CdpEngineModule::adjust_position(
 					&AccountId::from(ALICE),
-					XBTC,
+					CurrencyId::XBTC,
 					amount(100) as i128,
 					amount(500) as i128
 				));
-				assert_eq!(Currencies::free_balance(XBTC, &AccountId::from(ALICE)), amount(900));
-				assert_eq!(Currencies::free_balance(AUSD, &AccountId::from(ALICE)), amount(50));
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), amount(500));
-				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), XBTC), amount(100));
 				assert_eq!(
-					CdpEngineModule::liquidate(<Runtime as system::Trait>::Origin::NONE, XBTC, AccountId::from(ALICE))
-						.is_ok(),
+					Currencies::free_balance(CurrencyId::XBTC, &AccountId::from(ALICE)),
+					amount(900)
+				);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::AUSD, &AccountId::from(ALICE)),
+					amount(50)
+				);
+				assert_eq!(
+					LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+					amount(500)
+				);
+				assert_eq!(
+					LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+					amount(100)
+				);
+				assert_eq!(
+					CdpEngineModule::liquidate(
+						<Runtime as frame_system::Trait>::Origin::NONE,
+						CurrencyId::XBTC,
+						AccountId::from(ALICE)
+					)
+					.is_ok(),
 					false
 				);
 				assert_ok!(CdpEngineModule::set_collateral_params(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT,
-					XBTC,
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT,
+					CurrencyId::XBTC,
 					None,
 					Some(Some(Ratio::from_rational(3, 1))),
 					None,
@@ -372,15 +442,21 @@ mod tests {
 					None
 				));
 				assert_ok!(CdpEngineModule::liquidate(
-					<Runtime as system::Trait>::Origin::NONE,
-					XBTC,
+					<Runtime as frame_system::Trait>::Origin::NONE,
+					CurrencyId::XBTC,
 					AccountId::from(ALICE)
 				));
 
-				assert_eq!(Currencies::free_balance(XBTC, &AccountId::from(ALICE)), amount(900));
-				assert_eq!(Currencies::free_balance(AUSD, &AccountId::from(ALICE)), amount(50));
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), 0);
-				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), XBTC), 0);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::XBTC, &AccountId::from(ALICE)),
+					amount(900)
+				);
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::AUSD, &AccountId::from(ALICE)),
+					amount(50)
+				);
+				assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
+				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC), 0);
 			});
 	}
 
@@ -388,15 +464,15 @@ mod tests {
 	fn test_cdp_engine_module() {
 		ExtBuilder::default()
 			.balances(vec![
-				(AccountId::from(ALICE), AUSD, amount(1000)),
-				(AccountId::from(ALICE), XBTC, amount(1000)),
+				(AccountId::from(ALICE), CurrencyId::AUSD, amount(1000)),
+				(AccountId::from(ALICE), CurrencyId::XBTC, amount(1000)),
 			])
 			.build()
 			.execute_with(|| {
 				SystemModule::set_block_number(1);
 				assert_ok!(CdpEngineModule::set_collateral_params(
-					<acala_runtime::Runtime as system::Trait>::Origin::ROOT,
-					XBTC,
+					<acala_runtime::Runtime as frame_system::Trait>::Origin::ROOT,
+					CurrencyId::XBTC,
 					Some(Some(Rate::from_rational(1, 100000))),
 					Some(Some(Ratio::from_rational(3, 2))),
 					Some(Some(Rate::from_rational(2, 10))),
@@ -405,72 +481,93 @@ mod tests {
 				));
 
 				assert_eq!(
-					CdpEngineModule::stability_fee(XBTC),
+					CdpEngineModule::stability_fee(CurrencyId::XBTC),
 					Some(Rate::from_rational(1, 100000))
 				);
 				assert_eq!(
-					CdpEngineModule::liquidation_ratio(XBTC),
+					CdpEngineModule::liquidation_ratio(CurrencyId::XBTC),
 					Some(Ratio::from_rational(3, 2))
 				);
 				assert_eq!(
-					CdpEngineModule::liquidation_penalty(XBTC),
+					CdpEngineModule::liquidation_penalty(CurrencyId::XBTC),
 					Some(Rate::from_rational(2, 10))
 				);
 				assert_eq!(
-					CdpEngineModule::required_collateral_ratio(XBTC),
+					CdpEngineModule::required_collateral_ratio(CurrencyId::XBTC),
 					Some(Ratio::from_rational(9, 5))
 				);
-				assert_eq!(CdpEngineModule::maximum_total_debit_value(XBTC), amount(10000));
+				assert_eq!(
+					CdpEngineModule::maximum_total_debit_value(CurrencyId::XBTC),
+					amount(10000)
+				);
 
 				assert_eq!(
-					CdpEngineModule::calculate_collateral_ratio(XBTC, 100, 50, Price::from_rational(1, 1)),
+					CdpEngineModule::calculate_collateral_ratio(CurrencyId::XBTC, 100, 50, Price::from_rational(1, 1)),
 					Ratio::from_rational(100 * 10, 50)
 				);
 
-				assert_ok!(CdpEngineModule::check_debit_cap(XBTC, amount(99999)));
-				assert_eq!(CdpEngineModule::check_debit_cap(XBTC, amount(100001)).is_ok(), false);
+				assert_ok!(CdpEngineModule::check_debit_cap(CurrencyId::XBTC, amount(99999)));
+				assert_eq!(
+					CdpEngineModule::check_debit_cap(CurrencyId::XBTC, amount(100001)).is_ok(),
+					false
+				);
 
 				assert_ok!(CdpEngineModule::adjust_position(
 					&AccountId::from(ALICE),
-					XBTC,
+					CurrencyId::XBTC,
 					amount(100) as i128,
 					0
 				));
-				assert_eq!(Currencies::free_balance(XBTC, &AccountId::from(ALICE)), amount(900));
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), 0);
-				assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), XBTC), amount(100));
+				assert_eq!(
+					Currencies::free_balance(CurrencyId::XBTC, &AccountId::from(ALICE)),
+					amount(900)
+				);
+				assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
+				assert_eq!(
+					LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+					amount(100)
+				);
 
 				assert_noop!(
-					CdpEngineModule::settle_cdp_has_debit(AccountId::from(ALICE), XBTC),
+					CdpEngineModule::settle_cdp_has_debit(AccountId::from(ALICE), CurrencyId::XBTC),
 					module_cdp_engine::Error::<Runtime>::AlreadyNoDebit,
 				);
 
 				assert_ok!(set_oracle_price(vec![
-					(AUSD, Price::from_rational(1, 1)),
-					(XBTC, Price::from_rational(3, 1))
+					(CurrencyId::AUSD, Price::from_rational(1, 1)),
+					(CurrencyId::XBTC, Price::from_rational(3, 1))
 				]));
 
 				assert_ok!(CdpEngineModule::adjust_position(
 					&AccountId::from(ALICE),
-					XBTC,
+					CurrencyId::XBTC,
 					0,
 					amount(100) as i128
 				));
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), amount(100));
+				assert_eq!(
+					LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+					amount(100)
+				);
 				assert_eq!(CdpTreasuryModule::debit_pool(), 0);
-				assert_eq!(CdpTreasuryModule::total_collaterals(XBTC), 0);
-				assert_ok!(CdpEngineModule::settle_cdp_has_debit(AccountId::from(ALICE), XBTC));
+				assert_eq!(CdpTreasuryModule::total_collaterals(CurrencyId::XBTC), 0);
+				assert_ok!(CdpEngineModule::settle_cdp_has_debit(
+					AccountId::from(ALICE),
+					CurrencyId::XBTC
+				));
 
 				let settle_cdp_in_debit_event = acala_runtime::Event::module_cdp_engine(
-					module_cdp_engine::RawEvent::SettleCDPInDebit(XBTC, AccountId::from(ALICE)),
+					module_cdp_engine::RawEvent::SettleCDPInDebit(CurrencyId::XBTC, AccountId::from(ALICE)),
 				);
 				assert!(SystemModule::events()
 					.iter()
 					.any(|record| record.event == settle_cdp_in_debit_event));
 
-				assert_eq!(LoansModule::debits(XBTC, AccountId::from(ALICE)), 0);
+				assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
 				assert_eq!(CdpTreasuryModule::debit_pool(), amount(10));
-				assert_eq!(CdpTreasuryModule::total_collaterals(XBTC), 3333333333333333330);
+				assert_eq!(
+					CdpTreasuryModule::total_collaterals(CurrencyId::XBTC),
+					3333333333333333330
+				);
 			});
 	}
 }


### PR DESCRIPTION
It's complicated that define association types to do cross-module function call, you have to define these according to the correct reference relationship. So I define the general types in primitives directly like Laminar. 