### PR TITLE
Merge collateral and debit storage into position.

### DIFF
--- a/modules/cdp_engine/src/tests.rs
+++ b/modules/cdp_engine/src/tests.rs
@@ -344,19 +344,19 @@ fn adjust_position_work() {
 		);
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 0);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 0);
 		assert_ok!(CDPEngineModule::adjust_position(&ALICE, BTC, 100, 50));
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 900);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 50);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 50);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 50);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
 		assert_eq!(CDPEngineModule::adjust_position(&ALICE, BTC, 0, 20).is_ok(), false);
 		assert_ok!(CDPEngineModule::adjust_position(&ALICE, BTC, 0, -20));
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 900);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 30);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 30);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 30);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
 	});
 }
 
@@ -394,8 +394,8 @@ fn liquidate_unsafe_cdp_by_collateral_auction() {
 		assert_ok!(CDPEngineModule::adjust_position(&ALICE, BTC, 100, 50));
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 900);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 50);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 50);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 50);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
 		assert_noop!(
 			CDPEngineModule::liquidate_unsafe_cdp(ALICE, BTC),
 			Error::<Runtime>::MustBeUnsafe,
@@ -425,8 +425,8 @@ fn liquidate_unsafe_cdp_by_collateral_auction() {
 		assert_eq!(CDPTreasuryModule::debit_pool(), 50);
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 900);
 		assert_eq!(Currencies::free_balance(AUSD, &ALICE), 50);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 0);
 	});
 }
 
@@ -525,14 +525,14 @@ fn settle_cdp_has_debit_work() {
 		));
 		assert_ok!(CDPEngineModule::adjust_position(&ALICE, BTC, 100, 0));
 		assert_eq!(Currencies::free_balance(BTC, &ALICE), 900);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
 		assert_noop!(
 			CDPEngineModule::settle_cdp_has_debit(ALICE, BTC),
 			Error::<Runtime>::NoDebitValue,
 		);
 		assert_ok!(CDPEngineModule::adjust_position(&ALICE, BTC, 0, 50));
-		assert_eq!(LoansModule::debits(BTC, ALICE), 50);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 50);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
 		assert_ok!(CDPEngineModule::settle_cdp_has_debit(ALICE, BTC));
@@ -542,7 +542,7 @@ fn settle_cdp_has_debit_work() {
 			.iter()
 			.any(|record| record.event == settle_cdp_in_debit_event));
 
-		assert_eq!(LoansModule::debits(BTC, ALICE), 0);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 0);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 50);
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 50);
 	});

--- a/modules/honzon/src/tests.rs
+++ b/modules/honzon/src/tests.rs
@@ -86,8 +86,8 @@ fn transfer_loan_from_should_work() {
 		assert_ok!(HonzonModule::adjust_loan(Origin::signed(ALICE), BTC, 100, 50));
 		assert_ok!(HonzonModule::authorize(Origin::signed(ALICE), BTC, BOB));
 		assert_ok!(HonzonModule::transfer_loan_from(Origin::signed(BOB), BTC, ALICE));
-		assert_eq!(LoansModule::collaterals(BOB, BTC), 100);
-		assert_eq!(LoansModule::debits(BTC, BOB), 50);
+		assert_eq!(LoansModule::positions(BTC, BOB).collateral, 100);
+		assert_eq!(LoansModule::positions(BTC, BOB).debit, 50);
 	});
 }
 
@@ -114,8 +114,8 @@ fn adjust_loan_should_work() {
 			Change::NewValue(10000),
 		));
 		assert_ok!(HonzonModule::adjust_loan(Origin::signed(ALICE), BTC, 100, 50));
-		assert_eq!(LoansModule::collaterals(ALICE, BTC), 100);
-		assert_eq!(LoansModule::debits(BTC, ALICE), 50);
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 50);
 	});
 }
 

--- a/runtime/tests/integration_test.rs
+++ b/runtime/tests/integration_test.rs
@@ -274,19 +274,19 @@ fn liquidate_cdp() {
 			));
 
 			assert_eq!(
-				LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
 				amount(500_000)
 			);
 			assert_eq!(
-				LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).collateral,
 				amount(10)
 			);
 			assert_eq!(
-				LoansModule::debits(CurrencyId::XBTC, AccountId::from(BOB)),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(BOB)).debit,
 				amount(50_000)
 			);
 			assert_eq!(
-				LoansModule::collaterals(AccountId::from(BOB), CurrencyId::XBTC),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(BOB)).collateral,
 				amount(1)
 			);
 			assert_eq!(CdpTreasuryModule::debit_pool(), 0);
@@ -319,8 +319,14 @@ fn liquidate_cdp() {
 				.iter()
 				.any(|record| record.event == liquidate_alice_xbtc_cdp_event));
 
-			assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
-			assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC), 0);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
+				0
+			);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).collateral,
+				0
+			);
 			assert_eq!(AuctionManagerModule::collateral_auctions(0).is_some(), true);
 			assert_eq!(CdpTreasuryModule::debit_pool(), amount(50_000));
 
@@ -341,8 +347,11 @@ fn liquidate_cdp() {
 				.iter()
 				.any(|record| record.event == liquidate_bob_xbtc_cdp_event));
 
-			assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(BOB)), 0);
-			assert_eq!(LoansModule::collaterals(AccountId::from(BOB), CurrencyId::XBTC), 0);
+			assert_eq!(LoansModule::positions(CurrencyId::XBTC, AccountId::from(BOB)).debit, 0);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(BOB)).collateral,
+				0
+			);
 			assert_eq!(CdpTreasuryModule::debit_pool(), amount(55_000));
 			assert!(CdpTreasuryModule::surplus_pool() >= amount(5_000));
 		});
@@ -481,11 +490,11 @@ fn test_honzon_module() {
 				amount(50)
 			);
 			assert_eq!(
-				LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
 				amount(500)
 			);
 			assert_eq!(
-				LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).collateral,
 				amount(100)
 			);
 			assert_eq!(
@@ -520,8 +529,14 @@ fn test_honzon_module() {
 				Currencies::free_balance(CurrencyId::AUSD, &AccountId::from(ALICE)),
 				amount(50)
 			);
-			assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
-			assert_eq!(LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC), 0);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
+				0
+			);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).collateral,
+				0
+			);
 		});
 }
 
@@ -596,9 +611,12 @@ fn test_cdp_engine_module() {
 				Currencies::free_balance(CurrencyId::XBTC, &AccountId::from(ALICE)),
 				amount(900)
 			);
-			assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
 			assert_eq!(
-				LoansModule::collaterals(AccountId::from(ALICE), CurrencyId::XBTC),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
+				0
+			);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).collateral,
 				amount(100)
 			);
 
@@ -619,7 +637,7 @@ fn test_cdp_engine_module() {
 				amount(100) as i128
 			));
 			assert_eq!(
-				LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)),
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
 				amount(100)
 			);
 			assert_eq!(CdpTreasuryModule::debit_pool(), 0);
@@ -636,7 +654,10 @@ fn test_cdp_engine_module() {
 				.iter()
 				.any(|record| record.event == settle_cdp_in_debit_event));
 
-			assert_eq!(LoansModule::debits(CurrencyId::XBTC, AccountId::from(ALICE)), 0);
+			assert_eq!(
+				LoansModule::positions(CurrencyId::XBTC, AccountId::from(ALICE)).debit,
+				0
+			);
 			assert_eq!(CdpTreasuryModule::debit_pool(), amount(10));
 			assert_eq!(
 				CdpTreasuryModule::total_collaterals(CurrencyId::XBTC),


### PR DESCRIPTION
Loans module: merge collateral and debit storage into position, to improve performance and reduce storage size. (For the similar reason of pallet-balances refactor in https://github.com/paritytech/substrate/issues/4613 )