### PR TITLE
abstract struct method instead of directlycheck is_zero

### DIFF
--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -24,7 +24,7 @@ use frame_system::{
 	self as system, ensure_none,
 	offchain::{SendTransactionTypes, SubmitTransaction},
 };
-use orml_traits::{Auction, AuctionHandler, AuctionInfo, Change, MultiCurrency, OnNewBidResult};
+use orml_traits::{Auction, AuctionHandler, Change, MultiCurrency, OnNewBidResult};
 use orml_utilities::with_transaction_result;
 use primitives::{AuctionId, Balance, CurrencyId};
 use sp_runtime::{
@@ -69,6 +69,17 @@ pub struct CollateralAuctionItem<AccountId, BlockNumber> {
 	target: Balance,
 	/// Auction start time
 	start_time: BlockNumber,
+}
+
+impl<AccountId, BlockNumber> CollateralAuctionItem<AccountId, BlockNumber> {
+	/// Return the collateral auction will never be reverse stage
+	fn always_forward(&self) -> bool {
+		self.target.is_zero()
+	}
+
+	fn in_reverse_stage(&self, last_bid_price: Balance) -> bool {
+		!self.always_forward() && last_bid_price >= self.target
+	}
 }
 
 /// Information of an debit auction
@@ -300,6 +311,10 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
+	fn get_last_bid(auction_id: AuctionId) -> Option<(T::AccountId, Balance)> {
+		T::Auction::auction_info(auction_id).and_then(|auction_info| auction_info.bid)
+	}
+
 	fn submit_cancel_auction_tx(auction_id: AuctionId) {
 		let call = Call::<T>::cancel(auction_id);
 		if SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()).is_err() {
@@ -338,9 +353,17 @@ impl<T: Trait> Module<T> {
 			}
 			_ => {
 				for (collateral_auction_id, _) in <CollateralAuctions<T>>::iter() {
-					if !Self::collateral_auction_in_reverse_stage(collateral_auction_id) {
-						Self::submit_cancel_auction_tx(collateral_auction_id);
+					if let (Some(collateral_auction), Some((_, last_bid_price))) = (
+						Self::collateral_auctions(collateral_auction_id),
+						Self::get_last_bid(collateral_auction_id),
+					) {
+						// if collateral auction has already been in reverse stage,
+						// should skip it.
+						if collateral_auction.in_reverse_stage(last_bid_price) {
+							continue;
+						}
 					}
+					Self::submit_cancel_auction_tx(collateral_auction_id);
 					guard.extend_lock().map_err(|_| OffchainErr::OffchainLock)?;
 				}
 			}
@@ -353,11 +376,7 @@ impl<T: Trait> Module<T> {
 		let surplus_auction = <SurplusAuctions<T>>::take(id).ok_or(Error::<T>::AuctionNotExists)?;
 
 		// if there's bid
-		if let Some(AuctionInfo {
-			bid: Some((bidder, bid_price)),
-			..
-		}) = T::Auction::auction_info(id)
-		{
+		if let Some((bidder, bid_price)) = Self::get_last_bid(id) {
 			// refund native token to the bidder
 			// TODO: transfer from RESERVED TREASURY instead of issuing
 			T::Currency::deposit(T::GetNativeCurrencyId::get(), &bidder, bid_price)?;
@@ -370,7 +389,6 @@ impl<T: Trait> Module<T> {
 		TotalSurplusInAuction::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
 
 		// remove the auction info
-		<SurplusAuctions<T>>::remove(id);
 		T::Auction::remove_auction(id);
 
 		Ok(())
@@ -380,10 +398,7 @@ impl<T: Trait> Module<T> {
 		let debit_auction = <DebitAuctions<T>>::take(id).ok_or(Error::<T>::AuctionNotExists)?;
 
 		// if there's bid
-		if let Some(AuctionInfo {
-			bid: Some((bidder, _)), ..
-		}) = T::Auction::auction_info(id)
-		{
+		if let Some((bidder, _)) = Self::get_last_bid(id) {
 			// refund stable token to the bidder
 			T::CDPTreasury::issue_debit(&bidder, debit_auction.fix, false)?;
 			// decrease account ref of bidder
@@ -394,25 +409,28 @@ impl<T: Trait> Module<T> {
 		TotalDebitInAuction::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
 
 		// remove the auction info
-		<DebitAuctions<T>>::remove(id);
 		T::Auction::remove_auction(id);
 
 		Ok(())
 	}
 
 	fn cancel_collateral_auction(id: AuctionId) -> DispatchResult {
-		// must not in reverse bid stage
-		ensure!(
-			!Self::collateral_auction_in_reverse_stage(id),
-			Error::<T>::InReverseStage
-		);
-		let collateral_auction = <CollateralAuctions<T>>::take(id).ok_or(Error::<T>::AuctionNotExists)?;
+		let collateral_auction = <CollateralAuctions<T>>::get(id).ok_or(Error::<T>::AuctionNotExists)?;
+		let last_bid = Self::get_last_bid(id);
+
+		// collateral auction must not be in reverse stage
+		if let Some((_, bid_price)) = last_bid {
+			ensure!(
+				!collateral_auction.in_reverse_stage(bid_price),
+				Error::<T>::InReverseStage,
+			);
+		}
 
 		// calculate how much collateral to offset target in settle price
 		let stable_currency_id = T::GetStableCurrencyId::get();
 		let settle_price = T::PriceSource::get_relative_price(stable_currency_id, collateral_auction.currency_id)
 			.ok_or(Error::<T>::InvalidFeedPrice)?;
-		let confiscate_collateral_amount = if collateral_auction.target.is_zero() {
+		let confiscate_collateral_amount = if collateral_auction.always_forward() {
 			collateral_auction.amount
 		} else {
 			sp_std::cmp::min(
@@ -430,11 +448,7 @@ impl<T: Trait> Module<T> {
 		)?;
 
 		// if there's bid
-		if let Some(AuctionInfo {
-			bid: Some((bidder, bid_price)),
-			..
-		}) = T::Auction::auction_info(id)
-		{
+		if let Some((bidder, bid_price)) = last_bid {
 			// refund stable token to the bidder
 			T::CDPTreasury::issue_debit(&bidder, bid_price, false)?;
 
@@ -456,21 +470,6 @@ impl<T: Trait> Module<T> {
 		T::Auction::remove_auction(id);
 
 		Ok(())
-	}
-
-	fn collateral_auction_in_reverse_stage(id: AuctionId) -> bool {
-		if let (
-			Some(CollateralAuctionItem { target, .. }),
-			Some(AuctionInfo {
-				bid: Some((_, bid_price)),
-				..
-			}),
-		) = (Self::collateral_auctions(id), T::Auction::auction_info(id))
-		{
-			!target.is_zero() && bid_price >= target
-		} else {
-			false
-		}
 	}
 
 	/// Return `true` if price increment rate is greater than or equal to
@@ -545,7 +544,7 @@ impl<T: Trait> Module<T> {
 						Error::<T>::InvalidBidPrice
 					);
 
-					let mut payment = if collateral_auction.target.is_zero() {
+					let mut payment = if collateral_auction.always_forward() {
 						new_bid_price
 					} else {
 						sp_std::cmp::min(collateral_auction.target, new_bid_price)
@@ -556,7 +555,7 @@ impl<T: Trait> Module<T> {
 
 					// if there's bid before, return stablecoin from new bidder to last bidder
 					if let Some((last_bidder, _)) = last_bid {
-						let refund = if collateral_auction.target.is_zero() {
+						let refund = if collateral_auction.always_forward() {
 							last_bid_price
 						} else {
 							sp_std::cmp::min(last_bid_price, collateral_auction.target)
@@ -576,7 +575,7 @@ impl<T: Trait> Module<T> {
 					// if collateral auction will be in reverse stage, refund collateral to it's
 					// origin from auction CDP treasury
 					let should_reverse =
-						!collateral_auction.target.is_zero() && new_bid_price > collateral_auction.target;
+						!collateral_auction.always_forward() && new_bid_price > collateral_auction.target;
 					if should_reverse {
 						let new_collateral_amount = Rate::checked_from_rational(
 							sp_std::cmp::max(last_bid_price, collateral_auction.target),
@@ -722,7 +721,7 @@ impl<T: Trait> Module<T> {
 			let mut should_deal = true;
 
 			// if bid_price doesn't reach target and trading with DEX will get better result
-			if (bid_price < collateral_auction.target || collateral_auction.target.is_zero())
+			if (bid_price < collateral_auction.target || collateral_auction.always_forward())
 				&& bid_price
 					< T::DEX::get_target_amount(
 						collateral_auction.currency_id,
@@ -741,7 +740,7 @@ impl<T: Trait> Module<T> {
 					// refund stable currency to the last bidder, ignore result to continue
 					let _ = T::CDPTreasury::issue_debit(&bidder, bid_price, false);
 
-					if !collateral_auction.target.is_zero() && amount > collateral_auction.target {
+					if !collateral_auction.always_forward() && amount > collateral_auction.target {
 						// refund extra stable currency to recipient, ignore result to continue
 						let _ = T::CDPTreasury::issue_debit(
 							&collateral_auction.refund_recipient,
@@ -769,7 +768,7 @@ impl<T: Trait> Module<T> {
 					collateral_auction.amount,
 				);
 
-				let payment_amount = if collateral_auction.target.is_zero() {
+				let payment_amount = if collateral_auction.always_forward() {
 					bid_price
 				} else {
 					sp_std::cmp::min(collateral_auction.target, bid_price)
@@ -1012,9 +1011,12 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 				return InvalidTransaction::Stale.into();
 			}
 
-			if <CollateralAuctions<T>>::contains_key(auction_id) {
-				if !Self::collateral_auction_in_reverse_stage(*auction_id) {
-					return InvalidTransaction::Stale.into();
+			if let Some(collateral_auction) = Self::collateral_auctions(auction_id) {
+				if let Some((_, bid_price)) = Self::get_last_bid(*auction_id) {
+					// if collateral auction is in reverse stage, shouldn't cancel
+					if collateral_auction.in_reverse_stage(bid_price) {
+						return InvalidTransaction::Stale.into();
+					}
 				}
 			} else if !<SurplusAuctions<T>>::contains_key(auction_id) && !<DebitAuctions<T>>::contains_key(auction_id) {
 				return InvalidTransaction::Stale.into();

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -455,7 +455,7 @@ fn cancel_collateral_auction_work() {
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 100);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
-		assert_ok!(AuctionModule::bid(Some(BOB).into(), 0, 80));
+		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 80));
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 920);
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 80);

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -403,7 +403,7 @@ fn cancel_debit_auction_work() {
 }
 
 #[test]
-fn collateral_auction_in_reverse_stage() {
+fn collateral_auction_methods() {
 	ExtBuilder::default().build().execute_with(|| {
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
 		let collateral_auction_with_positive_target = AuctionManagerModule::collateral_auctions(0).unwrap();
@@ -411,12 +411,31 @@ fn collateral_auction_in_reverse_stage() {
 		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(99), false);
 		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(100), true);
 		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(101), true);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(99), 99);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(100), 100);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(101), 100);
+		assert_eq!(collateral_auction_with_positive_target.collateral_amount(80, 100), 10);
+		assert_eq!(collateral_auction_with_positive_target.collateral_amount(100, 200), 5);
 
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0);
 		let collateral_auction_with_zero_target = AuctionManagerModule::collateral_auctions(1).unwrap();
 		assert_eq!(collateral_auction_with_zero_target.always_forward(), true);
 		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(0), false);
 		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(100), false);
+		assert_eq!(collateral_auction_with_zero_target.payment_amount(99), 99);
+		assert_eq!(collateral_auction_with_zero_target.payment_amount(101), 101);
+		assert_eq!(collateral_auction_with_zero_target.collateral_amount(100, 200), 10);
+	});
+}
+
+#[test]
+fn debit_auction_methods() {
+	ExtBuilder::default().build().execute_with(|| {
+		AuctionManagerModule::new_debit_auction(200, 100);
+		let debit_auction = AuctionManagerModule::debit_auctions(0).unwrap();
+		assert_eq!(debit_auction.amount_for_sale(0, 100), 200);
+		assert_eq!(debit_auction.amount_for_sale(100, 200), 100);
+		assert_eq!(debit_auction.amount_for_sale(200, 1000), 40);
 	});
 }
 

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -403,37 +403,40 @@ fn cancel_debit_auction_work() {
 }
 
 #[test]
-fn collateral_auction_in_reverse_stage_work() {
+fn collateral_auction_in_reverse_stage() {
 	ExtBuilder::default().build().execute_with(|| {
-		// collateral auction which target > 0
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(0), false);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(0), false);
-		assert_ok!(AuctionModule::bid(Some(BOB).into(), 0, 20));
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(0), false);
-		assert_ok!(AuctionModule::bid(Some(ALICE).into(), 0, 100));
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(0), true);
+		let collateral_auction_with_positive_target = AuctionManagerModule::collateral_auctions(0).unwrap();
+		assert_eq!(collateral_auction_with_positive_target.always_forward(), false);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(99), false);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(100), true);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(101), true);
 
-		// collateral auction which target is zero
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0);
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(1), false);
-		assert_ok!(AuctionModule::bid(Some(ALICE).into(), 1, 5));
-		assert_eq!(AuctionManagerModule::collateral_auction_in_reverse_stage(1), false);
+		let collateral_auction_with_zero_target = AuctionManagerModule::collateral_auctions(1).unwrap();
+		assert_eq!(collateral_auction_with_zero_target.always_forward(), true);
+		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(0), false);
+		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(100), false);
 	});
 }
 
 #[test]
 fn cancel_collateral_auction_failed() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 10));
 		assert_noop!(
 			AuctionManagerModule::cancel_collateral_auction(0),
 			Error::<Runtime>::AuctionNotExists
 		);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
-		assert_ok!(AuctionModule::bid(Some(ALICE).into(), 0, 100));
+		assert_ok!(AuctionModule::bid(Origin::signed(ALICE), 0, 100));
+		let collateral_auction = AuctionManagerModule::collateral_auctions(0).unwrap();
+		assert_eq!(collateral_auction.always_forward(), false);
+		assert_eq!(AuctionManagerModule::get_last_bid(0), Some((ALICE, 100)));
+		assert_eq!(collateral_auction.in_reverse_stage(100), true);
 		assert_noop!(
 			AuctionManagerModule::cancel_collateral_auction(0),
-			Error::<Runtime>::InReverseStage
+			Error::<Runtime>::InReverseStage,
 		);
 	});
 }


### PR DESCRIPTION
close #368 

And fix a bug: 
https://github.com/AcalaNetwork/Acala/blob/1c6dfb68f1edb1f770dfc63f2bc0cbb7237777bf/modules/auction_manager/src/lib.rs#L1015-L1018
Only collateral auction in reverse stage could be canceled, the checks in `cancel_collateral_auction` and offchain worker is correct, but totally wrong in `validate_ungined`, it will cause those txs that could have been successfully executed to be rejected by txpool.