### PR TITLE
Refactor staking pool of homa

### DIFF
--- a/modules/staking_pool/src/lib.rs
+++ b/modules/staking_pool/src/lib.rs
@@ -175,9 +175,7 @@ impl<T: Trait> Module<T> {
 		TotalBonded::try_mutate(|total_bonded| -> DispatchResult {
 			*total_bonded = total_bonded.checked_add(amount).ok_or(Error::<T>::Overflow)?;
 			Ok(())
-		})?;
-
-		Ok(())
+		})
 	}
 
 	pub fn deposit_free_pool(who: &T::AccountId, amount: Balance) -> DispatchResult {
@@ -188,9 +186,7 @@ impl<T: Trait> Module<T> {
 		FreeUnbonded::try_mutate(|free| -> DispatchResult {
 			*free = free.checked_add(amount).ok_or(Error::<T>::Overflow)?;
 			Ok(())
-		})?;
-
-		Ok(())
+		})
 	}
 
 	pub fn claim_period_percent(era: EraIndex) -> Ratio {
@@ -225,9 +221,7 @@ impl<T: Trait> Module<T> {
 					.reciprocal()
 					.unwrap_or_default()
 					.saturating_mul_int(communal_bonded_staking_amount);
-				staking_amount_to_unbond = liquid_exchange_rate
-					.checked_mul_int(liquid_amount_to_redeem)
-					.ok_or(Error::<T>::Overflow)?;
+				staking_amount_to_unbond = communal_bonded_staking_amount;
 			}
 
 			// burn liquid currency

--- a/modules/staking_pool/src/lib.rs
+++ b/modules/staking_pool/src/lib.rs
@@ -5,7 +5,7 @@ use frame_system::{self as system};
 use orml_traits::MultiCurrency;
 use primitives::{Balance, CurrencyId, EraIndex};
 use sp_runtime::{
-	traits::{AccountIdConversion, One, Saturating, UniqueSaturatedInto, Zero},
+	traits::{AccountIdConversion, One, Saturating, Zero},
 	DispatchError, DispatchResult, FixedPointNumber, ModuleId,
 };
 use sp_std::prelude::*;
@@ -47,11 +47,11 @@ decl_event!(
 		<T as system::Trait>::AccountId,
 		Balance = Balance,
 	{
-		/// [account, bond, mint]
-		BondAndMint(AccountId, Balance, Balance),
+		/// [who, issued_liquid, bonded_staking, left_in_free]
+		MintLiquid(AccountId, Balance, Balance, Balance),
 		/// [who, redeem_amount]
 		RedeemByUnbond(AccountId, Balance),
-		/// [who, fee, redeem_amount, unbond_amount]
+		/// [who, fee_in_liquid, liquid_amount_burned, staking_amount_retrived]
 		RedeemByFreeUnbonded(AccountId, Balance, Balance, Balance),
 		/// [who, target_era, fee, redeem_amount, unbond_amount]
 		RedeemByClaimUnbonding(AccountId, EraIndex, Balance, Balance, Balance),
@@ -64,6 +64,7 @@ decl_error! {
 		StakingCurrencyNotEnough,
 		LiquidCurrencyNotEnough,
 		InvalidEra,
+		Overflow,
 	}
 }
 
@@ -104,33 +105,34 @@ impl<T: Trait> Module<T> {
 		T::ModuleId::get().into_account()
 	}
 
-	// it represent how much bonded DOT is belong to LDOT holders
-	// use it in operation checks
+	/// It represent how much bonded DOT is belong to LDOT holders
+	/// use it in operation checks
 	pub fn get_communal_bonded() -> Balance {
 		Self::total_bonded().saturating_sub(Self::next_era_unbond().1)
 	}
 
-	// it represent how much bonded DOT(include bonded, unbonded, unbonding) is
-	// belong to LDOT holders use it in exchange rate calculation
+	/// It represent how much bonded DOT(include bonded, unbonded, unbonding) is
+	/// belong to LDOT holders use it in exchange rate calculation
 	pub fn get_total_communal_balance() -> Balance {
 		Self::get_communal_bonded()
 			.saturating_add(Self::free_unbonded())
 			.saturating_add(Self::unbonding_to_free())
 	}
 
-	// communal_bonded_ratio = communal_bonded / total_communal_balance
+	/// communal_bonded_ratio = communal_bonded / total_communal_balance
 	pub fn get_communal_bonded_ratio() -> Ratio {
 		Ratio::checked_from_rational(Self::get_communal_bonded(), Self::get_total_communal_balance())
 			.unwrap_or_default()
 	}
 
-	// LDOT/DOT = total communal DOT / total supply of LDOT
+	/// liquid currency / staking currency  = total communal staking currency /
+	/// total supply of liquid currency
 	pub fn liquid_exchange_rate() -> ExchangeRate {
-		let total_dot_amount = Self::get_total_communal_balance();
-		let total_ldot_amount = T::Currency::total_issuance(T::LiquidCurrencyId::get());
+		let total_communal_staking_amount = Self::get_total_communal_balance();
+		let total_liquid_amount = T::Currency::total_issuance(T::LiquidCurrencyId::get());
 
-		if !total_dot_amount.is_zero() && !total_ldot_amount.is_zero() {
-			ExchangeRate::checked_from_rational(total_dot_amount, total_ldot_amount)
+		if !total_communal_staking_amount.is_zero() && !total_liquid_amount.is_zero() {
+			ExchangeRate::checked_from_rational(total_communal_staking_amount, total_liquid_amount)
 				.unwrap_or_else(T::DefaultExchangeRate::get)
 		} else {
 			T::DefaultExchangeRate::get()
@@ -142,7 +144,7 @@ impl<T: Trait> Module<T> {
 		<ClaimedUnbond<T>>::iter_prefix(who)
 			.filter(|(era_index, _)| era_index <= &current_era)
 			.fold(Zero::zero(), |available_unbonded, (_, claimed)| {
-				available_unbonded + claimed
+				available_unbonded.saturating_add(claimed)
 			})
 	}
 
@@ -154,72 +156,38 @@ impl<T: Trait> Module<T> {
 		<ClaimedUnbond<T>>::iter_prefix(who)
 			.filter(|(era_index, _)| era_index <= &current_era)
 			.for_each(|(era_index, claimed)| {
-				withdrawn_amount += claimed;
+				withdrawn_amount = withdrawn_amount.saturating_add(claimed);
 				<ClaimedUnbond<T>>::remove(who, era_index);
 			});
 
-		let _ = T::Currency::transfer(staking_currency_id, &Self::account_id(), who, withdrawn_amount);
-		TotalClaimedUnbonded::mutate(|balance| *balance -= withdrawn_amount);
+		T::Currency::transfer(staking_currency_id, &Self::account_id(), who, withdrawn_amount)?;
+		TotalClaimedUnbonded::mutate(|balance| *balance = balance.saturating_sub(withdrawn_amount));
 		Ok(withdrawn_amount)
 	}
 
-	pub fn bond(who: &T::AccountId, amount: Balance) -> sp_std::result::Result<Balance, DispatchError> {
-		let liquid_exchange_rate = Self::liquid_exchange_rate();
-
-		// bond dot
-		T::Currency::ensure_can_withdraw(T::StakingCurrencyId::get(), who, amount)
-			.map_err(|_| Error::<T>::StakingCurrencyNotEnough)?;
+	pub fn bond(who: &T::AccountId, amount: Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
 		T::Bridge::transfer_to_bridge(who, amount)?;
 		T::Bridge::bond_extra(amount)?;
-		TotalBonded::mutate(|bonded| *bonded += amount);
+		TotalBonded::try_mutate(|total_bonded| -> DispatchResult {
+			*total_bonded = total_bonded.checked_add(amount).ok_or(Error::<T>::Overflow)?;
+			Ok(())
+		})?;
 
-		// issue ldot to who
-		let ldot_amount = liquid_exchange_rate
-			.reciprocal()
-			.unwrap_or_default()
-			.saturating_mul_int(amount);
-		T::Currency::deposit(T::LiquidCurrencyId::get(), who, ldot_amount)?;
-
-		<Module<T>>::deposit_event(RawEvent::BondAndMint(who.clone(), amount, ldot_amount));
-		Ok(ldot_amount)
+		Ok(())
 	}
 
-	pub fn redeem_by_unbond(who: &T::AccountId, amount: Balance) -> DispatchResult {
-		let mut ldot_to_redeem = amount;
-		let liquid_exchange_rate = Self::liquid_exchange_rate();
-		let mut unbond_amount = liquid_exchange_rate.saturating_mul_int(ldot_to_redeem);
-		let communal_bonded = Self::get_communal_bonded();
-
-		if !unbond_amount.is_zero() && !communal_bonded.is_zero() {
-			if unbond_amount > communal_bonded {
-				// communal_bonded is not enough, calculate actual redeem ldot
-				let new_redeem_amount: u128 = liquid_exchange_rate
-					.reciprocal()
-					.unwrap_or_default()
-					.saturating_mul_int(communal_bonded)
-					.unique_saturated_into();
-				ldot_to_redeem = new_redeem_amount.unique_saturated_into();
-				unbond_amount = communal_bonded;
-			}
-
-			// burn who's ldot
-			let liquid_currency_id = T::LiquidCurrencyId::get();
-			T::Currency::withdraw(liquid_currency_id, who, ldot_to_redeem)
-				.map_err(|_| Error::<T>::LiquidCurrencyNotEnough)?;
-
-			// start unbond at next era, and the unbond become unbonded after bonding
-			// duration
-			let unbonded_era_index = Self::current_era()
-				+ EraIndex::one()
-				+ <<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get();
-			NextEraUnbond::mutate(|(unbond, claimed)| {
-				*unbond += unbond_amount;
-				*claimed += unbond_amount;
-			});
-			TotalBonded::mutate(|bonded| *bonded -= unbond_amount);
-			<ClaimedUnbond<T>>::mutate(who, unbonded_era_index, |balance| *balance += unbond_amount);
-			<Module<T>>::deposit_event(RawEvent::RedeemByUnbond(who.clone(), ldot_to_redeem));
+	pub fn deposit_free_pool(who: &T::AccountId, amount: Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
 		}
+		T::Currency::transfer(T::StakingCurrencyId::get(), who, &Self::account_id(), amount)?;
+		FreeUnbonded::try_mutate(|free| -> DispatchResult {
+			*free = free.checked_add(amount).ok_or(Error::<T>::Overflow)?;
+			Ok(())
+		})?;
 
 		Ok(())
 	}
@@ -227,7 +195,7 @@ impl<T: Trait> Module<T> {
 	pub fn claim_period_percent(era: EraIndex) -> Ratio {
 		Ratio::checked_from_rational(
 			era.saturating_sub(Self::current_era()),
-			<<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get() + EraIndex::one(),
+			<<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get().saturating_add(EraIndex::one()),
 		)
 		.unwrap_or_default()
 	}
@@ -239,56 +207,117 @@ impl<T: Trait> Module<T> {
 			.saturating_mul_int(amount)
 	}
 
+	/// This function must to be called in `with_transaction_result` scope to
+	/// ensure atomic
+	pub fn redeem_by_unbond(who: &T::AccountId, amount: Balance) -> DispatchResult {
+		let mut liquid_amount_to_redeem = amount;
+		let mut staking_amount_to_unbond = Self::liquid_exchange_rate()
+			.checked_mul_int(liquid_amount_to_redeem)
+			.ok_or(Error::<T>::Overflow)?;
+		let communal_bonded_staking_amount = Self::get_communal_bonded();
+
+		if !staking_amount_to_unbond.is_zero() && !communal_bonded_staking_amount.is_zero() {
+			// communal_bonded_staking_amount is not enough, re-calculate
+			if staking_amount_to_unbond > communal_bonded_staking_amount {
+				let ratio = Ratio::checked_from_rational(communal_bonded_staking_amount, staking_amount_to_unbond)
+					.expect("staking_amount is not zero; qed");
+
+				liquid_amount_to_redeem = ratio.saturating_mul_int(liquid_amount_to_redeem);
+				staking_amount_to_unbond = communal_bonded_staking_amount;
+			}
+
+			// burn liquid currency
+			T::Currency::withdraw(T::LiquidCurrencyId::get(), who, liquid_amount_to_redeem)
+				.map_err(|_| Error::<T>::LiquidCurrencyNotEnough)?;
+
+			// start unbond at next era, and the unbond become unbonded after bonding
+			// duration
+			let unbonded_era_index = Self::current_era()
+				.checked_add(EraIndex::one())
+				.and_then(|n| n.checked_add(<<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get()))
+				.ok_or(Error::<T>::Overflow)?;
+			NextEraUnbond::try_mutate(|(unbond, claimed)| -> DispatchResult {
+				*unbond = unbond
+					.checked_add(staking_amount_to_unbond)
+					.ok_or(Error::<T>::Overflow)?;
+				*claimed = claimed
+					.checked_add(staking_amount_to_unbond)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
+			TotalBonded::try_mutate(|bonded| -> DispatchResult {
+				*bonded = bonded
+					.checked_sub(staking_amount_to_unbond)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
+			<ClaimedUnbond<T>>::try_mutate(who, unbonded_era_index, |balance| -> DispatchResult {
+				*balance = balance
+					.checked_add(staking_amount_to_unbond)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
+
+			<Module<T>>::deposit_event(RawEvent::RedeemByUnbond(who.clone(), liquid_amount_to_redeem));
+		}
+
+		Ok(())
+	}
+
+	/// This function must to be called in `with_transaction_result` scope to
+	/// ensure atomic
 	pub fn redeem_by_free_unbonded(who: &T::AccountId, amount: Balance) -> DispatchResult {
-		let current_era = Self::current_era();
-		let mut total_deduct = amount;
-		let mut fee = Self::calculate_claim_fee(total_deduct, current_era);
-		let mut ldot_to_redeem = total_deduct.saturating_sub(fee);
-		let liquid_exchange_rate = Self::liquid_exchange_rate();
-		let mut unbond_amount = liquid_exchange_rate.saturating_mul_int(ldot_to_redeem);
-		let free_unbonded = Self::free_unbonded();
+		let mut liquid_amount_to_redeem = amount;
+		let mut fee_in_liquid_currency = sp_std::cmp::min(
+			liquid_amount_to_redeem,
+			Self::calculate_claim_fee(liquid_amount_to_redeem, Self::current_era()),
+		);
+		let mut liquid_amount_to_burn = liquid_amount_to_redeem.saturating_sub(fee_in_liquid_currency);
+		let mut staking_amount = Self::liquid_exchange_rate()
+			.checked_mul_int(liquid_amount_to_burn)
+			.ok_or(Error::<T>::Overflow)?;
+		let free_unbonded_pool = Self::free_unbonded();
 
-		if !unbond_amount.is_zero() && !free_unbonded.is_zero() {
-			if unbond_amount > free_unbonded {
-				// free_unbonded is not enough, re-calculate actual redeem ldot
-				let new_ldot_to_redeem = liquid_exchange_rate
-					.reciprocal()
-					.unwrap_or_default()
-					.saturating_mul_int(free_unbonded);
-
-				// re-assign
-				fee = Ratio::checked_from_rational(new_ldot_to_redeem, ldot_to_redeem)
-					.unwrap_or_default()
-					.saturating_mul_int(fee);
-				ldot_to_redeem = new_ldot_to_redeem;
-				unbond_amount = free_unbonded;
-				total_deduct = fee + ldot_to_redeem;
+		if !staking_amount.is_zero() && !free_unbonded_pool.is_zero() {
+			// if free_unbonded_pool is not enough, need re-calculate
+			if staking_amount > free_unbonded_pool {
+				let ratio = Ratio::checked_from_rational(free_unbonded_pool, staking_amount)
+					.expect("staking_amount is not zero; qed");
+				liquid_amount_to_redeem = ratio.saturating_mul_int(liquid_amount_to_redeem);
+				fee_in_liquid_currency = sp_std::cmp::min(
+					liquid_amount_to_redeem,
+					ratio.saturating_mul_int(fee_in_liquid_currency),
+				);
+				liquid_amount_to_burn = liquid_amount_to_redeem.saturating_sub(fee_in_liquid_currency);
+				staking_amount = free_unbonded_pool;
 			}
 
 			let liquid_currency_id = T::LiquidCurrencyId::get();
-			let staking_currency_id = T::StakingCurrencyId::get();
-			T::Currency::ensure_can_withdraw(liquid_currency_id, who, total_deduct)
-				.map_err(|_| Error::<T>::LiquidCurrencyNotEnough)?;
-			T::Currency::transfer(staking_currency_id, &Self::account_id(), who, unbond_amount)?;
-			FreeUnbonded::mutate(|balance| *balance -= unbond_amount);
-			T::Currency::withdraw(liquid_currency_id, who, total_deduct).expect("never failed after balance check");
+			T::Currency::withdraw(liquid_currency_id, who, liquid_amount_to_redeem)?;
+			T::Currency::transfer(T::StakingCurrencyId::get(), &Self::account_id(), who, staking_amount)?;
+			FreeUnbonded::try_mutate(|free_unbonded| -> DispatchResult {
+				*free_unbonded = free_unbonded.checked_sub(staking_amount).ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
 
-			let commission_fee = Ratio::one()
+			let commission_to_homa = Ratio::one()
 				.saturating_sub(T::ClaimFeeReturnRatio::get())
-				.saturating_mul_int(fee);
-			T::OnCommission::on_commission(liquid_currency_id, commission_fee);
+				.saturating_mul_int(fee_in_liquid_currency);
+			T::OnCommission::on_commission(liquid_currency_id, commission_to_homa);
 
 			<Module<T>>::deposit_event(RawEvent::RedeemByFreeUnbonded(
 				who.clone(),
-				fee,
-				ldot_to_redeem,
-				unbond_amount,
+				fee_in_liquid_currency,
+				liquid_amount_to_burn,
+				staking_amount,
 			));
 		}
 
 		Ok(())
 	}
 
+	/// This function must to be called in `with_transaction_result` scope to
+	/// ensure atomic
 	pub fn redeem_by_claim_unbonding(who: &T::AccountId, amount: Balance, target_era: EraIndex) -> DispatchResult {
 		let current_era = Self::current_era();
 		let bonding_duration = <<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get();
@@ -297,50 +326,63 @@ impl<T: Trait> Module<T> {
 			Error::<T>::InvalidEra,
 		);
 
-		let mut total_deduct = amount;
-		let mut fee = Self::calculate_claim_fee(total_deduct, target_era);
-		let mut ldot_to_redeem = total_deduct.saturating_sub(fee);
-		let liquid_exchange_rate = Self::liquid_exchange_rate();
-		let mut unbond_amount = liquid_exchange_rate.saturating_mul_int(ldot_to_redeem);
-		let target_era_unbonding = Self::unbonding(target_era);
-		let target_era_unclaimed = target_era_unbonding.0.saturating_sub(target_era_unbonding.1);
+		let mut liquid_amount_to_redeem = amount;
+		let mut fee_in_liquid_currency = sp_std::cmp::min(
+			liquid_amount_to_redeem,
+			Self::calculate_claim_fee(liquid_amount_to_redeem, target_era),
+		);
+		let mut liquid_amount_to_burn = liquid_amount_to_redeem.saturating_sub(fee_in_liquid_currency);
+		let mut staking_amount_to_claim = Self::liquid_exchange_rate().saturating_mul_int(liquid_amount_to_burn);
+		let (unbonding_of_target_era, claimed_unbonding_of_target_era) = Self::unbonding(target_era);
+		let available_unclaimed_unbonding = unbonding_of_target_era.saturating_sub(claimed_unbonding_of_target_era);
 
-		if !unbond_amount.is_zero() && !target_era_unclaimed.is_zero() {
-			if unbond_amount > target_era_unclaimed {
-				// target_era_unclaimed is not enough, re-calculate actual redeem ldot
-				let new_ldot_to_redeem = liquid_exchange_rate
-					.reciprocal()
-					.unwrap_or_default()
-					.saturating_mul_int(target_era_unclaimed);
-
-				// re-assign
-				fee = Ratio::checked_from_rational(new_ldot_to_redeem, ldot_to_redeem)
-					.unwrap_or_default()
-					.saturating_mul_int(fee);
-				ldot_to_redeem = new_ldot_to_redeem;
-				unbond_amount = target_era_unclaimed;
-				total_deduct = fee + ldot_to_redeem;
+		if !staking_amount_to_claim.is_zero() && !available_unclaimed_unbonding.is_zero() {
+			// if available_unclaimed_unbonding is not enough, need re-calculate
+			if staking_amount_to_claim > available_unclaimed_unbonding {
+				let ratio = Ratio::checked_from_rational(available_unclaimed_unbonding, staking_amount_to_claim)
+					.expect("staking_amount_to_claim is not zero; qed");
+				liquid_amount_to_redeem = ratio.saturating_mul_int(liquid_amount_to_redeem);
+				fee_in_liquid_currency = sp_std::cmp::min(
+					liquid_amount_to_redeem,
+					ratio.saturating_mul_int(fee_in_liquid_currency),
+				);
+				liquid_amount_to_burn = liquid_amount_to_redeem.saturating_sub(fee_in_liquid_currency);
+				staking_amount_to_claim = available_unclaimed_unbonding;
 			}
 
 			let liquid_currency_id = T::LiquidCurrencyId::get();
-			T::Currency::withdraw(liquid_currency_id, who, total_deduct)
+			T::Currency::withdraw(liquid_currency_id, who, liquid_amount_to_redeem)
 				.map_err(|_| Error::<T>::LiquidCurrencyNotEnough)?;
+			<ClaimedUnbond<T>>::try_mutate(who, target_era, |claimed_unbond| -> DispatchResult {
+				*claimed_unbond = claimed_unbond
+					.checked_add(staking_amount_to_claim)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
+			Unbonding::try_mutate(target_era, |(_, claimed_unbonding)| -> DispatchResult {
+				*claimed_unbonding = claimed_unbonding
+					.checked_add(staking_amount_to_claim)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
+			UnbondingToFree::try_mutate(|unbonding_to_free| -> DispatchResult {
+				*unbonding_to_free = unbonding_to_free
+					.checked_sub(staking_amount_to_claim)
+					.ok_or(Error::<T>::Overflow)?;
+				Ok(())
+			})?;
 
-			<ClaimedUnbond<T>>::mutate(who, target_era, |balance| *balance += unbond_amount);
-			Unbonding::mutate(target_era, |(_, claimed)| *claimed += unbond_amount);
-			UnbondingToFree::mutate(|balance| *balance = balance.saturating_sub(unbond_amount));
-
-			let commission_fee = Ratio::one()
+			let commission_to_homa = Ratio::one()
 				.saturating_sub(T::ClaimFeeReturnRatio::get())
-				.saturating_mul_int(fee);
-			T::OnCommission::on_commission(liquid_currency_id, commission_fee);
+				.saturating_mul_int(fee_in_liquid_currency);
+			T::OnCommission::on_commission(liquid_currency_id, commission_to_homa);
 
 			<Module<T>>::deposit_event(RawEvent::RedeemByClaimUnbonding(
 				who.clone(),
 				target_era,
-				fee,
-				ldot_to_redeem,
-				unbond_amount,
+				fee_in_liquid_currency,
+				liquid_amount_to_burn,
+				staking_amount_to_claim,
 			));
 		}
 
@@ -350,13 +392,15 @@ impl<T: Trait> Module<T> {
 	pub fn unbond_and_update(era: EraIndex) {
 		let (total_to_unbond, claimed_to_unbond) = Self::next_era_unbond();
 		let bonding_duration = <<T as Trait>::Bridge as PolkadotBridgeType<_, _>>::BondingDuration::get();
-		let unbonded_era_index = era + bonding_duration;
+		let unbonded_era_index = era.saturating_add(bonding_duration);
 
 		if !total_to_unbond.is_zero() && T::Bridge::unbond(total_to_unbond).is_ok() {
 			NextEraUnbond::kill();
-			TotalBonded::mutate(|bonded| *bonded -= total_to_unbond);
+			TotalBonded::mutate(|bonded| *bonded = bonded.saturating_sub(total_to_unbond));
 			Unbonding::insert(unbonded_era_index, (total_to_unbond, claimed_to_unbond));
-			UnbondingToFree::mutate(|unbonding| *unbonding += total_to_unbond - claimed_to_unbond);
+			UnbondingToFree::mutate(|unbonding| {
+				*unbonding = unbonding.saturating_add(total_to_unbond.saturating_sub(claimed_to_unbond))
+			});
 		}
 	}
 
@@ -380,12 +424,14 @@ impl<T: Trait> Module<T> {
 			let claimed_unbonded_added = bridge_available.min(claimed_unbonded);
 			let free_unbonded_added = bridge_available.saturating_sub(claimed_unbonded_added);
 			if !claimed_unbonded_added.is_zero() {
-				TotalClaimedUnbonded::mutate(|balance| *balance += claimed_unbonded_added);
+				TotalClaimedUnbonded::mutate(|balance| *balance = balance.saturating_add(claimed_unbonded_added));
 			}
 			if !free_unbonded_added.is_zero() {
-				FreeUnbonded::mutate(|balance| *balance += free_unbonded_added);
+				FreeUnbonded::mutate(|balance| *balance = balance.saturating_add(free_unbonded_added));
 			}
-			UnbondingToFree::mutate(|balance| *balance = balance.saturating_sub(total_unbonded - claimed_unbonded));
+			UnbondingToFree::mutate(|balance| {
+				*balance = balance.saturating_sub(total_unbonded.saturating_sub(claimed_unbonded))
+			});
 			Unbonding::remove(era);
 		}
 
@@ -403,7 +449,7 @@ impl<T: Trait> Module<T> {
 				.min(Self::get_communal_bonded());
 
 			if !unbond_to_free.is_zero() {
-				NextEraUnbond::mutate(|(unbond, _)| *unbond += unbond_to_free);
+				NextEraUnbond::mutate(|(unbond, _)| *unbond = unbond.saturating_add(unbond_to_free));
 			}
 		} else if communal_bonded_ratio < min_bond_ratio {
 			// bond more
@@ -412,11 +458,8 @@ impl<T: Trait> Module<T> {
 				.saturating_mul_int(total_communal_balance)
 				.min(Self::free_unbonded());
 
-			if T::Bridge::transfer_to_bridge(&Self::account_id(), bond_amount).is_ok() {
-				FreeUnbonded::mutate(|balance| *balance -= bond_amount);
-				if T::Bridge::bond_extra(bond_amount).is_ok() {
-					TotalBonded::mutate(|bonded| *bonded += bond_amount);
-				}
+			if Self::bond(&Self::account_id(), bond_amount).is_ok() {
+				FreeUnbonded::mutate(|balance| *balance = balance.saturating_sub(bond_amount));
 			}
 		}
 
@@ -440,8 +483,47 @@ impl<T: Trait> OnNewEra<EraIndex> for Module<T> {
 impl<T: Trait> HomaProtocol<T::AccountId, Balance, EraIndex> for Module<T> {
 	type Balance = Balance;
 
+	/// This function must to be called in `with_transaction_result` scope to
+	/// ensure atomic
 	fn mint(who: &T::AccountId, amount: Self::Balance) -> sp_std::result::Result<Self::Balance, DispatchError> {
-		Self::bond(who, amount)
+		let staking_currency_id = T::StakingCurrencyId::get();
+		T::Currency::ensure_can_withdraw(staking_currency_id, who, amount)
+			.map_err(|_| Error::<T>::StakingCurrencyNotEnough)?;
+
+		let min_bond_ratio = T::MinBondRatio::get();
+		let total_communal_balance = Self::get_total_communal_balance();
+		let communal_bonded = Self::get_communal_bonded();
+
+		// issue liquid currency to who
+		let liquid_amount_to_issue = Self::liquid_exchange_rate()
+			.reciprocal()
+			.unwrap_or_default()
+			.checked_mul_int(amount)
+			.ok_or(Error::<T>::Overflow)?;
+		T::Currency::deposit(T::LiquidCurrencyId::get(), who, liquid_amount_to_issue)?;
+
+		let gap_amount = total_communal_balance
+			.checked_add(amount)
+			.and_then(|n| min_bond_ratio.checked_mul_int(n))
+			.map(|n| n.saturating_sub(communal_bonded))
+			.ok_or(Error::<T>::Overflow)?;
+
+		let amount_to_bond = sp_std::cmp::min(gap_amount, amount);
+		let remainer_to_free = amount.saturating_sub(amount_to_bond);
+
+		// bond
+		Self::bond(who, amount_to_bond)?;
+
+		// accumulate into free pool
+		Self::deposit_free_pool(who, remainer_to_free)?;
+
+		<Module<T>>::deposit_event(RawEvent::MintLiquid(
+			who.clone(),
+			liquid_amount_to_issue,
+			amount_to_bond,
+			remainer_to_free,
+		));
+		Ok(liquid_amount_to_issue)
 	}
 
 	fn redeem_by_unbond(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {

--- a/modules/staking_pool/src/mock.rs
+++ b/modules/staking_pool/src/mock.rs
@@ -186,7 +186,7 @@ impl PolkadotBridge<AccountId, BlockNumber, Balance, EraIndex> for MockBridge {}
 parameter_types! {
 	pub const GetStakingCurrencyId: CurrencyId = DOT;
 	pub const GetLiquidCurrencyId: CurrencyId = LDOT;
-	pub MaxBondRatio: Ratio = Ratio::saturating_from_rational(60, 100);	// 60%
+	pub MaxBondRatio: Ratio = Ratio::saturating_from_rational(80, 100);	// 80%
 	pub MinBondRatio: Ratio = Ratio::saturating_from_rational(50, 100);	// 50%
 	pub MaxClaimFee: Rate = Rate::saturating_from_rational(10, 100);	// 10%
 	pub DefaultExchangeRate: ExchangeRate = ExchangeRate::saturating_from_rational(10, 100);	// 1 : 10

--- a/modules/staking_pool/src/tests.rs
+++ b/modules/staking_pool/src/tests.rs
@@ -5,11 +5,12 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{
-	BondingDuration, CurrenciesModule, ExtBuilder, Runtime, StakingPoolModule, System, TestEvent, ALICE, BOB, DOT, LDOT,
+	BondingDuration, CurrenciesModule, ExtBuilder, Runtime, StakingPoolModule, System, TestEvent, ALICE, BOB, DOT,
+	LDOT, TOTAL_COMMISSION,
 };
 
 #[test]
-fn claim_period_percent_work() {
+fn mint_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_noop!(
@@ -66,162 +67,215 @@ fn redeem_by_unbond_work() {
 			StakingPoolModule::redeem_by_unbond(&ALICE, 5000),
 			Error::<Runtime>::LiquidCurrencyNotEnough,
 		);
-		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 1000);
 		assert_eq!(StakingPoolModule::total_bonded(), 500);
 		assert_eq!(StakingPoolModule::free_unbonded(), 500);
-		assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
 		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
+		assert_eq!(StakingPoolModule::get_communal_bonded(), 500);
+		assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
 		assert_eq!(
 			StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 + BondingDuration::get()),
 			0
 		);
 
 		assert_ok!(StakingPoolModule::redeem_by_unbond(&ALICE, 1000));
-		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
+		let redeem_by_unbond_event_1 = TestEvent::staking_pool(RawEvent::RedeemByUnbond(ALICE, 1000, 100));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_unbond_event_1));
+
 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
-		assert_eq!(StakingPoolModule::total_bonded(), 400);
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
 		assert_eq!(StakingPoolModule::free_unbonded(), 500);
-		assert_eq!(StakingPoolModule::get_total_communal_balance(), 900);
 		assert_eq!(StakingPoolModule::next_era_unbond(), (100, 100));
+		assert_eq!(StakingPoolModule::get_communal_bonded(), 400);
+		assert_eq!(StakingPoolModule::get_total_communal_balance(), 900);
 		assert_eq!(
 			StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 + BondingDuration::get()),
 			100
 		);
 
-		// assert_eq!(StakingPoolModule::total_bonded(), 1500);
-		// assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
-		// assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 5000);
-		// assert_eq!(StakingPoolModule::next_era_unbond(), (500, 500));
-		// assert_eq!(
-		// 	StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 +
-		// BondingDuration::get()), 	500
-		// );
+		// over the communal_bonded
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 9000);
+		assert_eq!(
+			StakingPoolModule::claimed_unbond(&BOB, 0 + 1 + BondingDuration::get()),
+			0
+		);
 
-		// let redeem_by_unbond_event =
-		// TestEvent::staking_pool(RawEvent::RedeemByUnbond(ALICE, 5000));
-		// assert!(System::events()
-		// 	.iter()
-		// 	.any(|record| record.event == redeem_by_unbond_event));
+		assert_ok!(StakingPoolModule::redeem_by_unbond(&BOB, 9000));
+		let redeem_by_unbond_event_2 = TestEvent::staking_pool(RawEvent::RedeemByUnbond(BOB, 4000, 400));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_unbond_event_2));
+
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 5000);
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 500);
+		assert_eq!(StakingPoolModule::next_era_unbond(), (500, 500));
+		assert_eq!(StakingPoolModule::get_communal_bonded(), 0);
+		assert_eq!(StakingPoolModule::get_total_communal_balance(), 500);
+		assert_eq!(
+			StakingPoolModule::claimed_unbond(&BOB, 0 + 1 + BondingDuration::get()),
+			400
+		);
 	});
 }
 
-// #[test]
-// fn redeem_by_free_unbonded_work() {
-// 	ExtBuilder::default().build().execute_with(|| {
-// 		System::set_block_number(1);
-// 		assert_eq!(StakingPoolModule::mint(&ALICE, 1000), Ok(10000));
-// 		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
-// 		TotalBonded::mutate(|bonded| *bonded -= 1500);
-// 		FreeUnbonded::put(1500);
-// 		assert_ok!(CurrenciesModule::deposit(DOT, &StakingPoolModule::account_id(),
-// 1500)); 		assert_eq!(StakingPoolModule::total_bonded(), 500);
-// 		assert_eq!(StakingPoolModule::free_unbonded(), 1500);
-// 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 0);
-// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
-// 		assert_eq!(
-// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-// 			1500
-// 		);
+#[test]
+fn redeem_by_free_unbonded_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
+		assert_ok!(CurrenciesModule::transfer(Some(BOB).into(), ALICE, LDOT, 1000));
+		assert_noop!(
+			StakingPoolModule::redeem_by_free_unbonded(&ALICE, 5000),
+			Error::<Runtime>::LiquidCurrencyNotEnough,
+		);
 
-// 		assert_noop!(
-// 			StakingPoolModule::redeem_by_free_unbonded(&ALICE, 15000),
-// 			Error::<Runtime>::LiquidCurrencyNotEnough,
-// 		);
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 500);
+		assert_eq!(
+			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+			500
+		);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 1000);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 0);
 
-// 		assert_ok!(StakingPoolModule::redeem_by_free_unbonded(&ALICE, 10000));
-// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
-// 		assert_eq!(StakingPoolModule::free_unbonded(), 600);
-// 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 900);
-// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
-// 		assert_eq!(
-// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-// 			600
-// 		);
+		assert_ok!(StakingPoolModule::redeem_by_free_unbonded(&ALICE, 1000));
+		let redeem_by_free_unbonded_event_1 =
+			TestEvent::staking_pool(RawEvent::RedeemByFreeUnbonded(ALICE, 100, 900, 90));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_free_unbonded_event_1));
 
-// 		let redeem_by_free_unbonded_event =
-// 			TestEvent::staking_pool(RawEvent::RedeemByFreeUnbonded(ALICE, 1000, 9000,
-// 900)); 		assert!(System::events()
-// 			.iter()
-// 			.any(|record| record.event == redeem_by_free_unbonded_event));
-// 	});
-// }
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 410);
+		assert_eq!(
+			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+			410
+		);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1090);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 20);
 
-// #[test]
-// fn redeem_by_claim_unbonding_work() {
-// 	ExtBuilder::default().build().execute_with(|| {
-// 		System::set_block_number(1);
-// 		assert_eq!(StakingPoolModule::mint(&ALICE, 1000), Ok(10000));
-// 		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
-// 		TotalBonded::mutate(|bonded| *bonded -= 1500);
-// 		Unbonding::insert(2, (1500, 0));
-// 		UnbondingToFree::put(1500);
-// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
-// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
-// 		assert_eq!(StakingPoolModule::unbonding(2), (1500, 0));
-// 		assert_eq!(StakingPoolModule::unbonding_to_free(), 1500);
-// 		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 0);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &BOB), 0);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 9000);
 
-// 		assert_eq!(StakingPoolModule::current_era(), 0);
-// 		assert_noop!(
-// 			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 0,
-// BondingDuration::get() + 1), 			Error::<Runtime>::InvalidEra,
-// 		);
-// 		assert_noop!(
-// 			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 15000, 2),
-// 			Error::<Runtime>::LiquidCurrencyNotEnough,
-// 		);
-// 		assert_eq!(
-// 			StakingPoolModule::claim_period_percent(2),
-// 			Ratio::saturating_from_rational(2, 4 + 1)
-// 		);
-// 		assert_eq!(StakingPoolModule::calculate_claim_fee(10000, 2), 600);
-// 		assert_ok!(StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 10000, 2));
-// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
-// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
-// 		assert_eq!(StakingPoolModule::unbonding(2), (1500, 940));
-// 		assert_eq!(StakingPoolModule::unbonding_to_free(), 560);
-// 		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 940);
+		assert_ok!(StakingPoolModule::redeem_by_free_unbonded(&BOB, 9000));
+		let redeem_by_free_unbonded_event_2 =
+			TestEvent::staking_pool(RawEvent::RedeemByFreeUnbonded(BOB, 451, 4060, 410));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_free_unbonded_event_2));
 
-// 		let redeem_by_claim_unbonding_event =
-// 			TestEvent::staking_pool(RawEvent::RedeemByClaimUnbonding(ALICE, 2, 600, 9400,
-// 940)); 		assert!(System::events()
-// 			.iter()
-// 			.any(|record| record.event == redeem_by_claim_unbonding_event));
-// 	});
-// }
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 0);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()), 0);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &BOB), 410);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 4489);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 110);
+	});
+}
 
-// #[test]
-// fn rebalance_work() {
-// 	ExtBuilder::default().build().execute_with(|| {
-// 		TotalBonded::put(20000);
-// 		Unbonding::insert(1, (20000, 10000));
-// 		UnbondingToFree::put(10000);
-// 		NextEraUnbond::put((5000, 5000));
+#[test]
+fn redeem_by_claim_unbonding_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(CurrenciesModule::transfer(Some(ALICE).into(), BOB, DOT, 1000));
+		assert_eq!(StakingPoolModule::mint(&BOB, 2000), Ok(20000));
+		assert_ok!(CurrenciesModule::transfer(Some(BOB).into(), ALICE, LDOT, 1000));
 
-// 		assert_eq!(StakingPoolModule::current_era(), 0);
-// 		assert_eq!(StakingPoolModule::total_bonded(), 20000);
-// 		assert_eq!(StakingPoolModule::free_unbonded(), 0);
-// 		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 0);
-// 		assert_eq!(CurrenciesModule::free_balance(DOT,
-// &StakingPoolModule::account_id()), 0); 		assert_eq!(StakingPoolModule::
-// unbonding(1), (20000, 10000)); 		assert_eq!(StakingPoolModule::unbonding(1 +
-// BondingDuration::get()), (0, 0)); 		assert_eq!(StakingPoolModule::
-// next_era_unbond(), (5000, 5000));
+		TotalBonded::mutate(|bonded| *bonded -= 500);
+		Unbonding::insert(2, (500, 0));
+		UnbondingToFree::put(500);
 
-// 		CurrentEra::put(1);
-// 		StakingPoolModule::rebalance(1);
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 1000);
+		assert_eq!(StakingPoolModule::unbonding(2), (500, 0));
+		assert_eq!(StakingPoolModule::unbonding_to_free(), 500);
+		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 0);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 0);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 1000);
+		assert_eq!(StakingPoolModule::current_era(), 0);
 
-// 		assert_eq!(StakingPoolModule::current_era(), 1);
-// 		assert_eq!(StakingPoolModule::total_bonded(), 15000);
-// 		assert_eq!(StakingPoolModule::free_unbonded(), 10000);
-// 		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 10000);
-// 		assert_eq!(
-// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-// 			20000
-// 		);
-// 		assert_eq!(StakingPoolModule::unbonding(1), (0, 0));
-// 		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (5000,
-// 5000)); 		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
-// 	});
-// }
+		assert_noop!(
+			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 0, BondingDuration::get() + 1),
+			Error::<Runtime>::InvalidEra,
+		);
+		assert_noop!(
+			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 1001, 2),
+			Error::<Runtime>::LiquidCurrencyNotEnough,
+		);
+
+		assert_eq!(
+			StakingPoolModule::claim_period_percent(2),
+			Ratio::saturating_from_rational(2, 4 + 1)
+		);
+		assert_eq!(StakingPoolModule::calculate_claim_fee(1000, 2), 60);
+
+		assert_ok!(StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 1000, 2));
+		let redeem_by_claimed_unbonding_event_1 =
+			TestEvent::staking_pool(RawEvent::RedeemByClaimUnbonding(ALICE, 2, 60, 940, 94));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_claimed_unbonding_event_1));
+
+		assert_eq!(StakingPoolModule::unbonding(2), (500, 94));
+		assert_eq!(StakingPoolModule::unbonding_to_free(), 406);
+		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 94);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 12);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
+
+		// over the communal_bonded
+		assert_eq!(StakingPoolModule::claimed_unbond(&BOB, 2), 0);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 19000);
+
+		assert_ok!(StakingPoolModule::redeem_by_claim_unbonding(&BOB, 19000, 2));
+		let redeem_by_claimed_unbonding_event_2 =
+			TestEvent::staking_pool(RawEvent::RedeemByClaimUnbonding(BOB, 2, 258, 4049, 406));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == redeem_by_claimed_unbonding_event_2));
+
+		assert_eq!(StakingPoolModule::unbonding(2), (500, 500));
+		assert_eq!(StakingPoolModule::unbonding_to_free(), 0);
+		assert_eq!(StakingPoolModule::claimed_unbond(&BOB, 2), 406);
+		assert_eq!(TOTAL_COMMISSION.with(|v| *v.borrow_mut()), 63);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &BOB), 14693);
+	});
+}
+
+#[test]
+fn rebalance_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		TotalBonded::put(20000);
+		Unbonding::insert(1, (20000, 10000));
+		UnbondingToFree::put(10000);
+		NextEraUnbond::put((5000, 5000));
+
+		assert_eq!(StakingPoolModule::current_era(), 0);
+		assert_eq!(StakingPoolModule::total_bonded(), 20000);
+		assert_eq!(StakingPoolModule::free_unbonded(), 0);
+		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 0);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()), 0);
+		assert_eq!(StakingPoolModule::unbonding(1), (20000, 10000));
+		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (0, 0));
+		assert_eq!(StakingPoolModule::next_era_unbond(), (5000, 5000));
+
+		CurrentEra::put(1);
+		StakingPoolModule::rebalance(1);
+
+		assert_eq!(StakingPoolModule::current_era(), 1);
+		assert_eq!(StakingPoolModule::total_bonded(), 15000);
+		assert_eq!(StakingPoolModule::free_unbonded(), 10000);
+		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 10000);
+		assert_eq!(
+			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+			20000
+		);
+		assert_eq!(StakingPoolModule::unbonding(1), (0, 0));
+		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (5000, 5000));
+		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
+	});
+}

--- a/modules/staking_pool/src/tests.rs
+++ b/modules/staking_pool/src/tests.rs
@@ -12,21 +12,22 @@ use mock::{
 fn claim_period_percent_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
 		assert_noop!(
-			StakingPoolModule::bond(&ALICE, 1001),
+			StakingPoolModule::mint(&ALICE, 1001),
 			Error::<Runtime>::StakingCurrencyNotEnough,
 		);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
 		assert_eq!(StakingPoolModule::total_bonded(), 0);
-		assert_eq!(StakingPoolModule::bond(&ALICE, 500), Ok(5000));
+		assert_eq!(StakingPoolModule::free_unbonded(), 0);
+		assert_eq!(StakingPoolModule::mint(&ALICE, 500), Ok(5000));
 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 500);
-		assert_eq!(StakingPoolModule::total_bonded(), 500);
 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 5000);
+		assert_eq!(StakingPoolModule::total_bonded(), 250);
+		assert_eq!(StakingPoolModule::free_unbonded(), 250);
 
-		let bond_and_mint_event = TestEvent::staking_pool(RawEvent::BondAndMint(ALICE, 500, 5000));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == bond_and_mint_event));
+		let mint_liquid_event = TestEvent::staking_pool(RawEvent::MintLiquid(ALICE, 5000, 250, 250));
+		assert!(System::events().iter().any(|record| record.event == mint_liquid_event));
 	});
 }
 
@@ -59,152 +60,168 @@ fn withdraw_unbonded_work() {
 fn redeem_by_unbond_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		assert_eq!(StakingPoolModule::bond(&ALICE, 1000), Ok(10000));
-		assert_eq!(StakingPoolModule::bond(&BOB, 1000), Ok(10000));
-		assert_eq!(StakingPoolModule::total_bonded(), 2000);
-		assert_eq!(StakingPoolModule::get_total_communal_balance(), 2000);
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
+		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
+		assert_ok!(CurrenciesModule::transfer(Some(BOB).into(), ALICE, LDOT, 1000));
+		assert_noop!(
+			StakingPoolModule::redeem_by_unbond(&ALICE, 5000),
+			Error::<Runtime>::LiquidCurrencyNotEnough,
+		);
+		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 1000);
+		assert_eq!(StakingPoolModule::total_bonded(), 500);
+		assert_eq!(StakingPoolModule::free_unbonded(), 500);
+		assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
 		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
 		assert_eq!(
 			StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 + BondingDuration::get()),
 			0
 		);
-		assert_noop!(
-			StakingPoolModule::redeem_by_unbond(&ALICE, 15000),
-			Error::<Runtime>::LiquidCurrencyNotEnough,
-		);
-		assert_ok!(StakingPoolModule::redeem_by_unbond(&ALICE, 5000));
-		assert_eq!(StakingPoolModule::total_bonded(), 1500);
-		assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 5000);
-		assert_eq!(StakingPoolModule::next_era_unbond(), (500, 500));
+
+		assert_ok!(StakingPoolModule::redeem_by_unbond(&ALICE, 1000));
+		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 1000);
+		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
+		assert_eq!(StakingPoolModule::total_bonded(), 400);
+		assert_eq!(StakingPoolModule::free_unbonded(), 500);
+		assert_eq!(StakingPoolModule::get_total_communal_balance(), 900);
+		assert_eq!(StakingPoolModule::next_era_unbond(), (100, 100));
 		assert_eq!(
 			StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 + BondingDuration::get()),
-			500
+			100
 		);
 
-		let redeem_by_unbond_event = TestEvent::staking_pool(RawEvent::RedeemByUnbond(ALICE, 5000));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == redeem_by_unbond_event));
+		// assert_eq!(StakingPoolModule::total_bonded(), 1500);
+		// assert_eq!(StakingPoolModule::get_total_communal_balance(), 1000);
+		// assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 5000);
+		// assert_eq!(StakingPoolModule::next_era_unbond(), (500, 500));
+		// assert_eq!(
+		// 	StakingPoolModule::claimed_unbond(&ALICE, 0 + 1 +
+		// BondingDuration::get()), 	500
+		// );
+
+		// let redeem_by_unbond_event =
+		// TestEvent::staking_pool(RawEvent::RedeemByUnbond(ALICE, 5000));
+		// assert!(System::events()
+		// 	.iter()
+		// 	.any(|record| record.event == redeem_by_unbond_event));
 	});
 }
 
-#[test]
-fn redeem_by_free_unbonded_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		System::set_block_number(1);
-		assert_eq!(StakingPoolModule::bond(&ALICE, 1000), Ok(10000));
-		assert_eq!(StakingPoolModule::bond(&BOB, 1000), Ok(10000));
-		TotalBonded::mutate(|bonded| *bonded -= 1500);
-		FreeUnbonded::put(1500);
-		assert_ok!(CurrenciesModule::deposit(DOT, &StakingPoolModule::account_id(), 1500));
-		assert_eq!(StakingPoolModule::total_bonded(), 500);
-		assert_eq!(StakingPoolModule::free_unbonded(), 1500);
-		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 0);
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
-		assert_eq!(
-			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-			1500
-		);
+// #[test]
+// fn redeem_by_free_unbonded_work() {
+// 	ExtBuilder::default().build().execute_with(|| {
+// 		System::set_block_number(1);
+// 		assert_eq!(StakingPoolModule::mint(&ALICE, 1000), Ok(10000));
+// 		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
+// 		TotalBonded::mutate(|bonded| *bonded -= 1500);
+// 		FreeUnbonded::put(1500);
+// 		assert_ok!(CurrenciesModule::deposit(DOT, &StakingPoolModule::account_id(),
+// 1500)); 		assert_eq!(StakingPoolModule::total_bonded(), 500);
+// 		assert_eq!(StakingPoolModule::free_unbonded(), 1500);
+// 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 0);
+// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
+// 		assert_eq!(
+// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+// 			1500
+// 		);
 
-		assert_noop!(
-			StakingPoolModule::redeem_by_free_unbonded(&ALICE, 15000),
-			Error::<Runtime>::LiquidCurrencyNotEnough,
-		);
+// 		assert_noop!(
+// 			StakingPoolModule::redeem_by_free_unbonded(&ALICE, 15000),
+// 			Error::<Runtime>::LiquidCurrencyNotEnough,
+// 		);
 
-		assert_ok!(StakingPoolModule::redeem_by_free_unbonded(&ALICE, 10000));
-		assert_eq!(StakingPoolModule::total_bonded(), 500);
-		assert_eq!(StakingPoolModule::free_unbonded(), 600);
-		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 900);
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
-		assert_eq!(
-			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-			600
-		);
+// 		assert_ok!(StakingPoolModule::redeem_by_free_unbonded(&ALICE, 10000));
+// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
+// 		assert_eq!(StakingPoolModule::free_unbonded(), 600);
+// 		assert_eq!(CurrenciesModule::free_balance(DOT, &ALICE), 900);
+// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
+// 		assert_eq!(
+// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+// 			600
+// 		);
 
-		let redeem_by_free_unbonded_event =
-			TestEvent::staking_pool(RawEvent::RedeemByFreeUnbonded(ALICE, 1000, 9000, 900));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == redeem_by_free_unbonded_event));
-	});
-}
+// 		let redeem_by_free_unbonded_event =
+// 			TestEvent::staking_pool(RawEvent::RedeemByFreeUnbonded(ALICE, 1000, 9000,
+// 900)); 		assert!(System::events()
+// 			.iter()
+// 			.any(|record| record.event == redeem_by_free_unbonded_event));
+// 	});
+// }
 
-#[test]
-fn redeem_by_claim_unbonding_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		System::set_block_number(1);
-		assert_eq!(StakingPoolModule::bond(&ALICE, 1000), Ok(10000));
-		assert_eq!(StakingPoolModule::bond(&BOB, 1000), Ok(10000));
-		TotalBonded::mutate(|bonded| *bonded -= 1500);
-		Unbonding::insert(2, (1500, 0));
-		UnbondingToFree::put(1500);
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
-		assert_eq!(StakingPoolModule::total_bonded(), 500);
-		assert_eq!(StakingPoolModule::unbonding(2), (1500, 0));
-		assert_eq!(StakingPoolModule::unbonding_to_free(), 1500);
-		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 0);
+// #[test]
+// fn redeem_by_claim_unbonding_work() {
+// 	ExtBuilder::default().build().execute_with(|| {
+// 		System::set_block_number(1);
+// 		assert_eq!(StakingPoolModule::mint(&ALICE, 1000), Ok(10000));
+// 		assert_eq!(StakingPoolModule::mint(&BOB, 1000), Ok(10000));
+// 		TotalBonded::mutate(|bonded| *bonded -= 1500);
+// 		Unbonding::insert(2, (1500, 0));
+// 		UnbondingToFree::put(1500);
+// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 10000);
+// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
+// 		assert_eq!(StakingPoolModule::unbonding(2), (1500, 0));
+// 		assert_eq!(StakingPoolModule::unbonding_to_free(), 1500);
+// 		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 0);
 
-		assert_eq!(StakingPoolModule::current_era(), 0);
-		assert_noop!(
-			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 0, BondingDuration::get() + 1),
-			Error::<Runtime>::InvalidEra,
-		);
-		assert_noop!(
-			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 15000, 2),
-			Error::<Runtime>::LiquidCurrencyNotEnough,
-		);
-		assert_eq!(
-			StakingPoolModule::claim_period_percent(2),
-			Ratio::saturating_from_rational(2, 4 + 1)
-		);
-		assert_eq!(StakingPoolModule::calculate_claim_fee(10000, 2), 600);
-		assert_ok!(StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 10000, 2));
-		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
-		assert_eq!(StakingPoolModule::total_bonded(), 500);
-		assert_eq!(StakingPoolModule::unbonding(2), (1500, 940));
-		assert_eq!(StakingPoolModule::unbonding_to_free(), 560);
-		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 940);
+// 		assert_eq!(StakingPoolModule::current_era(), 0);
+// 		assert_noop!(
+// 			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 0,
+// BondingDuration::get() + 1), 			Error::<Runtime>::InvalidEra,
+// 		);
+// 		assert_noop!(
+// 			StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 15000, 2),
+// 			Error::<Runtime>::LiquidCurrencyNotEnough,
+// 		);
+// 		assert_eq!(
+// 			StakingPoolModule::claim_period_percent(2),
+// 			Ratio::saturating_from_rational(2, 4 + 1)
+// 		);
+// 		assert_eq!(StakingPoolModule::calculate_claim_fee(10000, 2), 600);
+// 		assert_ok!(StakingPoolModule::redeem_by_claim_unbonding(&ALICE, 10000, 2));
+// 		assert_eq!(CurrenciesModule::free_balance(LDOT, &ALICE), 0);
+// 		assert_eq!(StakingPoolModule::total_bonded(), 500);
+// 		assert_eq!(StakingPoolModule::unbonding(2), (1500, 940));
+// 		assert_eq!(StakingPoolModule::unbonding_to_free(), 560);
+// 		assert_eq!(StakingPoolModule::claimed_unbond(&ALICE, 2), 940);
 
-		let redeem_by_claim_unbonding_event =
-			TestEvent::staking_pool(RawEvent::RedeemByClaimUnbonding(ALICE, 2, 600, 9400, 940));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == redeem_by_claim_unbonding_event));
-	});
-}
+// 		let redeem_by_claim_unbonding_event =
+// 			TestEvent::staking_pool(RawEvent::RedeemByClaimUnbonding(ALICE, 2, 600, 9400,
+// 940)); 		assert!(System::events()
+// 			.iter()
+// 			.any(|record| record.event == redeem_by_claim_unbonding_event));
+// 	});
+// }
 
-#[test]
-fn rebalance_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		TotalBonded::put(20000);
-		Unbonding::insert(1, (20000, 10000));
-		UnbondingToFree::put(10000);
-		NextEraUnbond::put((5000, 5000));
+// #[test]
+// fn rebalance_work() {
+// 	ExtBuilder::default().build().execute_with(|| {
+// 		TotalBonded::put(20000);
+// 		Unbonding::insert(1, (20000, 10000));
+// 		UnbondingToFree::put(10000);
+// 		NextEraUnbond::put((5000, 5000));
 
-		assert_eq!(StakingPoolModule::current_era(), 0);
-		assert_eq!(StakingPoolModule::total_bonded(), 20000);
-		assert_eq!(StakingPoolModule::free_unbonded(), 0);
-		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 0);
-		assert_eq!(CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()), 0);
-		assert_eq!(StakingPoolModule::unbonding(1), (20000, 10000));
-		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (0, 0));
-		assert_eq!(StakingPoolModule::next_era_unbond(), (5000, 5000));
+// 		assert_eq!(StakingPoolModule::current_era(), 0);
+// 		assert_eq!(StakingPoolModule::total_bonded(), 20000);
+// 		assert_eq!(StakingPoolModule::free_unbonded(), 0);
+// 		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 0);
+// 		assert_eq!(CurrenciesModule::free_balance(DOT,
+// &StakingPoolModule::account_id()), 0); 		assert_eq!(StakingPoolModule::
+// unbonding(1), (20000, 10000)); 		assert_eq!(StakingPoolModule::unbonding(1 +
+// BondingDuration::get()), (0, 0)); 		assert_eq!(StakingPoolModule::
+// next_era_unbond(), (5000, 5000));
 
-		CurrentEra::put(1);
-		StakingPoolModule::rebalance(1);
+// 		CurrentEra::put(1);
+// 		StakingPoolModule::rebalance(1);
 
-		assert_eq!(StakingPoolModule::current_era(), 1);
-		assert_eq!(StakingPoolModule::total_bonded(), 15000);
-		assert_eq!(StakingPoolModule::free_unbonded(), 10000);
-		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 10000);
-		assert_eq!(
-			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
-			20000
-		);
-		assert_eq!(StakingPoolModule::unbonding(1), (0, 0));
-		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (5000, 5000));
-		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
-	});
-}
+// 		assert_eq!(StakingPoolModule::current_era(), 1);
+// 		assert_eq!(StakingPoolModule::total_bonded(), 15000);
+// 		assert_eq!(StakingPoolModule::free_unbonded(), 10000);
+// 		assert_eq!(StakingPoolModule::total_claimed_unbonded(), 10000);
+// 		assert_eq!(
+// 			CurrenciesModule::free_balance(DOT, &StakingPoolModule::account_id()),
+// 			20000
+// 		);
+// 		assert_eq!(StakingPoolModule::unbonding(1), (0, 0));
+// 		assert_eq!(StakingPoolModule::unbonding(1 + BondingDuration::get()), (5000,
+// 5000)); 		assert_eq!(StakingPoolModule::next_era_unbond(), (0, 0));
+// 	});
+// }


### PR DESCRIPTION
1. fix bug of `redeem_by_unbond`: It's wrong that decrease `TotalBonded` while accumulating unbond of `NextEraUnbond`, this will cause loss to users who will redeem later.

2. resolve #330 , shouldn't bond all DOT when mint,  only bond part or all of DOT when the `communal_bonded_ratio` of staking pool is below `MinBondRatio`. The remainder is kept in `free_pool`.

3. make arithetic safer