### PR TITLE
refactor cdp treasury

### DIFF
--- a/modules/auction_manager/benchmarking/src/lib.rs
+++ b/modules/auction_manager/benchmarking/src/lib.rs
@@ -56,7 +56,7 @@ benchmarks! {
 		<T as auction_manager::Trait>::Currency::deposit(native_currency_id, &bidder, dollar(10))?;
 
 		// create surplus auction
-		AuctionManager::<T>::new_surplus_auction(dollar(1));
+		AuctionManager::<T>::new_surplus_auction(dollar(1))?;
 		let auction_id: AuctionId = Default::default();
 
 		// bid surplus auction
@@ -78,7 +78,7 @@ benchmarks! {
 		<T as auction_manager::Trait>::Currency::deposit(stable_currency_id, &bidder, dollar(20))?;
 
 		// create debit auction
-		AuctionManager::<T>::new_debit_auction(dollar(1), dollar(10));
+		AuctionManager::<T>::new_debit_auction(dollar(1), dollar(10))?;
 		let auction_id: AuctionId = Default::default();
 
 		// bid debit auction
@@ -106,7 +106,7 @@ benchmarks! {
 		feed_price::<T>(CurrencyId::DOT, Price::saturating_from_integer(120))?;
 
 		// create collateral auction
-		AuctionManager::<T>::new_collateral_auction(&funder, CurrencyId::DOT, dollar(1), dollar(100));
+		AuctionManager::<T>::new_collateral_auction(&funder, CurrencyId::DOT, dollar(1), dollar(100))?;
 		let auction_id: AuctionId = Default::default();
 
 		// bid collateral auction

--- a/modules/auction_manager/benchmarking/src/mock.rs
+++ b/modules/auction_manager/benchmarking/src/mock.rs
@@ -167,7 +167,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = ();
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = EmergencyShutdownModule;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -228,6 +228,8 @@ decl_error! {
 		MustAfterShutdown,
 		/// Bid price is invalid
 		InvalidBidPrice,
+		/// Invalid input amount
+		InvalidAmount,
 	}
 }
 
@@ -903,64 +905,77 @@ impl<T: Trait> AuctionManager<T::AccountId> for Module<T> {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-	) {
-		if let (Some(new_total_collateral), Some(new_total_target)) = (
-			Self::total_collateral_in_auction(currency_id).checked_add(amount),
-			Self::total_target_in_auction().checked_add(target),
-		) {
-			TotalCollateralInAuction::insert(currency_id, new_total_collateral);
-			TotalTargetInAuction::put(new_total_target);
+	) -> DispatchResult {
+		ensure!(!amount.is_zero(), Error::<T>::InvalidAmount,);
+		TotalCollateralInAuction::try_mutate(currency_id, |total| -> DispatchResult {
+			*total = total.checked_add(amount).ok_or(Error::<T>::InvalidAmount)?;
+			Ok(())
+		})?;
+		TotalTargetInAuction::try_mutate(|total| -> DispatchResult {
+			*total = total.checked_add(target).ok_or(Error::<T>::InvalidAmount)?;
+			Ok(())
+		})?;
 
-			let block_number = <system::Module<T>>::block_number();
-			let auction_id: AuctionId = T::Auction::new_auction(block_number, None)
-				.expect("AuctionId is sufficient large so this can never fail"); // do not set end time for collateral auction
-			let collateral_auction = CollateralAuctionItem {
-				refund_recipient: who.clone(),
-				currency_id,
-				amount,
-				target,
-				start_time: block_number,
-			};
+		let block_number = <system::Module<T>>::block_number();
+		let auction_id: AuctionId =
+			T::Auction::new_auction(block_number, None).expect("AuctionId is sufficient large so this can never fail"); // do not set end time for collateral auction
+		let collateral_auction = CollateralAuctionItem {
+			refund_recipient: who.clone(),
+			currency_id,
+			amount,
+			target,
+			start_time: block_number,
+		};
 
-			// increase account ref of refund recipient
-			system::Module::<T>::inc_ref(&who);
+		// increase account ref of refund recipient
+		system::Module::<T>::inc_ref(&who);
 
-			<CollateralAuctions<T>>::insert(auction_id, collateral_auction);
-			<Module<T>>::deposit_event(RawEvent::NewCollateralAuction(auction_id, currency_id, amount, target));
-		}
+		<CollateralAuctions<T>>::insert(auction_id, collateral_auction);
+		<Module<T>>::deposit_event(RawEvent::NewCollateralAuction(auction_id, currency_id, amount, target));
+		Ok(())
 	}
 
-	fn new_debit_auction(initial_amount: Self::Balance, fix_debit: Self::Balance) {
-		if let Some(new_total_debit) = Self::total_debit_in_auction().checked_add(fix_debit) {
-			TotalDebitInAuction::put(new_total_debit);
-			let start_block = <system::Module<T>>::block_number();
-			let end_block = start_block + T::AuctionTimeToClose::get();
-			// set close time for initial debit auction
-			let auction_id: AuctionId = T::Auction::new_auction(start_block, Some(end_block))
-				.expect("AuctionId is sufficient large so this can never fail");
-			let debit_auction = DebitAuctionItem {
-				amount: initial_amount,
-				fix: fix_debit,
-				start_time: start_block,
-			};
-			<DebitAuctions<T>>::insert(auction_id, debit_auction);
-			<Module<T>>::deposit_event(RawEvent::NewDebitAuction(auction_id, initial_amount, fix_debit));
-		}
+	fn new_debit_auction(initial_amount: Self::Balance, fix_debit: Self::Balance) -> DispatchResult {
+		ensure!(
+			!initial_amount.is_zero() && !fix_debit.is_zero(),
+			Error::<T>::InvalidAmount,
+		);
+		TotalDebitInAuction::try_mutate(|total| -> DispatchResult {
+			*total = total.checked_add(fix_debit).ok_or(Error::<T>::InvalidAmount)?;
+			Ok(())
+		})?;
+
+		let start_block = <system::Module<T>>::block_number();
+		let end_block = start_block + T::AuctionTimeToClose::get();
+		let auction_id: AuctionId = T::Auction::new_auction(start_block, Some(end_block))
+			.expect("AuctionId is sufficient large so this can never fail"); // set end time for debit auction
+		let debit_auction = DebitAuctionItem {
+			amount: initial_amount,
+			fix: fix_debit,
+			start_time: start_block,
+		};
+
+		<DebitAuctions<T>>::insert(auction_id, debit_auction);
+		<Module<T>>::deposit_event(RawEvent::NewDebitAuction(auction_id, initial_amount, fix_debit));
+		Ok(())
 	}
 
-	fn new_surplus_auction(amount: Self::Balance) {
-		if let Some(new_total_surplus) = Self::total_surplus_in_auction().checked_add(amount) {
-			TotalSurplusInAuction::put(new_total_surplus);
-			// do not set end time for surplus auction
-			let auction_id: AuctionId = T::Auction::new_auction(<system::Module<T>>::block_number(), None)
-				.expect("AuctionId is sufficient large so this can never fail");
-			let surplus_auction = SurplusAuctionItem {
-				amount,
-				start_time: <system::Module<T>>::block_number(),
-			};
-			<SurplusAuctions<T>>::insert(auction_id, surplus_auction);
-			<Module<T>>::deposit_event(RawEvent::NewSurplusAuction(auction_id, amount));
-		}
+	fn new_surplus_auction(amount: Self::Balance) -> DispatchResult {
+		ensure!(!amount.is_zero(), Error::<T>::InvalidAmount,);
+		TotalSurplusInAuction::try_mutate(|total| -> DispatchResult {
+			*total = total.checked_add(amount).ok_or(Error::<T>::InvalidAmount)?;
+			Ok(())
+		})?;
+
+		let auction_id: AuctionId = T::Auction::new_auction(<system::Module<T>>::block_number(), None)
+			.expect("AuctionId is sufficient large so this can never fail"); // do not set end time for surplus auction
+		let surplus_auction = SurplusAuctionItem {
+			amount,
+			start_time: <system::Module<T>>::block_number(),
+		};
+		<SurplusAuctions<T>>::insert(auction_id, surplus_auction);
+		<Module<T>>::deposit_event(RawEvent::NewSurplusAuction(auction_id, amount));
+		Ok(())
 	}
 
 	fn get_total_debit_in_auction() -> Self::Balance {

--- a/modules/auction_manager/src/mock.rs
+++ b/modules/auction_manager/src/mock.rs
@@ -127,7 +127,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = DEXModule;
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/auction_manager/src/tests.rs
+++ b/modules/auction_manager/src/tests.rs
@@ -17,7 +17,7 @@ fn get_auction_time_to_close_work() {
 #[test]
 fn collateral_auction_methods() {
 	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		let collateral_auction_with_positive_target = AuctionManagerModule::collateral_auctions(0).unwrap();
 		assert_eq!(collateral_auction_with_positive_target.always_forward(), false);
 		assert_eq!(collateral_auction_with_positive_target.in_reverse_stage(99), false);
@@ -29,7 +29,7 @@ fn collateral_auction_methods() {
 		assert_eq!(collateral_auction_with_positive_target.collateral_amount(80, 100), 10);
 		assert_eq!(collateral_auction_with_positive_target.collateral_amount(100, 200), 5);
 
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 0));
 		let collateral_auction_with_zero_target = AuctionManagerModule::collateral_auctions(1).unwrap();
 		assert_eq!(collateral_auction_with_zero_target.always_forward(), true);
 		assert_eq!(collateral_auction_with_zero_target.in_reverse_stage(0), false);
@@ -43,7 +43,7 @@ fn collateral_auction_methods() {
 #[test]
 fn debit_auction_methods() {
 	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(200, 100));
 		let debit_auction = AuctionManagerModule::debit_auctions(0).unwrap();
 		assert_eq!(debit_auction.amount_for_sale(0, 100), 200);
 		assert_eq!(debit_auction.amount_for_sale(100, 200), 100);
@@ -56,7 +56,12 @@ fn new_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(System::refs(&ALICE), 0);
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_noop!(
+			AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 0, 100),
+			Error::<Runtime>::InvalidAmount,
+		);
+
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		let new_collateral_auction_event = TestEvent::auction_manager(RawEvent::NewCollateralAuction(0, BTC, 10, 100));
 		assert!(System::events()
 			.iter()
@@ -66,6 +71,11 @@ fn new_collateral_auction_work() {
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 100);
 		assert_eq!(AuctionModule::auctions_index(), 1);
 		assert_eq!(System::refs(&ALICE), 1);
+
+		assert_noop!(
+			AuctionManagerModule::new_collateral_auction(&ALICE, BTC, Balance::max_value(), Balance::max_value()),
+			Error::<Runtime>::InvalidAmount,
+		);
 	});
 }
 
@@ -73,7 +83,16 @@ fn new_collateral_auction_work() {
 fn new_debit_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_noop!(
+			AuctionManagerModule::new_debit_auction(0, 100),
+			Error::<Runtime>::InvalidAmount,
+		);
+		assert_noop!(
+			AuctionManagerModule::new_debit_auction(200, 0),
+			Error::<Runtime>::InvalidAmount,
+		);
+
+		assert_ok!(AuctionManagerModule::new_debit_auction(200, 100));
 		let new_debit_auction_event = TestEvent::auction_manager(RawEvent::NewDebitAuction(0, 200, 100));
 		assert!(System::events()
 			.iter()
@@ -81,6 +100,11 @@ fn new_debit_auction_work() {
 
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 		assert_eq!(AuctionModule::auctions_index(), 1);
+
+		assert_noop!(
+			AuctionManagerModule::new_debit_auction(200, Balance::max_value()),
+			Error::<Runtime>::InvalidAmount,
+		);
 	});
 }
 
@@ -88,7 +112,12 @@ fn new_debit_auction_work() {
 fn new_surplus_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_noop!(
+			AuctionManagerModule::new_surplus_auction(0),
+			Error::<Runtime>::InvalidAmount,
+		);
+
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		let new_surplus_auction_event = TestEvent::auction_manager(RawEvent::NewSurplusAuction(0, 100));
 		assert!(System::events()
 			.iter()
@@ -96,6 +125,11 @@ fn new_surplus_auction_work() {
 
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
 		assert_eq!(AuctionModule::auctions_index(), 1);
+
+		assert_noop!(
+			AuctionManagerModule::new_surplus_auction(Balance::max_value()),
+			Error::<Runtime>::InvalidAmount,
+		);
 	});
 }
 
@@ -108,7 +142,7 @@ fn collateral_auction_bid_handler_work() {
 		);
 
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&ALICE, BTC, 10));
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
 		assert_eq!(Tokens::free_balance(AUSD, &BOB), 1000);
 		assert_eq!(System::refs(&BOB), 0);
@@ -158,7 +192,7 @@ fn debit_auction_bid_handler_work() {
 			Error::<Runtime>::AuctionNotExists,
 		);
 
-		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(200, 100));
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 		assert_eq!(AuctionManagerModule::debit_auctions(0).unwrap().amount, 200);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
@@ -200,7 +234,7 @@ fn surplus_auction_bid_handler_work() {
 			Error::<Runtime>::AuctionNotExists,
 		);
 
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		assert_eq!(Tokens::free_balance(ACA, &BOB), 1000);
 		assert_eq!(System::refs(&BOB), 0);
 
@@ -231,7 +265,7 @@ fn surplus_auction_bid_handler_work() {
 #[test]
 fn bid_when_soft_cap_for_collateral_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 100), None).auction_end_change,
 			Change::NewValue(Some(101))
@@ -250,7 +284,7 @@ fn bid_when_soft_cap_for_collateral_auction_work() {
 #[test]
 fn bid_when_soft_cap_for_debit_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(200, 100));
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 100), None).auction_end_change,
 			Change::NewValue(Some(101))
@@ -269,7 +303,7 @@ fn bid_when_soft_cap_for_debit_auction_work() {
 #[test]
 fn bid_when_soft_cap_for_surplus_auction_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		assert_eq!(
 			AuctionManagerModule::on_new_bid(1, 0, (BOB, 100), None).auction_end_change,
 			Change::NewValue(Some(101))
@@ -290,7 +324,7 @@ fn collateral_auction_end_handler_without_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200));
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 100);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 200);
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 100);
@@ -314,7 +348,7 @@ fn collateral_auction_end_handler_in_reverse_stage() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200));
 		assert_eq!(
 			AuctionManagerModule::collateral_auction_bid_handler(2, 0, (BOB, 400), None).is_ok(),
 			true
@@ -350,7 +384,7 @@ fn collateral_auction_end_handler_by_dealing_which_target_not_zero() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200));
 		assert_eq!(
 			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 100), None).is_ok(),
 			true
@@ -385,7 +419,7 @@ fn collateral_auction_end_handler_by_dex_which_target_not_zero() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 100));
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 100, 200));
 		assert_eq!(
 			AuctionManagerModule::collateral_auction_bid_handler(1, 0, (BOB, 20), None).is_ok(),
 			true
@@ -428,7 +462,7 @@ fn collateral_auction_end_handler_by_dex_which_target_not_zero() {
 fn debit_auction_end_handler_without_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_debit_auction(300, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(300, 100));
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
 
 		AuctionManagerModule::debit_auction_end_handler(0, None);
@@ -445,7 +479,7 @@ fn debit_auction_end_handler_without_bid() {
 fn debit_auction_end_handler_with_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_debit_auction(300, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(300, 100));
 		assert_eq!(
 			AuctionManagerModule::debit_auction_bid_handler(1, 0, (BOB, 100), None).is_ok(),
 			true
@@ -472,7 +506,7 @@ fn debit_auction_end_handler_with_bid() {
 fn surplus_auction_end_handler_without_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
 
 		AuctionManagerModule::surplus_auction_end_handler(0, None);
@@ -490,7 +524,7 @@ fn surplus_auction_end_handler_with_bid() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::on_system_surplus(100));
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		assert_eq!(
 			AuctionManagerModule::surplus_auction_bid_handler(1, 0, (BOB, 500), None).is_ok(),
 			true
@@ -525,7 +559,7 @@ fn cancel_surplus_auction_work() {
 			Error::<Runtime>::AuctionNotExists
 		);
 
-		AuctionManagerModule::new_surplus_auction(100);
+		assert_ok!(AuctionManagerModule::new_surplus_auction(100));
 		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 500));
 		assert_eq!(AuctionManagerModule::surplus_auctions(0).is_some(), true);
 		assert_eq!(AuctionManagerModule::total_surplus_in_auction(), 100);
@@ -556,7 +590,7 @@ fn cancel_debit_auction_work() {
 			AuctionManagerModule::cancel_debit_auction(0),
 			Error::<Runtime>::AuctionNotExists
 		);
-		AuctionManagerModule::new_debit_auction(200, 100);
+		assert_ok!(AuctionManagerModule::new_debit_auction(200, 100));
 		assert_ok!(AuctionModule::bid(Origin::signed(BOB), 0, 100));
 		assert_eq!(AuctionManagerModule::debit_auctions(0).is_some(), true);
 		assert_eq!(AuctionManagerModule::total_debit_in_auction(), 100);
@@ -586,7 +620,7 @@ fn cancel_collateral_auction_failed() {
 			AuctionManagerModule::cancel_collateral_auction(0),
 			Error::<Runtime>::AuctionNotExists
 		);
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		assert_ok!(AuctionModule::bid(Origin::signed(ALICE), 0, 100));
 		let collateral_auction = AuctionManagerModule::collateral_auctions(0).unwrap();
 		assert_eq!(collateral_auction.always_forward(), false);
@@ -605,7 +639,7 @@ fn cancel_collateral_auction_work() {
 		System::set_block_number(1);
 		assert_ok!(CDPTreasuryModule::deposit_collateral(&CAROL, BTC, 10));
 		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
-		AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100);
+		assert_ok!(AuctionManagerModule::new_collateral_auction(&ALICE, BTC, 10, 100));
 		assert_eq!(AuctionManagerModule::total_collateral_in_auction(BTC), 10);
 		assert_eq!(AuctionManagerModule::total_target_in_auction(), 100);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);

--- a/modules/cdp_engine/benchmarking/src/mock.rs
+++ b/modules/cdp_engine/benchmarking/src/mock.rs
@@ -129,12 +129,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())

--- a/modules/cdp_engine/src/lib.rs
+++ b/modules/cdp_engine/src/lib.rs
@@ -686,7 +686,8 @@ impl<T: Trait> Module<T> {
 					collateral,
 					target_stable_amount,
 					who.clone(),
-				);
+					true,
+				)?;
 			}
 		}
 

--- a/modules/cdp_engine/src/mock.rs
+++ b/modules/cdp_engine/src/mock.rs
@@ -174,12 +174,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())
@@ -217,7 +222,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = DEXModule;
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/cdp_treasury/src/benchmarking.rs
+++ b/modules/cdp_treasury/src/benchmarking.rs
@@ -15,10 +15,6 @@ pub fn dollar(d: u32) -> Balance {
 benchmarks! {
 	_ {}
 
-	set_debit_and_surplus_handle_params {
-		let u in 0 .. 1000;
-	}: _(RawOrigin::Root, Some(dollar(100)), Some(dollar(100)), Some(dollar(100)), Some(dollar(100)))
-
 	set_collateral_auction_maximum_size {
 		let u in 0 .. 1000;
 	}: _(RawOrigin::Root, CurrencyId::DOT, dollar(100))
@@ -29,13 +25,6 @@ mod tests {
 	use super::*;
 	use crate::mock::{ExtBuilder, Runtime};
 	use frame_support::assert_ok;
-
-	#[test]
-	fn set_debit_and_surplus_handle_params() {
-		ExtBuilder::default().build().execute_with(|| {
-			assert_ok!(test_benchmark_set_debit_and_surplus_handle_params::<Runtime>());
-		});
-	}
 
 	#[test]
 	fn set_collateral_auction_maximum_size() {

--- a/modules/cdp_treasury/src/mock.rs
+++ b/modules/cdp_treasury/src/mock.rs
@@ -8,7 +8,7 @@ use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 use sp_std::cell::RefCell;
-use support::Rate;
+use support::{EmergencyShutdown, Rate};
 
 pub type AccountId = u128;
 pub type BlockNumber = u64;
@@ -155,16 +155,19 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
 		TOTAL_COLLATERAL_AUCTION.with(|v| *v.borrow_mut() += 1);
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
 		TOTAL_DEBIT_AUCTION.with(|v| *v.borrow_mut() += 1);
+		Ok(())
 	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
 		TOTAL_SURPLUS_AUCTION.with(|v| *v.borrow_mut() += 1);
+		Ok(())
 	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
@@ -201,10 +204,6 @@ thread_local! {
 	static IS_SHUTDOWN: RefCell<bool> = RefCell::new(false);
 }
 
-pub fn mock_shutdown() {
-	IS_SHUTDOWN.with(|v| *v.borrow_mut() = true)
-}
-
 pub struct MockEmergencyShutdown;
 impl EmergencyShutdown for MockEmergencyShutdown {
 	fn is_shutdown() -> bool {
@@ -221,7 +220,6 @@ impl Trait for Runtime {
 	type DEX = DEXModule;
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = Module<Runtime>;
 

--- a/modules/cdp_treasury/src/tests.rs
+++ b/modules/cdp_treasury/src/tests.rs
@@ -8,68 +8,24 @@ use mock::*;
 use sp_runtime::traits::BadOrigin;
 
 #[test]
-fn set_collateral_auction_maximum_size_work() {
+fn surplus_pool_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		System::set_block_number(1);
-		assert_eq!(CDPTreasuryModule::collateral_auction_maximum_size(BTC), 0);
-		assert_noop!(
-			CDPTreasuryModule::set_collateral_auction_maximum_size(Origin::signed(5), BTC, 200),
-			BadOrigin
-		);
-		assert_ok!(CDPTreasuryModule::set_collateral_auction_maximum_size(
-			Origin::signed(1),
-			BTC,
-			200
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
+		assert_ok!(Currencies::deposit(
+			GetStableCurrencyId::get(),
+			&CDPTreasuryModule::account_id(),
+			500
 		));
-
-		let update_collateral_auction_maximum_size_event =
-			TestEvent::cdp_treasury(Event::CollateralAuctionMaximumSizeUpdated(BTC, 200));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == update_collateral_auction_maximum_size_event));
+		assert_eq!(CDPTreasuryModule::surplus_pool(), 500);
 	});
 }
 
 #[test]
-fn set_debit_and_surplus_handle_params_work() {
+fn total_collaterals_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		System::set_block_number(1);
-		assert_noop!(
-			CDPTreasuryModule::set_debit_and_surplus_handle_params(
-				Origin::signed(5),
-				Some(100),
-				Some(1000),
-				Some(200),
-				Some(100),
-			),
-			BadOrigin
-		);
-		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::signed(1),
-			Some(100),
-			Some(1000),
-			Some(200),
-			Some(100),
-		));
-
-		let update_surplus_auction_fixed_size_event =
-			TestEvent::cdp_treasury(Event::SurplusAuctionFixedSizeUpdated(100));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == update_surplus_auction_fixed_size_event));
-		let update_surplus_buffer_size_event = TestEvent::cdp_treasury(Event::SurplusBufferSizeUpdated(1000));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == update_surplus_buffer_size_event));
-		let update_initial_amount_per_debit_auction_event =
-			TestEvent::cdp_treasury(Event::InitialAmountPerDebitAuctionUpdated(200));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == update_initial_amount_per_debit_auction_event));
-		let update_debit_auction_fixed_size_event = TestEvent::cdp_treasury(Event::DebitAuctionFixedSizeUpdated(100));
-		assert!(System::events()
-			.iter()
-			.any(|record| record.event == update_debit_auction_fixed_size_event));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 0);
+		assert_ok!(Currencies::deposit(BTC, &CDPTreasuryModule::account_id(), 10));
+		assert_eq!(CDPTreasuryModule::total_collaterals(BTC), 10);
 	});
 }
 
@@ -79,6 +35,10 @@ fn on_system_debit_work() {
 		assert_eq!(CDPTreasuryModule::debit_pool(), 0);
 		assert_ok!(CDPTreasuryModule::on_system_debit(1000));
 		assert_eq!(CDPTreasuryModule::debit_pool(), 1000);
+		assert_noop!(
+			CDPTreasuryModule::on_system_debit(Balance::max_value()),
+			Error::<Runtime>::DebitPoolOverflow,
+		);
 	});
 }
 
@@ -94,7 +54,7 @@ fn on_system_surplus_work() {
 }
 
 #[test]
-fn offset_debit_and_surplus_on_finalize_work() {
+fn offset_surplus_and_debit_on_finalize_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 0);
 		assert_eq!(CDPTreasuryModule::surplus_pool(), 0);
@@ -199,15 +159,6 @@ fn get_total_collaterals_work() {
 }
 
 #[test]
-fn get_surplus_pool_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
-		assert_eq!(CDPTreasuryModule::get_surplus_pool(), 1000);
-		assert_eq!(Currencies::free_balance(AUSD, &CDPTreasuryModule::account_id()), 1000);
-	});
-}
-
-#[test]
 fn get_debit_proportion_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(
@@ -240,9 +191,15 @@ fn create_collateral_auctions_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Currencies::deposit(BTC, &CDPTreasuryModule::account_id(), 10000));
 		assert_eq!(CDPTreasuryModule::collateral_auction_maximum_size(BTC), 0);
+		assert_noop!(
+			CDPTreasuryModule::create_collateral_auctions(BTC, 10001, 1000, ALICE, true),
+			Error::<Runtime>::CollateralNotEnough,
+		);
 
 		// without collateral auction maximum size
-		CDPTreasuryModule::create_collateral_auctions(BTC, 1000, 1000, ALICE);
+		assert_ok!(CDPTreasuryModule::create_collateral_auctions(
+			BTC, 1000, 1000, ALICE, true
+		));
 		assert_eq!(TOTAL_COLLATERAL_AUCTION.with(|v| *v.borrow_mut()), 1);
 
 		// set collateral auction maximum size
@@ -254,83 +211,76 @@ fn create_collateral_auctions_work() {
 
 		// amount < collateral auction maximum size
 		// auction + 1
-		CDPTreasuryModule::create_collateral_auctions(BTC, 200, 1000, ALICE);
+		assert_ok!(CDPTreasuryModule::create_collateral_auctions(
+			BTC, 200, 1000, ALICE, true
+		));
 		assert_eq!(TOTAL_COLLATERAL_AUCTION.with(|v| *v.borrow_mut()), 2);
 
 		// not exceed lots count cap
 		// auction + 4
-		CDPTreasuryModule::create_collateral_auctions(BTC, 1000, 1000, ALICE);
+		assert_ok!(CDPTreasuryModule::create_collateral_auctions(
+			BTC, 1000, 1000, ALICE, true
+		));
 		assert_eq!(TOTAL_COLLATERAL_AUCTION.with(|v| *v.borrow_mut()), 6);
 
 		// exceed lots count cap
 		// auction + 5
-		CDPTreasuryModule::create_collateral_auctions(BTC, 2000, 1000, ALICE);
+		assert_ok!(CDPTreasuryModule::create_collateral_auctions(
+			BTC, 2000, 1000, ALICE, true
+		));
 		assert_eq!(TOTAL_COLLATERAL_AUCTION.with(|v| *v.borrow_mut()), 11);
 	});
 }
 
 #[test]
-fn create_surplus_auction_when_on_finalize() {
+fn auction_surplus_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
-		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::signed(1),
-			Some(300),
-			None,
-			None,
-			None,
-		));
-
-		// not exceed lots cap
-		CDPTreasuryModule::on_finalize(1);
-		assert_eq!(TOTAL_SURPLUS_AUCTION.with(|v| *v.borrow_mut()), 3);
-
-		// exceed lots cap
-		assert_ok!(CDPTreasuryModule::on_system_surplus(2000));
-		CDPTreasuryModule::on_finalize(1);
-		assert_eq!(TOTAL_SURPLUS_AUCTION.with(|v| *v.borrow_mut()), 8);
-	});
-}
-
-#[test]
-fn create_debit_auction_when_on_finalize() {
-	ExtBuilder::default().build().execute_with(|| {
-		DebitPool::put(1000);
-		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::signed(1),
-			None,
-			None,
-			Some(100),
-			Some(300),
-		));
-
-		// not exceed lots cap
-		CDPTreasuryModule::on_finalize(1);
-		assert_eq!(TOTAL_DEBIT_AUCTION.with(|v| *v.borrow_mut()), 3);
-
-		// exceed lots cap
-		DebitPool::put(2000);
-		CDPTreasuryModule::on_finalize(1);
-		assert_eq!(TOTAL_DEBIT_AUCTION.with(|v| *v.borrow_mut()), 8);
-	});
-}
-
-#[test]
-fn no_new_surplus_or_debit_auctions_on_finalize_if_shutdown() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CDPTreasuryModule::on_system_surplus(1000));
-		DebitPool::put(1000);
-		assert_ok!(CDPTreasuryModule::set_debit_and_surplus_handle_params(
-			Origin::signed(1),
-			Some(300),
-			None,
-			Some(100),
-			Some(300),
-		));
-
-		mock_shutdown();
-		CDPTreasuryModule::on_finalize(1);
+		assert_noop!(CDPTreasuryModule::auction_surplus(Origin::signed(5), 100), BadOrigin,);
+		assert_noop!(
+			CDPTreasuryModule::auction_surplus(Origin::signed(1), 100),
+			Error::<Runtime>::SurplusPoolNotEnough,
+		);
+		assert_ok!(CDPTreasuryModule::on_system_surplus(100));
 		assert_eq!(TOTAL_SURPLUS_AUCTION.with(|v| *v.borrow_mut()), 0);
+		assert_ok!(CDPTreasuryModule::auction_surplus(Origin::signed(1), 100));
+		assert_eq!(TOTAL_SURPLUS_AUCTION.with(|v| *v.borrow_mut()), 1);
+	});
+}
+
+#[test]
+fn auction_debit_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_noop!(CDPTreasuryModule::auction_debit(Origin::signed(5), 100, 200), BadOrigin,);
+		assert_noop!(
+			CDPTreasuryModule::auction_debit(Origin::signed(1), 100, 200),
+			Error::<Runtime>::DebitPoolNotEnough,
+		);
+		assert_ok!(CDPTreasuryModule::on_system_debit(100));
 		assert_eq!(TOTAL_DEBIT_AUCTION.with(|v| *v.borrow_mut()), 0);
+		assert_ok!(CDPTreasuryModule::auction_debit(Origin::signed(1), 100, 200));
+		assert_eq!(TOTAL_DEBIT_AUCTION.with(|v| *v.borrow_mut()), 1);
+	});
+}
+
+#[test]
+fn set_collateral_auction_maximum_size_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		assert_eq!(CDPTreasuryModule::collateral_auction_maximum_size(BTC), 0);
+		assert_noop!(
+			CDPTreasuryModule::set_collateral_auction_maximum_size(Origin::signed(5), BTC, 200),
+			BadOrigin
+		);
+		assert_ok!(CDPTreasuryModule::set_collateral_auction_maximum_size(
+			Origin::signed(1),
+			BTC,
+			200
+		));
+
+		let update_collateral_auction_maximum_size_event =
+			TestEvent::cdp_treasury(Event::CollateralAuctionMaximumSizeUpdated(BTC, 200));
+		assert!(System::events()
+			.iter()
+			.any(|record| record.event == update_collateral_auction_maximum_size_event));
 	});
 }

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -109,7 +109,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = ();
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 
@@ -123,13 +122,13 @@ impl AuctionManager<AccountId> for MockAuctionManagerHandler {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
 		unimplemented!()
 	}
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
 		unimplemented!()
 	}
-	fn new_surplus_auction(_amount: Self::Balance) {
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
 		unimplemented!()
 	}
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {

--- a/modules/emergency_shutdown/benchmarking/src/mock.rs
+++ b/modules/emergency_shutdown/benchmarking/src/mock.rs
@@ -128,12 +128,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())

--- a/modules/emergency_shutdown/src/mock.rs
+++ b/modules/emergency_shutdown/src/mock.rs
@@ -168,12 +168,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())
@@ -215,7 +220,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = ();
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = EmergencyShutdownModule;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/emergency_shutdown/src/tests.rs
+++ b/modules/emergency_shutdown/src/tests.rs
@@ -12,10 +12,6 @@ fn emergency_shutdown_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(EmergencyShutdownModule::is_shutdown(), false);
-		assert_eq!(
-			<Runtime as cdp_treasury::Trait>::EmergencyShutdown::is_shutdown(),
-			false
-		);
 		assert_noop!(
 			EmergencyShutdownModule::emergency_shutdown(Origin::signed(5)),
 			BadOrigin,
@@ -26,7 +22,6 @@ fn emergency_shutdown_work() {
 		assert!(System::events().iter().any(|record| record.event == shutdown_event));
 
 		assert_eq!(EmergencyShutdownModule::is_shutdown(), true);
-		assert_eq!(<Runtime as cdp_treasury::Trait>::EmergencyShutdown::is_shutdown(), true);
 		assert_noop!(
 			EmergencyShutdownModule::emergency_shutdown(Origin::signed(1)),
 			Error::<Runtime>::AlreadyShutdown,

--- a/modules/honzon/benchmarking/src/mock.rs
+++ b/modules/honzon/benchmarking/src/mock.rs
@@ -128,12 +128,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())

--- a/modules/honzon/src/mock.rs
+++ b/modules/honzon/src/mock.rs
@@ -170,12 +170,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())
@@ -232,7 +237,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = ();
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/loans/src/mock.rs
+++ b/modules/loans/src/mock.rs
@@ -7,8 +7,7 @@ use frame_support::{impl_outer_event, impl_outer_origin, ord_parameter_types, pa
 use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, ModuleId, Perbill};
-use sp_std::cell::RefCell;
-use support::{AuctionManager, EmergencyShutdown, RiskManager};
+use support::{AuctionManager, RiskManager};
 
 pub type AccountId = u128;
 pub type AuctionId = u32;
@@ -127,12 +126,17 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 		_currency_id: Self::CurrencyId,
 		_amount: Self::Balance,
 		_target: Self::Balance,
-	) {
+	) -> DispatchResult {
+		Ok(())
 	}
 
-	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) {}
+	fn new_debit_auction(_amount: Self::Balance, _fix: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
-	fn new_surplus_auction(_amount: Self::Balance) {}
+	fn new_surplus_auction(_amount: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
 
 	fn cancel_auction(_id: Self::AuctionId) -> DispatchResult {
 		Ok(())
@@ -155,17 +159,6 @@ impl AuctionManager<AccountId> for MockAuctionManager {
 	}
 }
 
-thread_local! {
-	static IS_SHUTDOWN: RefCell<bool> = RefCell::new(false);
-}
-
-pub struct MockEmergencyShutdown;
-impl EmergencyShutdown for MockEmergencyShutdown {
-	fn is_shutdown() -> bool {
-		IS_SHUTDOWN.with(|v| *v.borrow_mut())
-	}
-}
-
 ord_parameter_types! {
 	pub const One: AccountId = 1;
 }
@@ -185,7 +178,6 @@ impl cdp_treasury::Trait for Runtime {
 	type DEX = ();
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = MockEmergencyShutdown;
 }
 pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -61,9 +61,9 @@ pub trait AuctionManager<AccountId> {
 		currency_id: Self::CurrencyId,
 		amount: Self::Balance,
 		target: Self::Balance,
-	);
-	fn new_debit_auction(amount: Self::Balance, fix: Self::Balance);
-	fn new_surplus_auction(amount: Self::Balance);
+	) -> DispatchResult;
+	fn new_debit_auction(amount: Self::Balance, fix: Self::Balance) -> DispatchResult;
+	fn new_surplus_auction(amount: Self::Balance) -> DispatchResult;
 	fn cancel_auction(id: Self::AuctionId) -> DispatchResult;
 
 	fn get_total_collateral_in_auction(id: Self::CurrencyId) -> Self::Balance;
@@ -191,7 +191,8 @@ pub trait CDPTreasuryExtended<AccountId>: CDPTreasury<AccountId> {
 		amount: Self::Balance,
 		target: Self::Balance,
 		refund_receiver: AccountId,
-	);
+		splited: bool,
+	) -> DispatchResult;
 }
 
 pub trait PriceProvider<CurrencyId> {

--- a/runtime/dev/src/benchmarking/auction.rs
+++ b/runtime/dev/src/benchmarking/auction.rs
@@ -38,7 +38,7 @@ runtime_benchmarks! {
 		set_balance(currency_id, &funder, collateral_amount);
 		set_balance(CurrencyId::AUSD, &bidder, bid_price);
 		<CdpTreasury as CDPTreasury<_>>::deposit_collateral(&funder, currency_id, collateral_amount)?;
-		AuctionManager::new_collateral_auction(&funder, currency_id, collateral_amount, target_amount);
+		AuctionManager::new_collateral_auction(&funder, currency_id, collateral_amount, target_amount)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, bid_price)
 
 	// `bid` a collateral auction, worst cases:
@@ -61,7 +61,7 @@ runtime_benchmarks! {
 		set_balance(CurrencyId::AUSD, &bidder, bid_price);
 		set_balance(CurrencyId::AUSD, &previous_bidder, previous_bid_price);
 		<CdpTreasury as CDPTreasury<_>>::deposit_collateral(&funder, currency_id, collateral_amount)?;
-		AuctionManager::new_collateral_auction(&funder, currency_id, collateral_amount, target_amount);
+		AuctionManager::new_collateral_auction(&funder, currency_id, collateral_amount, target_amount)?;
 		Auction::bid(RawOrigin::Signed(previous_bidder).into(), auction_id, previous_bid_price)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, bid_price)
 
@@ -78,7 +78,7 @@ runtime_benchmarks! {
 		let auction_id: AuctionId = 0;
 
 		set_balance(CurrencyId::ACA, &bidder, bid_price);
-		AuctionManager::new_surplus_auction(surplus_amount);
+		AuctionManager::new_surplus_auction(surplus_amount)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, bid_price)
 
 	// `bid` a surplus auction, worst cases:
@@ -96,7 +96,7 @@ runtime_benchmarks! {
 
 		set_balance(CurrencyId::ACA, &bidder, bid_price);
 		set_balance(CurrencyId::ACA, &previous_bidder, previous_bid_price);
-		AuctionManager::new_surplus_auction(surplus_amount);
+		AuctionManager::new_surplus_auction(surplus_amount)?;
 		Auction::bid(RawOrigin::Signed(previous_bidder).into(), auction_id, previous_bid_price)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, bid_price)
 
@@ -112,7 +112,7 @@ runtime_benchmarks! {
 		let auction_id: AuctionId = 0;
 
 		set_balance(CurrencyId::AUSD, &bidder, fix_debit_amount);
-		AuctionManager::new_debit_auction(initial_amount ,fix_debit_amount);
+		AuctionManager::new_debit_auction(initial_amount ,fix_debit_amount)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, fix_debit_amount)
 
 	// `bid` a debit auction, worst cases:
@@ -130,7 +130,7 @@ runtime_benchmarks! {
 
 		set_balance(CurrencyId::AUSD, &bidder, bid_price);
 		set_balance(CurrencyId::AUSD, &previous_bidder, previous_bid_price);
-		AuctionManager::new_debit_auction(initial_amount ,fix_debit_amount);
+		AuctionManager::new_debit_auction(initial_amount ,fix_debit_amount)?;
 		Auction::bid(RawOrigin::Signed(previous_bidder).into(), auction_id, previous_bid_price)?;
 	}: bid(RawOrigin::Signed(bidder), auction_id, bid_price)
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -64,7 +64,6 @@ pub use sp_runtime::{Perbill, Percent, Permill, Perquintill};
 
 pub use authority::AuthorityConfigImpl;
 pub use constants::{currency::*, fee::*, time::*};
-pub use module_cdp_treasury::SurplusDebitAuctionConfig;
 pub use primitives::{
 	AccountId, AccountIndex, AirDropCurrencyId, Amount, AuctionId, AuthoritysOriginId, Balance, BlockNumber,
 	CurrencyId, EraIndex, Hash, Moment, Nonce, Share, Signature,
@@ -919,7 +918,6 @@ impl module_cdp_treasury::Trait for Runtime {
 	type DEX = Dex;
 	type MaxAuctionsCount = MaxAuctionsCount;
 	type ModuleId = CDPTreasuryModuleId;
-	type EmergencyShutdown = EmergencyShutdown;
 }
 
 parameter_types! {

--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -242,8 +242,8 @@ fn testnet_genesis(
 		get_all_module_accounts, AirDropConfig, BabeConfig, BalancesConfig, CdpEngineConfig, CdpTreasuryConfig,
 		CurrencyId, DexConfig, GeneralCouncilMembershipConfig, GrandpaConfig, HomaCouncilMembershipConfig,
 		HonzonCouncilMembershipConfig, IndicesConfig, NewAccountDeposit, OperatorMembershipConfig, OracleConfig,
-		PolkadotBridgeConfig, SessionConfig, StakerStatus, StakingConfig, SudoConfig, SurplusDebitAuctionConfig,
-		SystemConfig, TechnicalCommitteeMembershipConfig, TokensConfig, VestingConfig, DOLLARS,
+		PolkadotBridgeConfig, SessionConfig, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
+		TechnicalCommitteeMembershipConfig, TokensConfig, VestingConfig, DOLLARS,
 	};
 
 	let new_account_deposit = NewAccountDeposit::get();
@@ -328,12 +328,6 @@ fn testnet_genesis(
 		}),
 		orml_vesting: Some(VestingConfig { vesting: vec![] }),
 		module_cdp_treasury: Some(CdpTreasuryConfig {
-			auction_config: SurplusDebitAuctionConfig {
-				surplus_auction_fixed_size: 1_000 * DOLLARS, // amount in aUSD of per surplus auction
-				surplus_buffer_size: 10_000 * DOLLARS,       // cache amount, exceed this will create surplus auction
-				initial_amount_per_debit_auction: 2_000 * DOLLARS, // initial bid amount in ACA of per debit auction
-				debit_auction_fixed_size: 1_000 * DOLLARS,   // amount in debit(aUSD) of per debit auction
-			},
 			collateral_auction_maximum_size: vec![
 				(CurrencyId::DOT, DOLLARS), // (currency_id, max size of a collateral auction)
 				(CurrencyId::XBTC, DOLLARS),
@@ -410,8 +404,7 @@ fn mandala_genesis(
 		CdpEngineConfig, CdpTreasuryConfig, CurrencyId, DexConfig, GeneralCouncilMembershipConfig, GrandpaConfig,
 		HomaCouncilMembershipConfig, HonzonCouncilMembershipConfig, IndicesConfig, NewAccountDeposit,
 		OperatorMembershipConfig, OracleConfig, PolkadotBridgeConfig, SessionConfig, StakerStatus, StakingConfig,
-		SudoConfig, SurplusDebitAuctionConfig, SystemConfig, TechnicalCommitteeMembershipConfig, TokensConfig,
-		VestingConfig, CENTS, DOLLARS,
+		SudoConfig, SystemConfig, TechnicalCommitteeMembershipConfig, TokensConfig, VestingConfig, CENTS, DOLLARS,
 	};
 
 	let new_account_deposit = NewAccountDeposit::get();
@@ -491,12 +484,6 @@ fn mandala_genesis(
 		}),
 		orml_vesting: Some(VestingConfig { vesting: vec![] }),
 		module_cdp_treasury: Some(CdpTreasuryConfig {
-			auction_config: SurplusDebitAuctionConfig {
-				surplus_auction_fixed_size: 100 * DOLLARS, // amount in aUSD of per surplus auction
-				surplus_buffer_size: 1_000 * DOLLARS,      // cache amount, exceed this will create surplus auction
-				initial_amount_per_debit_auction: 20 * DOLLARS, // initial bid amount in ACA of per debit auction
-				debit_auction_fixed_size: 1_000 * DOLLARS, // amount in debit(aUSD) of per debit auction
-			},
 			collateral_auction_maximum_size: vec![
 				(CurrencyId::DOT, DOLLARS), // (currency_id, max size of a collateral auction)
 				(CurrencyId::XBTC, 5 * CENTS),


### PR DESCRIPTION
close #361

1. expose call for council to create surplus and debit auction instead of auctomaticly create when `on_finalize`
2. auction creation functions return `DispatchResult ` now
3. remove `SurplusPool` and `TotalCollaterals` storage of cdp treasury