### PR TITLE
fix: Fixes #339. Use consistent Rust nightly version in builds and linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,14 @@ jobs:
         target: wasm32-unknown-unknown
         default: true
     - name: Check format
-      run: cargo fmt --all -- --check
+      run: cargo +nightly-2020-06-04 fmt --all -- --check
     - name: Install clippy
-      run: rustup component add clippy
+      run: rustup component add clippy --toolchain nightly-2020-06-04
     - name: Run clippy
-      run: cargo clippy -- -D warnings
+      run: cargo +nightly-2020-06-04 clippy -- -D warnings
     - name: Build
-      run: cargo build --locked
+      run: cargo +nightly-2020-06-04 build --locked
     - name: Run tests
-      run: cargo test --all
+      run: cargo +nightly-2020-06-04 test --all
     - name: Run benchmarking tests
-      run: cargo test --features runtime-benchmarks -p acala-runtime benchmarking
+      run: cargo +nightly-2020-06-04 test --features runtime-benchmarks -p acala-runtime benchmarking

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: rust
-rust: nightly-2019-08-15
+rust: nightly-2020-06-04
 cache: cargo
 before_script:
-    - rustup target add wasm32-unknown-unknown
-    - command -v wasm-gc || cargo install --git https://github.com/alexcrichton/wasm-gc --force
-    - rustup component add rustfmt
+    - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-06-04
+    - command -v wasm-gc || cargo +nightly-2020-06-04 install --git https://github.com/alexcrichton/wasm-gc --force
+    - rustup component add rustfmt --toolchain nightly-2020-06-04
 script:
-    - cargo fmt --all -- --check
-    - cargo build
-    - cargo test --all
+    - cargo +nightly-2020-06-04 fmt --all -- --check
+    - cargo +nightly-2020-06-04 build
+    - cargo +nightly-2020-06-04 test --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN apt-get update && \
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH="$PATH:$HOME/.cargo/bin" && \
-	rustup toolchain install nightly && \
-	rustup target add wasm32-unknown-unknown --toolchain nightly && \
+	rustup update stable && \
+	rustup toolchain install nightly-2020-06-04 && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly-2020-06-04 && \
 	rustup default stable && \
-	cargo build "--$PROFILE"
+	cargo +nightly-2020-06-04 build "--$PROFILE"
 
 # ===== SECOND STAGE ======
 

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 run: githooks
-	SKIP_WASM_BUILD= cargo run -- --dev --execution=native -lruntime=debug
+	SKIP_WASM_BUILD= cargo +nightly-2020-06-04 run -- --dev --execution=native -lruntime=debug
 
 toolchain:
 	./scripts/init.sh
 
 build-wasm: githooks
-	WASM_BUILD_TYPE=release cargo build
+	WASM_BUILD_TYPE=release cargo +nightly-2020-06-04 build
 
 check: githooks
-	SKIP_WASM_BUILD= cargo check
+	SKIP_WASM_BUILD= cargo +nightly-2020-06-04 check
 
 check-tests: githooks
 	SKIP_WASM_BUILD= cargo check --tests --all
 
 check-debug:
-	RUSTFLAGS="-Z external-macro-backtrace" BUILD_DUMMY_WASM_BINARY= cargo +nightly check
+	RUSTFLAGS="-Z external-macro-backtrace" BUILD_DUMMY_WASM_BINARY= cargo +nightly-2020-06-04 check
 
 check-dummy:
-	BUILD_DUMMY_WASM_BINARY= cargo check
+	BUILD_DUMMY_WASM_BINARY= cargo +nightly-2020-06-04 check
 
 test: githooks
-	SKIP_WASM_BUILD= cargo test --all
+	SKIP_WASM_BUILD= cargo +nightly-2020-06-04 test --all
 
 build: githooks
-	SKIP_WASM_BUILD= cargo build
+	SKIP_WASM_BUILD= cargo +nightly-2020-06-04 build
 
 purge: target/debug/acala
 	target/debug/acala purge-chain --dev -y
@@ -57,4 +57,4 @@ update: update-orml
 	make check
 
 prepare-wasm:
-	WASM_TARGET_DIRECTORY=${CURDIR} WASM_BUILD_TYPE=release cargo build
+	WASM_TARGET_DIRECTORY=${CURDIR} WASM_BUILD_TYPE=release cargo +nightly-2020-06-04 build

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -6,7 +6,7 @@ REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.rs$") || true)
 if [ ! -z "${files}" ]; then
-    cargo fmt --all
+    cargo +nightly-2020-06-04 fmt --all
     git add $(echo "$files" | paste -s -d " " -)
 fi
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,7 +5,8 @@ set -e
 echo "*** Initializing WASM build environment"
 
 if [ -z $CI ] ; then
-   rustup update nightly
+   rustup toolchain install nightly-2020-06-04
+   rustup default nightly-2020-06-04
    rustup update stable
 fi
 

--- a/scripts/update-mandala.sh
+++ b/scripts/update-mandala.sh
@@ -3,5 +3,5 @@
 set -e
 
 # cargo clean
-WASM_BUILD_TYPE=release cargo run -- build-spec --chain mandala-latest > ./resources/mandala.json
-WASM_BUILD_TYPE=release cargo run -- build-spec --chain ./resources/mandala.json --raw > ./resources/mandala-dist.json
+WASM_BUILD_TYPE=release cargo +nightly-2020-06-04 run -- build-spec --chain mandala-latest > ./resources/mandala.json
+WASM_BUILD_TYPE=release cargo +nightly-2020-06-04 run -- build-spec --chain ./resources/mandala.json --raw > ./resources/mandala-dist.json


### PR DESCRIPTION
The repo used a mixture of both `nightly-2020-06-04` and `nightly-2020-08-15`, so I've used the most recently version that it has been using in this PR.