### PR TITLE
optimize map storage

### DIFF
--- a/modules/cdp_engine/src/tests.rs
+++ b/modules/cdp_engine/src/tests.rs
@@ -180,23 +180,26 @@ fn set_collateral_params_work() {
 			Some(Some(Ratio::from_rational(9, 5))),
 			Some(10000),
 		));
+
+		let new_collateral_params = CDPEngineModule::collateral_params(BTC);
+
 		assert_eq!(
-			CDPEngineModule::stability_fee(BTC),
+			new_collateral_params.stability_fee,
 			Some(Rate::from_rational(1, 100000))
 		);
 		assert_eq!(
-			CDPEngineModule::liquidation_ratio(BTC),
+			new_collateral_params.liquidation_ratio,
 			Some(Ratio::from_rational(3, 2))
 		);
 		assert_eq!(
-			CDPEngineModule::liquidation_penalty(BTC),
+			new_collateral_params.liquidation_penalty,
 			Some(Rate::from_rational(2, 10))
 		);
 		assert_eq!(
-			CDPEngineModule::required_collateral_ratio(BTC),
+			new_collateral_params.required_collateral_ratio,
 			Some(Ratio::from_rational(9, 5))
 		);
-		assert_eq!(CDPEngineModule::maximum_total_debit_value(BTC), 10000);
+		assert_eq!(new_collateral_params.maximum_total_debit_value, 10000);
 	});
 }
 

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -385,11 +385,11 @@ mod tests {
 				assert_eq!(DexModule::liquidity_pool(CurrencyId::XBTC), (10003, 10003000));
 
 				assert_eq!(DexModule::total_shares(CurrencyId::XBTC), 10002998);
-				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 0);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), (0, 0));
 				DexModule::on_initialize(0);
-				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 100030);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), (100030, 0));
 				DexModule::on_initialize(0);
-				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), 200060);
+				assert_eq!(DexModule::total_interest(CurrencyId::XBTC), (200060, 0));
 			});
 	}
 

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -489,26 +489,25 @@ mod tests {
 					Some(amount(10000)),
 				));
 
+				let new_collateral_params = CdpEngineModule::collateral_params(CurrencyId::XBTC);
+
 				assert_eq!(
-					CdpEngineModule::stability_fee(CurrencyId::XBTC),
+					new_collateral_params.stability_fee,
 					Some(Rate::from_rational(1, 100000))
 				);
 				assert_eq!(
-					CdpEngineModule::liquidation_ratio(CurrencyId::XBTC),
+					new_collateral_params.liquidation_ratio,
 					Some(Ratio::from_rational(3, 2))
 				);
 				assert_eq!(
-					CdpEngineModule::liquidation_penalty(CurrencyId::XBTC),
+					new_collateral_params.liquidation_penalty,
 					Some(Rate::from_rational(2, 10))
 				);
 				assert_eq!(
-					CdpEngineModule::required_collateral_ratio(CurrencyId::XBTC),
+					new_collateral_params.required_collateral_ratio,
 					Some(Ratio::from_rational(9, 5))
 				);
-				assert_eq!(
-					CdpEngineModule::maximum_total_debit_value(CurrencyId::XBTC),
-					amount(10000)
-				);
+				assert_eq!(new_collateral_params.maximum_total_debit_value, amount(10000));
 
 				assert_eq!(
 					CdpEngineModule::calculate_collateral_ratio(CurrencyId::XBTC, 100, 50, Price::from_rational(1, 1)),


### PR DESCRIPTION
resolve #249

@xlc , I'm not sure if should merge `Collaterals` and `Debits` , `TotalCollaterals` and `TotalDebits` of `module_loans`. Because offchain worker of `module_cdp_engine` can only find cdp has debit by iterating `Debits`. If iterate the new item which merged by `Collaterals` and `Debits`, will get many cdp without debits. 