### PR TITLE
only enable mandala runtime by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Run clippy
       run: cargo clippy -- -D warnings
     - name: Build
-      run: cargo build --locked
+      run: cargo build --locked --features with-all-runtime
     - name: Run tests
-      run: cargo test --all
+      run: cargo test --all --features with-all-runtime
     - name: Run benchmarking tests
       run: cargo test --features runtime-benchmarks -p mandala-runtime benchmarking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,25 @@ acala-cli = { path = "cli" }
 acala-service = { path = "service" }
 
 [features]
+default = [ "with-mandala-runtime" ]
 runtime-benchmarks = [
 	"acala-cli/runtime-benchmarks",
+]
+with-mandala-runtime = [
+	"acala-service/with-mandala-runtime",
+	"acala-cli/with-mandala-runtime",
+]
+with-karura-runtime = [
+	"acala-service/with-karura-runtime",
+	"acala-cli/with-karura-runtime",
+]
+with-acala-runtime = [
+	"acala-service/with-acala-runtime",
+	"acala-cli/with-acala-runtime",
+]
+with-all-runtime = [
+	"acala-service/with-all-runtime",
+	"acala-cli/with-all-runtime",
 ]
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,17 @@ check: githooks
 check-tests: githooks
 	SKIP_WASM_BUILD= cargo check --tests --all
 
+check-all-runtime:
+	SKIP_WASM_BUILD= cargo check --tests --all --features with-all-runtime
+
 check-debug:
 	RUSTFLAGS="-Z external-macro-backtrace" SKIP_WASM_BUILD= cargo +nightly check
 
 test: githooks
 	SKIP_WASM_BUILD= cargo test --all
+
+test-all-runtime:
+	SKIP_WASM_BUILD= cargo test --all --features with-all-runtime
 
 build: githooks
 	SKIP_WASM_BUILD= cargo build

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,7 +18,7 @@ service = { package = "acala-service", path = "../service", default-features = f
 substrate-build-script-utils = { version = "2.0.0", default-features = false }
 
 [features]
-default = ["wasmtime", "cli"]
+default = [ "wasmtime", "cli", "with-mandala-runtime" ]
 wasmtime = [ "sc-cli/wasmtime" ]
 cli = [
 	"service",
@@ -28,3 +28,15 @@ cli = [
 	"frame-benchmarking-cli",
 ]
 runtime-benchmarks = [ "service/runtime-benchmarks" ]
+with-mandala-runtime = [
+	"service/with-mandala-runtime",
+]
+with-karura-runtime = [
+	"service/with-karura-runtime",
+]
+with-acala-runtime = [
+	"service/with-acala-runtime",
+]
+with-all-runtime = [
+	"service/with-all-runtime",
+]

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -50,13 +50,21 @@ impl SubstrateCli for Cli {
 		};
 
 		Ok(match id {
+			#[cfg(feature = "with-mandala-runtime")]
 			"dev" => Box::new(chain_spec::mandala::development_testnet_config()?),
+			#[cfg(feature = "with-mandala-runtime")]
 			"local" => Box::new(chain_spec::mandala::local_testnet_config()?),
+			#[cfg(feature = "with-mandala-runtime")]
 			"mandala" => Box::new(chain_spec::mandala::mandala_testnet_config()?),
+			#[cfg(feature = "with-mandala-runtime")]
 			"mandala-latest" => Box::new(chain_spec::mandala::latest_mandala_testnet_config()?),
+			#[cfg(feature = "with-karura-runtime")]
 			"karura" => Box::new(chain_spec::karura::karura_config()?),
+			#[cfg(feature = "with-karura-runtime")]
 			"karura-latest" => Box::new(chain_spec::karura::latest_karura_config()?),
+			#[cfg(feature = "with-acala-runtime")]
 			"acala" => Box::new(chain_spec::acala::acala_config()?),
+			#[cfg(feature = "with-acala-runtime")]
 			"acala-latest" => Box::new(chain_spec::acala::latest_acala_config()?),
 			path => {
 				let path = std::path::PathBuf::from(path);
@@ -69,11 +77,27 @@ impl SubstrateCli for Cli {
 				};
 
 				if starts_with("karura") {
-					Box::new(chain_spec::karura::ChainSpec::from_json_file(path)?)
+					#[cfg(feature = "with-karura-runtime")]
+					{
+						Box::new(chain_spec::karura::ChainSpec::from_json_file(path)?)
+					}
+
+					#[cfg(not(feature = "with-karura-runtime"))]
+					return Err("Karura runtime is not available. Please compile the node with `--features with-karura-runtime` to enable it.".into());
 				} else if starts_with("acala") {
-					Box::new(chain_spec::acala::ChainSpec::from_json_file(path)?)
+					#[cfg(feature = "with-acala-runtime")]
+					{
+						Box::new(chain_spec::acala::ChainSpec::from_json_file(path)?)
+					}
+					#[cfg(not(feature = "with-acala-runtime"))]
+					return Err("Acala runtime is not available. Please compile the node with `--features with-acala-runtime` to enable it.".into());
 				} else {
-					Box::new(chain_spec::mandala::ChainSpec::from_json_file(path)?)
+					#[cfg(feature = "with-mandala-runtime")]
+					{
+						Box::new(chain_spec::mandala::ChainSpec::from_json_file(path)?)
+					}
+					#[cfg(not(feature = "with-mandala-runtime"))]
+					return Err("Mandala runtime is not available. Please compile the node with `--features with-mandala-runtime` to enable it.".into());
 				}
 			}
 		})
@@ -81,11 +105,20 @@ impl SubstrateCli for Cli {
 
 	fn native_runtime_version(spec: &Box<dyn sc_service::ChainSpec>) -> &'static RuntimeVersion {
 		if spec.is_mandala() {
-			&service::mandala_runtime::VERSION
+			#[cfg(feature = "with-mandala-runtime")]
+			return &service::mandala_runtime::VERSION;
+			#[cfg(not(feature = "with-mandala-runtime"))]
+			panic!("Mandala runtime is not available. Please compile the node with `--features with-mandala-runtime` to enable it.");
 		} else if spec.is_karura() {
-			&service::karura_runtime::VERSION
+			#[cfg(feature = "with-karura-runtime")]
+			return &service::karura_runtime::VERSION;
+			#[cfg(not(feature = "with-karura-runtime"))]
+			panic!("Karura runtime is not available. Please compile the node with `--features with-karura-runtime` to enable it.");
 		} else {
-			&service::acala_runtime::VERSION
+			#[cfg(feature = "with-acala-runtime")]
+			return &service::acala_runtime::VERSION;
+			#[cfg(not(feature = "with-acala-runtime"))]
+			panic!("Acala runtime is not available. Please compile the node with `--features with-acala-runtime` to enable it.");
 		}
 	}
 }

--- a/scripts/build-only-wasm.sh
+++ b/scripts/build-only-wasm.sh
@@ -25,5 +25,5 @@ if [ -d $WASM_BUILDER_RUNNER ]; then
   cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
     | grep -vE "cargo:rerun-if-|Executing build command"
 else
-  cargo build --release -p $1
+  cargo build --release -p $1 --features with-$1
 fi

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -48,18 +48,32 @@ acala-primitives = { path = "../primitives" }
 acala-rpc = { path = "../rpc" }
 
 runtime-common = { path = "../runtime/common" }
-mandala-runtime = { path = "../runtime/mandala" }
-karura-runtime = { path = "../runtime/karura" }
-acala-runtime = { path = "../runtime/acala" }
+mandala-runtime = { path = "../runtime/mandala", optional = true }
+karura-runtime = { path = "../runtime/karura", optional = true }
+acala-runtime = { path = "../runtime/acala", optional = true }
 
 [dev-dependencies]
 sc-consensus-babe = { version = "0.8.0", features = ["test-helpers"] }
 
 [features]
-default = ["std"]
+default = ["std", "with-mandala-runtime"]
 std = []
 runtime-benchmarks = [
 	"mandala-runtime/runtime-benchmarks",
 	"karura-runtime/runtime-benchmarks",
 	"acala-runtime/runtime-benchmarks",
+]
+with-mandala-runtime = [
+	"mandala-runtime",
+]
+with-karura-runtime = [
+	"karura-runtime",
+]
+with-acala-runtime = [
+	"acala-runtime",
+]
+with-all-runtime = [
+	"with-mandala-runtime",
+	"with-karura-runtime",
+	"with-acala-runtime",
 ]

--- a/service/src/chain_spec/mod.rs
+++ b/service/src/chain_spec/mod.rs
@@ -8,8 +8,11 @@ use sp_core::{sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::IdentifyAccount;
 
+#[cfg(feature = "with-acala-runtime")]
 pub mod acala;
+#[cfg(feature = "with-karura-runtime")]
 pub mod karura;
+#[cfg(feature = "with-mandala-runtime")]
 pub mod mandala;
 
 // The URL for the telemetry server.

--- a/service/src/client.rs
+++ b/service/src/client.rs
@@ -130,16 +130,22 @@ pub trait ClientHandle {
 /// A client instance of Acala.
 #[derive(Clone)]
 pub enum Client {
+	#[cfg(feature = "with-mandala-runtime")]
 	Mandala(Arc<crate::FullClient<mandala_runtime::RuntimeApi, crate::MandalaExecutor>>),
+	#[cfg(feature = "with-karura-runtime")]
 	Karura(Arc<crate::FullClient<karura_runtime::RuntimeApi, crate::KaruraExecutor>>),
+	#[cfg(feature = "with-acala-runtime")]
 	Acala(Arc<crate::FullClient<acala_runtime::RuntimeApi, crate::AcalaExecutor>>),
 }
 
 impl ClientHandle for Client {
 	fn execute_with<T: ExecuteWithClient>(&self, t: T) -> T::Output {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => T::execute_with_client::<_, _, crate::FullBackend>(t, client.clone()),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => T::execute_with_client::<_, _, crate::FullBackend>(t, client.clone()),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => T::execute_with_client::<_, _, crate::FullBackend>(t, client.clone()),
 		}
 	}
@@ -148,8 +154,11 @@ impl ClientHandle for Client {
 impl sc_client_api::UsageProvider<Block> for Client {
 	fn usage_info(&self) -> sc_client_api::ClientInfo<Block> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.usage_info(),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.usage_info(),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.usage_info(),
 		}
 	}
@@ -158,40 +167,55 @@ impl sc_client_api::UsageProvider<Block> for Client {
 impl sc_client_api::BlockBackend<Block> for Client {
 	fn block_body(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Vec<<Block as BlockT>::Extrinsic>>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.block_body(id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.block_body(id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.block_body(id),
 		}
 	}
 
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.block(id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.block(id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.block(id),
 		}
 	}
 
 	fn block_status(&self, id: &BlockId<Block>) -> sp_blockchain::Result<BlockStatus> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.block_status(id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.block_status(id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.block_status(id),
 		}
 	}
 
 	fn justification(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Justification>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.justification(id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.justification(id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.justification(id),
 		}
 	}
 
 	fn block_hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.block_hash(number),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.block_hash(number),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.block_hash(number),
 		}
 	}
@@ -200,16 +224,22 @@ impl sc_client_api::BlockBackend<Block> for Client {
 impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 	fn storage(&self, id: &BlockId<Block>, key: &StorageKey) -> sp_blockchain::Result<Option<StorageData>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.storage(id, key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.storage(id, key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.storage(id, key),
 		}
 	}
 
 	fn storage_keys(&self, id: &BlockId<Block>, key_prefix: &StorageKey) -> sp_blockchain::Result<Vec<StorageKey>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.storage_keys(id, key_prefix),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.storage_keys(id, key_prefix),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.storage_keys(id, key_prefix),
 		}
 	}
@@ -220,8 +250,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.storage_hash(id, key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.storage_hash(id, key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.storage_hash(id, key),
 		}
 	}
@@ -232,8 +265,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(StorageKey, StorageData)>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.storage_pairs(id, key_prefix),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.storage_pairs(id, key_prefix),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.storage_pairs(id, key_prefix),
 		}
 	}
@@ -245,8 +281,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeyIterator<'a, <crate::FullBackend as sc_client_api::Backend<Block>>::State, Block>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.storage_keys_iter(id, prefix, start_key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.storage_keys_iter(id, prefix, start_key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.storage_keys_iter(id, prefix, start_key),
 		}
 	}
@@ -258,8 +297,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.child_storage(id, child_info, key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.child_storage(id, child_info, key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.child_storage(id, child_info, key),
 		}
 	}
@@ -271,8 +313,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.child_storage_keys(id, child_info, key_prefix),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.child_storage_keys(id, child_info, key_prefix),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.child_storage_keys(id, child_info, key_prefix),
 		}
 	}
@@ -284,8 +329,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.child_storage_hash(id, child_info, key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.child_storage_hash(id, child_info, key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.child_storage_hash(id, child_info, key),
 		}
 	}
@@ -296,8 +344,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		last: BlockId<Block>,
 	) -> sp_blockchain::Result<Option<(NumberFor<Block>, BlockId<Block>)>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.max_key_changes_range(first, last),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.max_key_changes_range(first, last),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.max_key_changes_range(first, last),
 		}
 	}
@@ -310,8 +361,11 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(NumberFor<Block>, u32)>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.key_changes(first, last, storage_key, key),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.key_changes(first, last, storage_key, key),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.key_changes(first, last, storage_key, key),
 		}
 	}
@@ -320,40 +374,55 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 impl sp_blockchain::HeaderBackend<Block> for Client {
 	fn header(&self, id: BlockId<Block>) -> sp_blockchain::Result<Option<Header>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.header(&id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.header(&id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.header(&id),
 		}
 	}
 
 	fn info(&self) -> sp_blockchain::Info<Block> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.info(),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.info(),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.info(),
 		}
 	}
 
 	fn status(&self, id: BlockId<Block>) -> sp_blockchain::Result<sp_blockchain::BlockStatus> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.status(id),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.status(id),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.status(id),
 		}
 	}
 
 	fn number(&self, hash: Hash) -> sp_blockchain::Result<Option<BlockNumber>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.number(hash),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.number(hash),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.number(hash),
 		}
 	}
 
 	fn hash(&self, number: BlockNumber) -> sp_blockchain::Result<Option<Hash>> {
 		match self {
+			#[cfg(feature = "with-mandala-runtime")]
 			Self::Mandala(client) => client.hash(number),
+			#[cfg(feature = "with-karura-runtime")]
 			Self::Karura(client) => client.hash(number),
+			#[cfg(feature = "with-acala-runtime")]
 			Self::Acala(client) => client.hash(number),
 		}
 	}


### PR DESCRIPTION
This should help reduce build time and memory usage

Use `--features with-all-runtime` to build all runtime, or `--features with-karura-runtime` / `--features with-acala-runtime` to build for Karura / Acala runtime.