### PR TITLE
modify end handler when auction passed

### DIFF
--- a/modules/auction_manager/benchmarking/src/mock.rs
+++ b/modules/auction_manager/benchmarking/src/mock.rs
@@ -118,7 +118,6 @@ parameter_types! {
 	pub const AuctionTimeToClose: u64 = 100;
 	pub const AuctionDurationSoftCap: u64 = 2000;
 	pub const GetStableCurrencyId: CurrencyId = AUSD;
-	pub GetAmountAdjustment: Rate = Rate::saturating_from_rational(1, 2);
 	pub const UnsignedPriority: u64 = 1 << 20;
 }
 
@@ -132,7 +131,6 @@ impl auction_manager::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type CDPTreasury = CDPTreasuryModule;
-	type GetAmountAdjustment = GetAmountAdjustment;
 	type DEX = ();
 	type PriceSource = prices::Module<Runtime>;
 	type UnsignedPriority = UnsignedPriority;

--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -783,7 +783,7 @@ impl<T: Trait> Module<T> {
 						auction_id,
 						collateral_auction.currency_id,
 						collateral_auction.amount,
-						bidder.clone(),
+						bidder,
 						payment_amount,
 					));
 				}

--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -163,9 +163,6 @@ pub trait Trait: SendTransactionTypes<Call<Self>> + system::Trait {
 	/// The native currency id
 	type GetNativeCurrencyId: Get<CurrencyId>;
 
-	/// The decrement of amount in debit auction when restocking
-	type GetAmountAdjustment: Get<Rate>;
-
 	/// Currency to transfer assets
 	type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>;
 
@@ -283,9 +280,6 @@ decl_module! {
 
 		/// The native currency id
 		const GetNativeCurrencyId: CurrencyId = T::GetNativeCurrencyId::get();
-
-		/// The decrement of amount in debit auction when restocking
-		const GetAmountAdjustment: Rate = T::GetAmountAdjustment::get();
 
 		/// Cancel active auction after system shutdown
 		///
@@ -729,73 +723,76 @@ impl<T: Trait> Module<T> {
 	}
 
 	fn collateral_auction_end_handler(auction_id: AuctionId, winner: Option<(T::AccountId, Balance)>) {
-		if let (Some(collateral_auction), Some((bidder, bid_price))) = (Self::collateral_auctions(auction_id), winner) {
-			let stable_currency_id = T::GetStableCurrencyId::get();
-			let mut should_deal = true;
+		if let Some(collateral_auction) = Self::collateral_auctions(auction_id) {
+			if let Some((bidder, bid_price)) = winner {
+				// decrease account ref of bidder
+				system::Module::<T>::dec_ref(&bidder);
 
-			// if bid_price doesn't reach target and trading with DEX will get better result
-			if !collateral_auction.in_reverse_stage(bid_price)
-				&& bid_price
-					< T::DEX::get_target_amount(
+				let mut should_deal = true;
+
+				// if bid_price doesn't reach target and trading with DEX will get better result
+				if !collateral_auction.in_reverse_stage(bid_price)
+					&& bid_price
+						< T::DEX::get_target_amount(
+							collateral_auction.currency_id,
+							T::GetStableCurrencyId::get(),
+							collateral_auction.amount,
+						) {
+					// try trade with DEX
+					if let Ok(amount) = T::CDPTreasury::swap_collateral_to_stable(
 						collateral_auction.currency_id,
-						stable_currency_id,
 						collateral_auction.amount,
+						Zero::zero(),
 					) {
-				// try trade with DEX
-				if let Ok(amount) = T::CDPTreasury::swap_collateral_to_stable(
-					collateral_auction.currency_id,
-					collateral_auction.amount,
-					Zero::zero(),
-				) {
-					// swap successfully, will not deal
-					should_deal = false;
+						// swap successfully, will not deal
+						should_deal = false;
 
-					// refund stable currency to the last bidder, ignore result to continue
-					let _ = T::CDPTreasury::issue_debit(&bidder, bid_price, false);
+						// refund stable currency to the last bidder, ignore result to continue
+						let _ = T::CDPTreasury::issue_debit(&bidder, bid_price, false);
 
-					if collateral_auction.in_reverse_stage(amount) {
-						// refund extra stable currency to recipient, ignore result to continue
-						let _ = T::CDPTreasury::issue_debit(
-							&collateral_auction.refund_recipient,
-							amount
-								.checked_sub(collateral_auction.target)
-								.expect("ensured amount > target; qed"),
-							false,
-						);
+						if collateral_auction.in_reverse_stage(amount) {
+							// refund extra stable currency to recipient, ignore result to continue
+							let _ = T::CDPTreasury::issue_debit(
+								&collateral_auction.refund_recipient,
+								amount
+									.checked_sub(collateral_auction.target)
+									.expect("ensured amount > target; qed"),
+								false,
+							);
+						}
+
+						<Module<T>>::deposit_event(RawEvent::DEXTakeCollateralAuction(
+							auction_id,
+							collateral_auction.currency_id,
+							collateral_auction.amount,
+							amount,
+						));
 					}
+				}
 
-					<Module<T>>::deposit_event(RawEvent::DEXTakeCollateralAuction(
+				if should_deal {
+					// transfer collateral to winner from CDP treasury, ignore result to continue
+					let _ = T::CDPTreasury::withdraw_collateral(
+						&bidder,
+						collateral_auction.currency_id,
+						collateral_auction.amount,
+					);
+
+					let payment_amount = collateral_auction.payment_amount(bid_price);
+					<Module<T>>::deposit_event(RawEvent::CollateralAuctionDealt(
 						auction_id,
 						collateral_auction.currency_id,
 						collateral_auction.amount,
-						amount,
+						bidder.clone(),
+						payment_amount,
 					));
 				}
+			} else {
+				<Module<T>>::deposit_event(RawEvent::CancelAuction(auction_id));
 			}
-
-			if should_deal {
-				// transfer collateral to winner from CDP treasury, ignore result to continue
-				let _ = T::CDPTreasury::withdraw_collateral(
-					&bidder,
-					collateral_auction.currency_id,
-					collateral_auction.amount,
-				);
-
-				let payment_amount = collateral_auction.payment_amount(bid_price);
-				<Module<T>>::deposit_event(RawEvent::CollateralAuctionDealt(
-					auction_id,
-					collateral_auction.currency_id,
-					collateral_auction.amount,
-					bidder.clone(),
-					payment_amount,
-				));
-			}
-
-			// decrease account ref of bidder and refund recipient
-			system::Module::<T>::dec_ref(&bidder);
-			system::Module::<T>::dec_ref(&collateral_auction.refund_recipient);
 
 			// update auction records
+			system::Module::<T>::dec_ref(&collateral_auction.refund_recipient);
 			TotalCollateralInAuction::mutate(collateral_auction.currency_id, |balance| {
 				*balance = balance.saturating_sub(collateral_auction.amount)
 			});
@@ -807,16 +804,12 @@ impl<T: Trait> Module<T> {
 	fn debit_auction_end_handler(auction_id: AuctionId, winner: Option<(T::AccountId, Balance)>) {
 		if let Some(debit_auction) = Self::debit_auctions(auction_id) {
 			if let Some((bidder, _)) = winner {
-				// issue native token to winner, ignore the result to continue
-				// TODO: transfer from RESERVED TREASURY instead of issuing
-				let _ = T::Currency::deposit(T::GetNativeCurrencyId::get(), &bidder, debit_auction.amount);
-
 				// decrease account ref of winner
 				system::Module::<T>::dec_ref(&bidder);
 
-				// decrease debit in auction and delete auction
-				TotalDebitInAuction::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
-				<DebitAuctions<T>>::remove(auction_id);
+				// issue native token to winner, ignore the result to continue
+				// TODO: transfer from RESERVED TREASURY instead of issuing
+				let _ = T::Currency::deposit(T::GetNativeCurrencyId::get(), &bidder, debit_auction.amount);
 
 				<Module<T>>::deposit_event(RawEvent::DebitAuctionDealt(
 					auction_id,
@@ -825,48 +818,37 @@ impl<T: Trait> Module<T> {
 					debit_auction.fix,
 				));
 			} else {
-				// there's no bidder until auction closed, adjust the native token amount
-				let start_block = <system::Module<T>>::block_number();
-				let end_block = start_block + T::AuctionTimeToClose::get();
-				let new_debit_auction_id: AuctionId = T::Auction::new_auction(start_block, Some(end_block))
-					.expect("AuctionId is sufficient large so this can never fail");
-				let new_amount = T::GetAmountAdjustment::get().saturating_mul_acc_int(debit_auction.amount);
-				let new_debit_auction = DebitAuctionItem {
-					amount: new_amount,
-					fix: debit_auction.fix,
-					start_time: start_block,
-				};
-				<DebitAuctions<T>>::insert(new_debit_auction_id, new_debit_auction.clone());
-				<DebitAuctions<T>>::remove(auction_id);
-
 				<Module<T>>::deposit_event(RawEvent::CancelAuction(auction_id));
-				<Module<T>>::deposit_event(RawEvent::NewDebitAuction(
-					new_debit_auction_id,
-					new_debit_auction.amount,
-					new_debit_auction.fix,
-				));
 			}
+
+			// remove debit auction item
+			<DebitAuctions<T>>::remove(auction_id);
+			TotalDebitInAuction::mutate(|balance| *balance = balance.saturating_sub(debit_auction.fix));
 		}
 	}
 
 	fn surplus_auction_end_handler(auction_id: AuctionId, winner: Option<(T::AccountId, Balance)>) {
-		if let (Some(surplus_auction), Some((bidder, bidder_price))) = (Self::surplus_auctions(auction_id), winner) {
-			// deposit unbacked stable token to winner by CDP treasury, ignore Err
-			let _ = T::CDPTreasury::issue_debit(&bidder, surplus_auction.amount, false);
+		if let Some(surplus_auction) = Self::surplus_auctions(auction_id) {
+			if let Some((bidder, bidder_price)) = winner {
+				// decrease account ref of winner
+				system::Module::<T>::dec_ref(&bidder);
 
-			// decrease account ref of winner
-			system::Module::<T>::dec_ref(&bidder);
+				// deposit unbacked stable token to winner by CDP treasury, ignore Err
+				let _ = T::CDPTreasury::issue_debit(&bidder, surplus_auction.amount, false);
 
-			// decrease surplus in auction
-			TotalSurplusInAuction::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
+				<Module<T>>::deposit_event(RawEvent::SurplusAuctionDealt(
+					auction_id,
+					surplus_auction.amount,
+					bidder,
+					bidder_price,
+				));
+			} else {
+				<Module<T>>::deposit_event(RawEvent::CancelAuction(auction_id));
+			}
+
+			// remove surplus auction item
 			<SurplusAuctions<T>>::remove(auction_id);
-
-			<Module<T>>::deposit_event(RawEvent::SurplusAuctionDealt(
-				auction_id,
-				surplus_auction.amount,
-				bidder,
-				bidder_price,
-			));
+			TotalSurplusInAuction::mutate(|balance| *balance = balance.saturating_sub(surplus_auction.amount));
 		}
 	}
 }

--- a/modules/auction_manager/src/mock.rs
+++ b/modules/auction_manager/src/mock.rs
@@ -186,7 +186,6 @@ parameter_types! {
 	pub const AuctionTimeToClose: u64 = 100;
 	pub const AuctionDurationSoftCap: u64 = 2000;
 	pub const GetNativeCurrencyId: CurrencyId = ACA;
-	pub GetAmountAdjustment: Rate = Rate::saturating_from_rational(1, 2);
 	pub const UnsignedPriority: u64 = 1 << 20;
 }
 
@@ -200,7 +199,6 @@ impl Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type CDPTreasury = CDPTreasuryModule;
-	type GetAmountAdjustment = GetAmountAdjustment;
 	type DEX = DEXModule;
 	type PriceSource = MockPriceSource;
 	type UnsignedPriority = UnsignedPriority;

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -7,6 +7,51 @@ use frame_support::{assert_noop, assert_ok};
 use mock::*;
 
 #[test]
+fn get_auction_time_to_close_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(AuctionManagerModule::get_auction_time_to_close(2000, 1), 100);
+		assert_eq!(AuctionManagerModule::get_auction_time_to_close(2001, 1), 50);
+	});
+}
+
+#[test]
+fn collateral_auction_methods() {
+	ExtBuilder::default().build().execute_with(|| {
+		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		let collateral_auction_with_positive_target = AuctionManagerModule::collateral_auctions(0).unwrap();
+		assert_eq!(collateral_auction_with_positive_target.always_forward(), false);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(99), false);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(100), true);
+		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(101), true);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(99), 99);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(100), 100);
+		assert_eq!(collateral_auction_with_positive_target.payment_amount(101), 100);
+		assert_eq!(collateral_auction_with_positive_target.collateral_amount(80, 100), 10);
+		assert_eq!(collateral_auction_with_positive_target.collateral_amount(100, 200), 5);
+
+		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0);
+		let collateral_auction_with_zero_target = AuctionManagerModule::collateral_auctions(1).unwrap();
+		assert_eq!(collateral_auction_with_zero_target.always_forward(), true);
+		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(0), false);
+		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(100), false);
+		assert_eq!(collateral_auction_with_zero_target.payment_amount(99), 99);
+		assert_eq!(collateral_auction_with_zero_target.payment_amount(101), 101);
+		assert_eq!(collateral_auction_with_zero_target.collateral_amount(100, 200), 10);
+	});
+}
+
+#[test]
+fn debit_auction_methods() {
+	ExtBuilder::default().build().execute_with(|| {
+		AuctionManagerModule::new_debit_auction(200, 100);
+		let debit_auction = AuctionManagerModule::debit_auctions(0).unwrap();
+		assert_eq!(debit_auction.amount_for_sale(0, 100), 200);
+		assert_eq!(debit_auction.amount_for_sale(100, 200), 100);
+		assert_eq!(debit_auction.amount_for_sale(200, 1000), 40);
+	});
+}
+
+#[test]
 fn new_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
@@ -55,74 +100,131 @@ fn new_surplus_auction_work() {
 }
 
 #[test]
-fn on_new_bid_for_collateral_auction_which_target_more_than_zero_work() {
+fn collateral_auction_bid_handler_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_noop!(
+			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 4), None),
+			Error::<Runtime>::AuctionNotExists,
+		);
+
+		assert_ok!(CDPTreasuryModule::deposit_collateral(&ALICE, BTC, 10));
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 4), None).accept_bid, false);
-		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 5), None).accept_bid, true);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 995);
-		assert_eq!(CDPTreasuryModule::surplus_pool(), 5);
+		assert_eq!(System::refs(&BOB), 0);
+
+		assert_noop!(
+			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 4), None),
+			Error::<Runtime>::InvalidBidPrice,
+		);
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 10), Some((BOB, 5))).accept_bid,
+			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 5), None).is_ok(),
 			true
 		);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 5);
+		assert_eq!(Tokens::free_balance(AUSD, &BOB), 995);
+		assert_eq!(System::refs(&BOB), 1);
+		assert_eq!(System::refs(&CAROL), 0);
+
+		assert_eq!(
+			AuctionManagerModule::collateral_auction_bid_handler(2, 0, (CAROL, 10), Some((BOB, 5))).is_ok(),
+			true
+		);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 10);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &CAROL), 990);
-		assert_eq!(CDPTreasuryModule::surplus_pool(), 10);
+		assert_eq!(System::refs(&BOB), 0);
+		assert_eq!(System::refs(&CAROL), 1);
+		assert_eq!(AuctionManagerModule::collateral_auctions(0).unwrap().amount, 10);
+
+		assert_eq!(
+			AuctionManagerModule::collateral_auction_bid_handler(3, 0, (BOB, 200), Some((CAROL, 10))).is_ok(),
+			true
+		);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
+		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
+		assert_eq!(Tokens::free_balance(AUSD, &CAROL), 1000);
+		assert_eq!(System::refs(&BOB), 1);
+		assert_eq!(System::refs(&CAROL), 0);
+		assert_eq!(AuctionManagerModule::collateral_auctions(0).unwrap().amount, 5);
 	});
 }
 
 #[test]
-fn on_new_bid_for_debit_auction_work() {
+fn debit_auction_bid_handler_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_noop!(
+			AuctionManagerModule::debit_auction_bid_handler(1, 0, (BOB, 99), None),
+			Error::<Runtime>::AuctionNotExists,
+		);
+
 		AuctionManagerModule::new_debit_auction(200, 100);
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 0, (BOB, 99), None).accept_bid,
-			false
+		assert_eq!(System::refs(&BOB), 0);
+
+		assert_noop!(
+			AuctionManagerModule::debit_auction_bid_handler(1, 0, (BOB, 99), None),
+			Error::<Runtime>::InvalidBidPrice,
 		);
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 0, (BOB, 100), None).accept_bid,
+			AuctionManagerModule::debit_auction_bid_handler(1, 0, (BOB, 100), None).is_ok(),
 			true
 		);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
+		assert_eq!(System::refs(&BOB), 1);
+		assert_eq!(System::refs(&CAROL), 0);
+
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 200), Some((BOB, 100))).accept_bid,
+			AuctionManagerModule::debit_auction_bid_handler(2, 0, (CAROL, 200), Some((BOB, 100))).is_ok(),
 			true
 		);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 100);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &CAROL), 900);
+		assert_eq!(System::refs(&BOB), 0);
+		assert_eq!(System::refs(&CAROL), 1);
 	});
 }
 
 #[test]
-fn on_new_bid_for_surplus_auction_work() {
+fn surplus_auction_bid_handler_work() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_noop!(
+			AuctionManagerModule::surplus_auction_bid_handler(1, 0, (BOB, 99), None),
+			Error::<Runtime>::AuctionNotExists,
+		);
+
 		AuctionManagerModule::new_surplus_auction(100);
-		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
-		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 0), None).accept_bid, false);
-		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 50), None).accept_bid, true);
-		assert_eq!(Tokens::free_balance(ACA, &BOB), 950);
+		assert_eq!(System::refs(&BOB), 0);
+
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 51), Some((BOB, 50))).accept_bid,
-			false
+			AuctionManagerModule::surplus_auction_bid_handler(1, 0, (BOB, 50), None).is_ok(),
+			true
+		);
+		assert_eq!(Tokens::free_balance(ACA, &BOB), 950);
+		assert_eq!(Tokens::free_balance(ACA, &CAROL), 1000);
+		assert_eq!(System::refs(&BOB), 1);
+		assert_eq!(System::refs(&CAROL), 0);
+
+		assert_noop!(
+			AuctionManagerModule::surplus_auction_bid_handler(2, 0, (CAROL, 51), Some((BOB, 50))),
+			Error::<Runtime>::InvalidBidPrice,
 		);
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(2, 0, (CAROL, 55), Some((BOB, 50))).accept_bid,
+			AuctionManagerModule::surplus_auction_bid_handler(2, 0, (CAROL, 55), Some((BOB, 50))).is_ok(),
 			true
 		);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(ACA, &CAROL), 945);
+		assert_eq!(System::refs(&BOB), 0);
+		assert_eq!(System::refs(&CAROL), 1);
 	});
 }
 
@@ -184,66 +286,94 @@ fn bid_when_soft_cap_for_surplus_auction_work() {
 }
 
 #[test]
-fn reverse_collateral_auction_which_target_more_than_zero_work() {
+fn collateral_auction_end_handler_without_bid() {
 	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
+		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
-		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1000);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_eq!(System::refs(&ALICE), 1);
+
+		AuctionManagerModule::collateral_auction_end_handler(0, None);
+		let auction_passed_event = TestEvent::auction_manager(RawEvent::CancelAuction(0));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == auction_passed_event));
+
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
+		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
+		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
+		assert_eq!(System::refs(&ALICE), 0);
+	});
+}
+
+#[test]
+fn collateral_auction_end_handler_in_reverse_stage() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
+		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 0, (BOB, 200), None).accept_bid,
-			true
-		);
-		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
-		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1000);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
-		assert_eq!(CDPTreasuryModule::surplus_pool(), 200);
-		assert_eq!(
-			AuctionManagerModule::on_new_bid(2, 0, (BOB, 400), Some((BOB, 200))).accept_bid,
+			AuctionManagerModule::collateral_auction_bid_handler(2, 0, (BOB, 400), None).is_ok(),
 			true
 		);
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 50);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 50);
 		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1050);
+		assert_eq!(Tokens::free_balance(BTC, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 200);
+		assert_eq!(System::refs(&ALICE), 1);
+		assert_eq!(System::refs(&BOB), 1);
+
+		AuctionManagerModule::collateral_auction_end_handler(0, Some((BOB, 400)));
+		let auction_dealt_event = TestEvent::auction_manager(RawEvent::CollateralAuctionDealt(0, BTC, 50, BOB, 200));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == auction_dealt_event));
+
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
+		assert_eq!(Tokens::free_balance(BTC, &ALICE), 1050);
+		assert_eq!(Tokens::free_balance(BTC, &BOB), 1050);
+		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 200);
+		assert_eq!(System::refs(&ALICE), 0);
+		assert_eq!(System::refs(&BOB), 0);
 	});
 }
 
 #[test]
-fn on_auction_ended_for_collateral_auction_which_target_more_than_zero_by_dealing() {
+fn collateral_auction_end_handler_by_dealing_which_target_not_zero() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_eq!(
+			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 100), None).is_ok(),
+			true
+		);
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
 		assert_eq!(Tokens::free_balance(BTC, &BOB), 1000);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 100);
 		assert_eq!(System::refs(&ALICE), 1);
-
-		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 0, (BOB, 200), None).accept_bid,
-			true
-		);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 800);
 		assert_eq!(System::refs(&BOB), 1);
 
-		AuctionManagerModule::on_auction_ended(0, Some((BOB, 200)));
-		let collateral_auction_deal_event =
-			TestEvent::auction_manager(RawEvent::CollateralAuctionDealt(0, BTC, 100, BOB, 200));
+		AuctionManagerModule::collateral_auction_end_handler(0, Some((BOB, 100)));
+		let auction_dealt_event = TestEvent::auction_manager(RawEvent::CollateralAuctionDealt(0, BTC, 100, BOB, 100));
 		assert!(System::events()
 			.iter()
-			.any(|record| record.event == collateral_auction_deal_event));
+			.any(|record| record.event == auction_dealt_event));
 
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
-		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
 		assert_eq!(Tokens::free_balance(BTC, &BOB), 1100);
 		assert_eq!(System::refs(&BOB), 0);
 		assert_eq!(System::refs(&ALICE), 0);
@@ -251,36 +381,39 @@ fn on_auction_ended_for_collateral_auction_which_target_more_than_zero_by_dealin
 }
 
 #[test]
-fn on_auction_ended_for_collateral_auction_which_target_more_than_zero_by_dex() {
+fn collateral_auction_end_handler_by_dex_which_target_not_zero() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
-		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
-		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
-		assert_eq!(System::refs(&ALICE), 1);
-
-		assert_eq!(AuctionManagerModule::on_new_bid(1, 0, (BOB, 20), None).accept_bid, true);
+		assert_eq!(
+			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 20), None).is_ok(),
+			true
+		);
 		assert_ok!(DEXModule::add_liquidity(Origin::signed(CAROL), BTC, 100, 1000));
 		assert_eq!(DEXModule::get_target_amount(BTC, AUSD, 100), 500);
+
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
+		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
+		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
 		assert_eq!(Tokens::free_balance(BTC, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 980);
 		assert_eq!(Tokens::free_balance(AUSD, &ALICE), 1000);
 		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 20);
+		assert_eq!(System::refs(&ALICE), 1);
 		assert_eq!(System::refs(&BOB), 1);
 
-		AuctionManagerModule::on_auction_ended(0, Some((BOB, 20)));
+		AuctionManagerModule::collateral_auction_end_handler(0, Some((BOB, 20)));
 		let dex_take_collateral_auction =
 			TestEvent::auction_manager(RawEvent::DEXTakeCollateralAuction(0, BTC, 100, 500));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == dex_take_collateral_auction));
 
-		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
-		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_eq!(AuctionManagerModule::total_target_in_auction(), 0);
+		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 0);
 		assert_eq!(Tokens::free_balance(BTC, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(AUSD, &ALICE), 1300);
@@ -292,26 +425,38 @@ fn on_auction_ended_for_collateral_auction_which_target_more_than_zero_by_dex() 
 }
 
 #[test]
-fn on_auction_ended_for_debit_auction_work() {
+fn debit_auction_end_handler_without_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_debit_auction(200, 100);
+		AuctionManagerModule::new_debit_auction(300, 100);
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(Tokens::total_issuance(ACA), 3000);
-		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
-		AuctionManagerModule::on_auction_ended(0, None);
-		assert_eq!(AuctionManagerModule::debit_auctions(1).unwrap().amount, 300);
+
+		AuctionManagerModule::debit_auction_end_handler(0, None);
+		let auction_passed_event = TestEvent::auction_manager(RawEvent::CancelAuction(0));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == auction_passed_event));
+
+		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 0);
+	});
+}
+
+#[test]
+fn debit_auction_end_handler_with_bid() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		AuctionManagerModule::new_debit_auction(300, 100);
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 1, (BOB, 100), None).accept_bid,
+			AuctionManagerModule::debit_auction_bid_handler(1, 0, (BOB, 100), None).is_ok(),
 			true
 		);
+		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
 		assert_eq!(System::refs(&BOB), 1);
 
-		AuctionManagerModule::on_auction_ended(1, Some((BOB, 100)));
-		let debit_auction_deal_event = TestEvent::auction_manager(RawEvent::DebitAuctionDealt(1, 300, BOB, 100));
+		AuctionManagerModule::debit_auction_end_handler(0, Some((BOB, 100)));
+		let debit_auction_deal_event = TestEvent::auction_manager(RawEvent::DebitAuctionDealt(0, 300, BOB, 100));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == debit_auction_deal_event));
@@ -324,35 +469,49 @@ fn on_auction_ended_for_debit_auction_work() {
 }
 
 #[test]
-fn on_auction_ended_for_surplus_auction_work() {
+fn surplus_auction_end_handler_without_bid() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		AuctionManagerModule::new_surplus_auction(100);
+		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
+
+		AuctionManagerModule::surplus_auction_end_handler(0, None);
+		let auction_passed_event = TestEvent::auction_manager(RawEvent::CancelAuction(0));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == auction_passed_event));
+
+		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 0);
+	});
+}
+
+#[test]
+fn surplus_auction_end_handler_with_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::on_system_surplus(100));
 		AuctionManagerModule::new_surplus_auction(100);
-		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
-		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
-		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
-		assert_eq!(Tokens::total_issuance(ACA), 3000);
-
 		assert_eq!(
-			AuctionManagerModule::on_new_bid(1, 0, (BOB, 500), None).accept_bid,
+			AuctionManagerModule::surplus_auction_bid_handler(1, 0, (BOB, 500), None).is_ok(),
 			true
 		);
+		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
+		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 500);
 		assert_eq!(Tokens::total_issuance(ACA), 2500);
 		assert_eq!(System::refs(&BOB), 1);
 
-		AuctionManagerModule::on_auction_ended(0, Some((BOB, 500)));
+		AuctionManagerModule::surplus_auction_end_handler(0, Some((BOB, 500)));
 		let surplus_auction_deal_event = TestEvent::auction_manager(RawEvent::SurplusAuctionDealt(0, 100, BOB, 500));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == surplus_auction_deal_event));
 
 		assert_eq!(CDPTreasuryModule::debit_pool(), 100);
-		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1100);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 0);
+		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1100);
+		assert_eq!(Tokens::total_issuance(ACA), 2500);
 		assert_eq!(System::refs(&BOB), 0);
 	});
 }
@@ -365,11 +524,12 @@ fn cancel_surplus_auction_work() {
 			AuctionManagerModule::cancel_surplus_auction(0),
 			Error::<Runtime>::AuctionNotExists
 		);
+
 		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 500));
 		assert_eq!(AuctionManagerModule::surplus_auctions(0).is_some(), true);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
 		assert_eq!(AuctionModule::auction_info(0).is_some(), true);
-		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 500));
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 500);
 		assert_eq!(System::refs(&BOB), 1);
 
@@ -397,9 +557,9 @@ fn cancel_debit_auction_work() {
 			Error::<Runtime>::AuctionNotExists
 		);
 		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 100));
 		assert_eq!(AuctionManagerModule::debit_auctions(0).is_some(), true);
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
-		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 100));
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 900);
 		assert_eq!(System::refs(&BOB), 1);
 
@@ -415,43 +575,6 @@ fn cancel_debit_auction_work() {
 		assert_eq!(AuctionModule::auction_info(0).is_some(), false);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(System::refs(&BOB), 0);
-	});
-}
-
-#[test]
-fn collateral_auction_methods() {
-	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
-		let collateral_auction_with_positive_target = AuctionManagerModule::collateral_auctions(0).unwrap();
-		assert_eq!(collateral_auction_with_positive_target.always_forward(), false);
-		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(99), false);
-		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(100), true);
-		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(101), true);
-		assert_eq!(collateral_auction_with_positive_target.payment_amount(99), 99);
-		assert_eq!(collateral_auction_with_positive_target.payment_amount(100), 100);
-		assert_eq!(collateral_auction_with_positive_target.payment_amount(101), 100);
-		assert_eq!(collateral_auction_with_positive_target.collateral_amount(80, 100), 10);
-		assert_eq!(collateral_auction_with_positive_target.collateral_amount(100, 200), 5);
-
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0);
-		let collateral_auction_with_zero_target = AuctionManagerModule::collateral_auctions(1).unwrap();
-		assert_eq!(collateral_auction_with_zero_target.always_forward(), true);
-		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(0), false);
-		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(100), false);
-		assert_eq!(collateral_auction_with_zero_target.payment_amount(99), 99);
-		assert_eq!(collateral_auction_with_zero_target.payment_amount(101), 101);
-		assert_eq!(collateral_auction_with_zero_target.collateral_amount(100, 200), 10);
-	});
-}
-
-#[test]
-fn debit_auction_methods() {
-	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_debit_auction(200, 100);
-		let debit_auction = AuctionManagerModule::debit_auctions(0).unwrap();
-		assert_eq!(debit_auction.amount_for_sale(0, 100), 200);
-		assert_eq!(debit_auction.amount_for_sale(100, 200), 100);
-		assert_eq!(debit_auction.amount_for_sale(200, 1000), 40);
 	});
 }
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -752,7 +752,6 @@ parameter_types! {
 	pub MinimumIncrementSize: Rate = Rate::saturating_from_rational(2, 100);
 	pub const AuctionTimeToClose: BlockNumber = 15 * MINUTES;
 	pub const AuctionDurationSoftCap: BlockNumber = 2 * HOURS;
-	pub GetAmountAdjustment: Rate = Rate::saturating_from_rational(20, 100);
 	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
@@ -766,7 +765,6 @@ impl module_auction_manager::Trait for Runtime {
 	type GetStableCurrencyId = GetStableCurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type CDPTreasury = CdpTreasury;
-	type GetAmountAdjustment = GetAmountAdjustment;
 	type DEX = Dex;
 	type PriceSource = Prices;
 	type UnsignedPriority = AuctionManagerUnsignedPriority;


### PR DESCRIPTION
1. Although set the auction end time to `None` when create collateral auction and surplus auction, the end handlers shouldn't not ignore the case that there is no bidder but the auction ends, the auction item should be removed correctly.

2. When auction passed(ends without bidder), cancel auction directly instead of relisting it.