### PR TITLE
check transaction priority

### DIFF
--- a/modules/auction_manager/src/lib.rs
+++ b/modules/auction_manager/src/lib.rs
@@ -14,11 +14,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use frame_support::{
-	debug, decl_error, decl_event, decl_module, decl_storage, ensure,
-	traits::Get,
-	weights::{DispatchClass, Weight},
-};
+use frame_support::{debug, decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, weights::Weight};
 use frame_system::{
 	self as system, ensure_none,
 	offchain::{SendTransactionTypes, SubmitTransaction},
@@ -328,7 +324,7 @@ decl_module! {
 		///		- collateral auction worst case: 197.5 µs
 		/// # </weight>
 		/// Use the collateral auction worst case as default weight.
-		#[weight = (T::WeightInfo::cancel_collateral_auction(), DispatchClass::Operational)]
+		#[weight = T::WeightInfo::cancel_collateral_auction()]
 		pub fn cancel(origin, id: AuctionId) {
 			with_transaction_result(|| {
 				ensure_none(origin)?;

--- a/modules/cdp_engine/src/lib.rs
+++ b/modules/cdp_engine/src/lib.rs
@@ -277,7 +277,7 @@ decl_module! {
 		///
 		/// - `currency_id`: CDP's collateral type.
 		/// - `who`: CDP's owner.
-		#[weight = (T::WeightInfo::liquidate_by_dex(), DispatchClass::Operational)]
+		#[weight = T::WeightInfo::liquidate_by_dex()]
 		pub fn liquidate(
 			origin,
 			currency_id: CurrencyId,
@@ -307,7 +307,7 @@ decl_module! {
 		/// -------------------
 		/// Base Weight: 161.5 µs
 		/// # </weight>
-		#[weight = (T::WeightInfo::settle(), DispatchClass::Operational)]
+		#[weight = T::WeightInfo::settle()]
 		pub fn settle(
 			origin,
 			currency_id: CurrencyId,

--- a/modules/staking_pool/src/lib.rs
+++ b/modules/staking_pool/src/lib.rs
@@ -4,6 +4,7 @@ use codec::{Decode, Encode};
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage, ensure,
 	traits::{EnsureOrigin, Get},
+	weights::DispatchClass,
 	IterableStorageDoubleMap,
 };
 use frame_system::{self as system};
@@ -154,7 +155,7 @@ decl_module! {
 		/// The sub account indexs of parachain to vault assets of Homa protocol in Polkadot.
 		const PoolAccountIndexes: Vec<u32> = T::PoolAccountIndexes::get();
 
-		#[weight = 10000]
+		#[weight = (10_000, DispatchClass::Operational)]
 		pub fn set_staking_pool_params(
 			origin,
 			target_max_free_unbonded_ratio: ChangeRatio,

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -27,7 +27,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	generic, impl_opaque_keys,
 	traits::AccountIdConversion,
-	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
+	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, ModuleId,
 };
 use sp_std::prelude::*;
@@ -137,14 +137,6 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 		DSWFModuleId::get().into_account(),
 		ZeroAccountId::get(),
 	]
-}
-
-// Priority of unsigned transactions
-parameter_types! {
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
 }
 
 parameter_types! {
@@ -637,7 +629,7 @@ impl pallet_staking::Trait for Runtime {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
-	type UnsignedPriority = StakingUnsignedPriority;
+	type UnsignedPriority = runtime_common::StakingUnsignedPriority;
 	type WeightInfo = ();
 	type OffchainSolutionWeightLimit = OffchainSolutionWeightLimit;
 }
@@ -875,7 +867,7 @@ impl module_auction_manager::Trait for Runtime {
 	type CDPTreasury = CdpTreasury;
 	type DEX = Dex;
 	type PriceSource = Prices;
-	type UnsignedPriority = AuctionManagerUnsignedPriority;
+	type UnsignedPriority = runtime_common::AuctionManagerUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::auction_manager::WeightInfo<Runtime>;
 }
@@ -970,7 +962,7 @@ impl module_cdp_engine::Trait for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfHonzonCouncil;
 	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
 	type DEX = Dex;
-	type UnsignedPriority = CdpEngineUnsignedPriority;
+	type UnsignedPriority = runtime_common::CdpEngineUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::cdp_engine::WeightInfo<Runtime>;
 }
@@ -1204,7 +1196,7 @@ impl ecosystem_renvm_bridge::Trait for Runtime {
 	type Currency = Currency<Runtime, RENBTCCurrencyId>;
 	type PublicKey = RenVmPublickKey;
 	type CurrencyIdentifier = RENBTCIdentifier;
-	type UnsignedPriority = RenvmBridgeUnsignedPriority;
+	type UnsignedPriority = runtime_common::RenvmBridgeUnsignedPriority;
 }
 
 parameter_types! {

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -139,6 +139,14 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 	]
 }
 
+// Priority of unsigned transactions
+parameter_types! {
+	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
+	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
+}
+
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 900; // mortal tx can be valid up to 1 hour after signing
 	/// We allow for 2 seconds of compute with a 4 second average block time.
@@ -600,7 +608,6 @@ parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 	pub const MaxIterations: u32 = 5;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
 	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
@@ -854,7 +861,6 @@ parameter_types! {
 	pub MinimumIncrementSize: Rate = Rate::saturating_from_rational(2, 100);
 	pub const AuctionTimeToClose: BlockNumber = 15 * MINUTES;
 	pub const AuctionDurationSoftCap: BlockNumber = 2 * HOURS;
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_auction_manager::Trait for Runtime {
@@ -949,7 +955,6 @@ parameter_types! {
 	pub DefaultLiquidationPenalty: Rate = Rate::saturating_from_rational(5, 100);
 	pub const MinimumDebitValue: Balance = DOLLARS;
 	pub MaxSlippageSwapWithDEX: Ratio = Ratio::saturating_from_rational(5, 100);
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_cdp_engine::Trait for Runtime {
@@ -1192,7 +1197,6 @@ parameter_types! {
 	pub const RENBTCCurrencyId: CurrencyId = CurrencyId::Token(TokenSymbol::RENBTC);
 	pub const RenVmPublickKey: [u8; 20] = hex!["4b939fc8ade87cb50b78987b1dda927460dc456a"];
 	pub const RENBTCIdentifier: [u8; 32] = hex!["f6b5b360905f856404bd4cf39021b82209908faa44159e68ea207ab8a5e13197"];
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 3;
 }
 
 impl ecosystem_renvm_bridge::Trait for Runtime {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,14 +1,22 @@
-//! Common runtime code for Acala and Karura.
+//! Common runtime code for Acala, Karura and Mandala.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::parameter_types;
 pub use module_support::{ExchangeRate, Price, Rate, Ratio};
-use sp_runtime::{traits::Saturating, FixedPointNumber, FixedPointOperand};
+use sp_runtime::{traits::Saturating, transaction_validity::TransactionPriority, FixedPointNumber, FixedPointOperand};
 
 pub mod precompile;
 
 pub type TimeStampedPrice = orml_oracle::TimestampedValue<Price, primitives::Moment>;
+
+// Priority of unsigned transactions
+parameter_types! {
+	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
+	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
+}
 
 parameter_types! {
 	pub FeeRateMatrix: [[Rate; 11]; 11] = [

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -27,7 +27,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	generic, impl_opaque_keys,
 	traits::AccountIdConversion,
-	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
+	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, ModuleId,
 };
 use sp_std::prelude::*;
@@ -137,14 +137,6 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 		DSWFModuleId::get().into_account(),
 		ZeroAccountId::get(),
 	]
-}
-
-// Priority of unsigned transactions
-parameter_types! {
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
 }
 
 parameter_types! {
@@ -637,7 +629,7 @@ impl pallet_staking::Trait for Runtime {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
-	type UnsignedPriority = StakingUnsignedPriority;
+	type UnsignedPriority = runtime_common::StakingUnsignedPriority;
 	type WeightInfo = ();
 	type OffchainSolutionWeightLimit = OffchainSolutionWeightLimit;
 }
@@ -875,7 +867,7 @@ impl module_auction_manager::Trait for Runtime {
 	type CDPTreasury = CdpTreasury;
 	type DEX = Dex;
 	type PriceSource = Prices;
-	type UnsignedPriority = AuctionManagerUnsignedPriority;
+	type UnsignedPriority = runtime_common::AuctionManagerUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::auction_manager::WeightInfo<Runtime>;
 }
@@ -970,7 +962,7 @@ impl module_cdp_engine::Trait for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfHonzonCouncil;
 	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
 	type DEX = Dex;
-	type UnsignedPriority = CdpEngineUnsignedPriority;
+	type UnsignedPriority = runtime_common::CdpEngineUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::cdp_engine::WeightInfo<Runtime>;
 }
@@ -1204,7 +1196,7 @@ impl ecosystem_renvm_bridge::Trait for Runtime {
 	type Currency = Currency<Runtime, RENBTCCurrencyId>;
 	type PublicKey = RenVmPublickKey;
 	type CurrencyIdentifier = RENBTCIdentifier;
-	type UnsignedPriority = RenvmBridgeUnsignedPriority;
+	type UnsignedPriority = runtime_common::RenvmBridgeUnsignedPriority;
 }
 
 parameter_types! {

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -139,6 +139,14 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 	]
 }
 
+// Priority of unsigned transactions
+parameter_types! {
+	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
+	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
+}
+
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 900; // mortal tx can be valid up to 1 hour after signing
 	/// We allow for 2 seconds of compute with a 4 second average block time.
@@ -600,7 +608,6 @@ parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 	pub const MaxIterations: u32 = 5;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
 	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
@@ -854,7 +861,6 @@ parameter_types! {
 	pub MinimumIncrementSize: Rate = Rate::saturating_from_rational(2, 100);
 	pub const AuctionTimeToClose: BlockNumber = 15 * MINUTES;
 	pub const AuctionDurationSoftCap: BlockNumber = 2 * HOURS;
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_auction_manager::Trait for Runtime {
@@ -949,7 +955,6 @@ parameter_types! {
 	pub DefaultLiquidationPenalty: Rate = Rate::saturating_from_rational(5, 100);
 	pub const MinimumDebitValue: Balance = DOLLARS;
 	pub MaxSlippageSwapWithDEX: Ratio = Ratio::saturating_from_rational(5, 100);
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_cdp_engine::Trait for Runtime {
@@ -1192,7 +1197,6 @@ parameter_types! {
 	pub const RENBTCCurrencyId: CurrencyId = CurrencyId::Token(TokenSymbol::RENBTC);
 	pub const RenVmPublickKey: [u8; 20] = hex!["4b939fc8ade87cb50b78987b1dda927460dc456a"];
 	pub const RENBTCIdentifier: [u8; 32] = hex!["f6b5b360905f856404bd4cf39021b82209908faa44159e68ea207ab8a5e13197"];
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 3;
 }
 
 impl ecosystem_renvm_bridge::Trait for Runtime {

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -140,6 +140,14 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 	]
 }
 
+// Priority of unsigned transactions
+parameter_types! {
+	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
+	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
+	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
+}
+
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 900; // mortal tx can be valid up to 1 hour after signing
 	/// We allow for 2 seconds of compute with a 4 second average block time.
@@ -601,7 +609,6 @@ parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 	pub const MaxIterations: u32 = 5;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
 	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
@@ -855,7 +862,6 @@ parameter_types! {
 	pub MinimumIncrementSize: Rate = Rate::saturating_from_rational(2, 100);
 	pub const AuctionTimeToClose: BlockNumber = 15 * MINUTES;
 	pub const AuctionDurationSoftCap: BlockNumber = 2 * HOURS;
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_auction_manager::Trait for Runtime {
@@ -950,7 +956,6 @@ parameter_types! {
 	pub DefaultLiquidationPenalty: Rate = Rate::saturating_from_rational(5, 100);
 	pub const MinimumDebitValue: Balance = DOLLARS;
 	pub MaxSlippageSwapWithDEX: Ratio = Ratio::saturating_from_rational(5, 100);
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 }
 
 impl module_cdp_engine::Trait for Runtime {
@@ -1197,7 +1202,6 @@ parameter_types! {
 	pub const RENBTCCurrencyId: CurrencyId = CurrencyId::Token(TokenSymbol::RENBTC);
 	pub const RenVmPublickKey: [u8; 20] = hex!["4b939fc8ade87cb50b78987b1dda927460dc456a"];
 	pub const RENBTCIdentifier: [u8; 32] = hex!["f6b5b360905f856404bd4cf39021b82209908faa44159e68ea207ab8a5e13197"];
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 3;
 }
 
 impl ecosystem_renvm_bridge::Trait for Runtime {

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -27,7 +27,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	generic, impl_opaque_keys,
 	traits::AccountIdConversion,
-	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
+	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, ModuleId,
 };
 use sp_std::prelude::*;
@@ -138,14 +138,6 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 		DSWFModuleId::get().into_account(),
 		ZeroAccountId::get(),
 	]
-}
-
-// Priority of unsigned transactions
-parameter_types! {
-	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const RenvmBridgeUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-	pub const CdpEngineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
-	pub const AuctionManagerUnsignedPriority: TransactionPriority = TransactionPriority::max_value() - 1;
 }
 
 parameter_types! {
@@ -638,7 +630,7 @@ impl pallet_staking::Trait for Runtime {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
-	type UnsignedPriority = StakingUnsignedPriority;
+	type UnsignedPriority = runtime_common::StakingUnsignedPriority;
 	type WeightInfo = ();
 	type OffchainSolutionWeightLimit = OffchainSolutionWeightLimit;
 }
@@ -876,7 +868,7 @@ impl module_auction_manager::Trait for Runtime {
 	type CDPTreasury = CdpTreasury;
 	type DEX = Dex;
 	type PriceSource = Prices;
-	type UnsignedPriority = AuctionManagerUnsignedPriority;
+	type UnsignedPriority = runtime_common::AuctionManagerUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::auction_manager::WeightInfo<Runtime>;
 }
@@ -971,7 +963,7 @@ impl module_cdp_engine::Trait for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfHonzonCouncil;
 	type MaxSlippageSwapWithDEX = MaxSlippageSwapWithDEX;
 	type DEX = Dex;
-	type UnsignedPriority = CdpEngineUnsignedPriority;
+	type UnsignedPriority = runtime_common::CdpEngineUnsignedPriority;
 	type EmergencyShutdown = EmergencyShutdown;
 	type WeightInfo = weights::cdp_engine::WeightInfo<Runtime>;
 }
@@ -1209,7 +1201,7 @@ impl ecosystem_renvm_bridge::Trait for Runtime {
 	type Currency = Currency<Runtime, RENBTCCurrencyId>;
 	type PublicKey = RenVmPublickKey;
 	type CurrencyIdentifier = RENBTCIdentifier;
-	type UnsignedPriority = RenvmBridgeUnsignedPriority;
+	type UnsignedPriority = runtime_common::RenvmBridgeUnsignedPriority;
 }
 
 parameter_types! {


### PR DESCRIPTION
close #440 

1. `cancel_auction`, `settle_cdp` and `liquidate_cdp` could be generated in large quantities in a short time, if their dispatch class are Operational,  maybe block other business transactions.

2. All configuration update functions should be Operational so that take effect as soon as possible.

3. `settle_cdp` should have a higher priority than `cancel_auction`, so that users can retrieve their remain assets as soon as possible when emergency shutdown occurs 