### PR TITLE
support instant sealing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-babe",
+ "sc-consensus-manual-seal",
  "sc-executor",
  "sc-finality-grandpa",
  "sc-network",
@@ -432,6 +433,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
 
 [[package]]
 name = "async-channel"
@@ -6927,6 +6934,37 @@ dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-runtime",
+]
+
+[[package]]
+name = "sc-consensus-manual-seal"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=b7712fed2c58a898f7706e16861d7109c8f585a5#b7712fed2c58a898f7706e16861d7109c8f585a5"
+dependencies = [
+ "assert_matches",
+ "derive_more",
+ "futures 0.3.8",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive 15.1.0",
+ "log",
+ "parking_lot 0.10.2",
+ "sc-client-api",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-transaction-pool",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-transaction-pool",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/paritytech/substrate.git?rev=b7712fed2c58a898f7706e16861d7109c8f585a5)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ sc-client-db = { git = "https://github.com/paritytech/substrate.git", rev = "b77
 sc-consensus = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
 sc-consensus-babe = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
 sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
 sc-consensus-epochs = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
 sc-executor = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", rev = "b7712fed2c58a898f7706e16861d7109c8f585a5" }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -62,4 +62,8 @@ pub struct Cli {
 	#[allow(missing_docs)]
 	#[structopt(flatten)]
 	pub run: RunCmd,
+
+	#[allow(missing_docs)]
+	#[structopt(long = "instant-sealing")]
+	pub instant_sealing: bool,
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -63,7 +63,9 @@ pub struct Cli {
 	#[structopt(flatten)]
 	pub run: RunCmd,
 
-	#[allow(missing_docs)]
+	/// Instant block sealing
+	///
+	/// Can only be used with `--dev`
 	#[structopt(long = "instant-sealing")]
 	pub instant_sealing: bool,
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -149,19 +149,16 @@ pub fn run() -> sc_cli::Result<()> {
 
 			set_default_ss58_version(chain_spec);
 
-			let instant_sealing = if cli.instant_sealing {
-				if chain_spec.chain_type() != ChainType::Development {
-					return Err("Instant sealing can be turned on only in `--dev` mode".into());
-				}
-				true
-			} else {
-				false
-			};
+			if cli.instant_sealing && chain_spec.chain_type() != ChainType::Development {
+				return Err("Instant sealing can be turned on only in `--dev` mode".into());
+			}
 
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::build_light(config),
-					_ => service::build_full(config, instant_sealing, false).map(|(_, _, task_manager)| task_manager),
+					_ => {
+						service::build_full(config, cli.instant_sealing, false).map(|(_, _, task_manager)| task_manager)
+					}
 				}
 			})
 		}

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -151,7 +151,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::build_light(config),
-					_ => service::build_full(config, false).map(|full| full.2),
+					_ => service::build_full(config, cli.instant_sealing, false).map(|full| full.2),
 				}
 			})
 		}
@@ -163,7 +163,7 @@ pub fn run() -> sc_cli::Result<()> {
 			set_default_ss58_version(chain_spec);
 
 			runner.sync_run(|config| {
-				let (client, _, _) = service::build_full(config, false)?;
+				let (client, _, _) = service::build_full(config, false, false)?;
 				cmd.run(client)
 			})
 		}

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -3,6 +3,7 @@
 
 use crate::cli::{Cli, Subcommand};
 use sc_cli::{Role, RuntimeVersion, SubstrateCli};
+use sc_service::ChainType;
 use service::{chain_spec, IdentifyVariant};
 
 fn get_exec_name() -> Option<String> {
@@ -148,10 +149,19 @@ pub fn run() -> sc_cli::Result<()> {
 
 			set_default_ss58_version(chain_spec);
 
+			let instant_sealing = if cli.instant_sealing {
+				if chain_spec.chain_type() != ChainType::Development {
+					return Err("Instant sealing can be turned on only in development mode".into());
+				}
+				true
+			} else {
+				false
+			};
+
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::build_light(config),
-					_ => service::build_full(config, cli.instant_sealing, false).map(|full| full.2),
+					_ => service::build_full(config, instant_sealing, false).map(|(_, _, task_manager)| task_manager),
 				}
 			})
 		}

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -151,7 +151,7 @@ pub fn run() -> sc_cli::Result<()> {
 
 			let instant_sealing = if cli.instant_sealing {
 				if chain_spec.chain_type() != ChainType::Development {
-					return Err("Instant sealing can be turned on only in development mode".into());
+					return Err("Instant sealing can be turned on only in `--dev` mode".into());
 				}
 				true
 			} else {

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -24,6 +24,7 @@ sc-service = { version = "0.8.0" }
 sc-executor = { version = "0.8.0" }
 sc-consensus = { version = "0.8.0" }
 sc-consensus-babe = { version = "0.8.0" }
+sc-consensus-manual-seal = { version = "0.8.0" }
 sc-transaction-pool = { version = "2.0.0" }
 sc-basic-authorship = { version = "0.8.0" }
 sc-network = { version = "0.8.0" }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -32,6 +32,7 @@ pub use sp_api::ConstructRuntimeApi;
 
 pub mod chain_spec;
 mod client;
+mod mock_timestamp_data_provider;
 
 #[cfg(feature = "with-mandala-runtime")]
 native_executor_instance!(
@@ -105,6 +106,7 @@ type LightClient<RuntimeApi, Executor> = sc_service::TLightClientWithBackend<Blo
 
 pub fn new_partial<RuntimeApi, Executor>(
 	config: &mut Configuration,
+	instant_sealing: bool,
 	test: bool,
 ) -> Result<
 	PartialComponents<
@@ -169,18 +171,31 @@ where
 
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-	let import_queue = sc_consensus_babe::import_queue(
-		babe_link.clone(),
-		block_import.clone(),
-		Some(Box::new(justification_import)),
-		None,
-		client.clone(),
-		select_chain.clone(),
-		inherent_data_providers.clone(),
-		&task_manager.spawn_handle(),
-		config.prometheus_registry(),
-		sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
-	)?;
+	let import_queue = if instant_sealing {
+		inherent_data_providers
+			.register_provider(mock_timestamp_data_provider::MockTimestampInherentDataProvider)
+			.map_err(Into::into)
+			.map_err(sp_consensus::error::Error::InherentData)?;
+
+		sc_consensus_manual_seal::import_queue(
+			Box::new(client.clone()),
+			&task_manager.spawn_handle(),
+			config.prometheus_registry(),
+		)
+	} else {
+		sc_consensus_babe::import_queue(
+			babe_link.clone(),
+			block_import.clone(),
+			Some(Box::new(justification_import)),
+			None,
+			client.clone(),
+			select_chain.clone(),
+			inherent_data_providers.clone(),
+			&task_manager.spawn_handle(),
+			config.prometheus_registry(),
+			sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
+		)?
+	};
 
 	let justification_stream = grandpa_link.justification_stream();
 	let shared_authority_set = grandpa_link.shared_authority_set().clone();
@@ -239,6 +254,7 @@ where
 /// Creates a full service from the configuration.
 pub fn new_full<RuntimeApi, Executor>(
 	mut config: Configuration,
+	instant_sealing: bool,
 	test: bool,
 ) -> Result<
 	(
@@ -266,11 +282,23 @@ where
 		transaction_pool,
 		inherent_data_providers,
 		other: (rpc_extensions_builder, import_setup, rpc_setup),
-	} = new_partial::<RuntimeApi, Executor>(&mut config, test)?;
+	} = new_partial::<RuntimeApi, Executor>(&mut config, instant_sealing, test)?;
 
 	let (shared_voter_state, finality_proof_provider) = rpc_setup;
 
-	let (network, network_status_sinks, system_rpc_tx, network_starter) =
+	let (network, network_status_sinks, system_rpc_tx, network_starter) = if instant_sealing {
+		sc_service::build_network(sc_service::BuildNetworkParams {
+			config: &config,
+			client: client.clone(),
+			transaction_pool: transaction_pool.clone(),
+			spawn_handle: task_manager.spawn_handle(),
+			import_queue,
+			on_demand: None,
+			block_announce_validator_builder: None,
+			finality_proof_request_builder: Some(Box::new(sc_network::config::DummyFinalityProofRequestBuilder)),
+			finality_proof_provider: None,
+		})?
+	} else {
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &config,
 			client: client.clone(),
@@ -281,7 +309,8 @@ where
 			block_announce_validator_builder: None,
 			finality_proof_request_builder: None,
 			finality_proof_provider: Some(finality_proof_provider),
-		})?;
+		})?
+	};
 
 	if config.offchain_worker.enabled {
 		sc_service::build_offchain_workers(
@@ -318,77 +347,102 @@ where
 
 	let (block_import, grandpa_link, babe_link) = import_setup;
 
-	if let sc_service::config::Role::Authority { .. } = &role {
-		let proposer = sc_basic_authorship::ProposerFactory::new(
-			task_manager.spawn_handle(),
-			client.clone(),
-			transaction_pool.clone(),
-			prometheus_registry.as_ref(),
-		);
+	if instant_sealing {
+		if role.is_authority() {
+			let env = sc_basic_authorship::ProposerFactory::new(
+				task_manager.spawn_handle(),
+				client.clone(),
+				transaction_pool.clone(),
+				prometheus_registry.as_ref(),
+			);
+			let authorship_future =
+				sc_consensus_manual_seal::run_instant_seal(sc_consensus_manual_seal::InstantSealParams {
+					block_import: client.clone(),
+					env,
+					client: client.clone(),
+					pool: transaction_pool.pool().clone(),
+					select_chain,
+					consensus_data_provider: None,
+					inherent_data_providers: inherent_data_providers.clone(),
+				});
+			// we spawn the future on a background thread managed by service.
+			task_manager
+				.spawn_essential_handle()
+				.spawn_blocking("instant-seal", authorship_future);
+		}
+	} else {
+		if let sc_service::config::Role::Authority { .. } = &role {
+			let proposer = sc_basic_authorship::ProposerFactory::new(
+				task_manager.spawn_handle(),
+				client.clone(),
+				transaction_pool.clone(),
+				prometheus_registry.clone().as_ref(),
+			);
 
-		let can_author_with = sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+			let can_author_with = sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
 
-		let babe_config = sc_consensus_babe::BabeParams {
-			keystore: keystore_container.sync_keystore(),
-			client: client.clone(),
-			select_chain,
-			env: proposer,
-			block_import,
-			sync_oracle: network.clone(),
-			inherent_data_providers: inherent_data_providers.clone(),
-			force_authoring,
-			babe_link,
-			can_author_with,
+			let babe_config = sc_consensus_babe::BabeParams {
+				keystore: keystore_container.sync_keystore(),
+				client: client.clone(),
+				select_chain,
+				env: proposer,
+				block_import,
+				sync_oracle: network.clone(),
+				inherent_data_providers: inherent_data_providers.clone(),
+				force_authoring,
+				babe_link,
+				can_author_with,
+			};
+
+			let babe = sc_consensus_babe::start_babe(babe_config)?;
+			task_manager
+				.spawn_essential_handle()
+				.spawn_blocking("babe-proposer", babe);
+		}
+
+		// if the node isn't actively participating in consensus then it doesn't
+		// need a keystore, regardless of which protocol we use below.
+		let keystore = if role.is_authority() {
+			Some(keystore_container.sync_keystore())
+		} else {
+			None
 		};
 
-		let babe = sc_consensus_babe::start_babe(babe_config)?;
-		task_manager
-			.spawn_essential_handle()
-			.spawn_blocking("babe-proposer", babe);
-	}
-
-	// if the node isn't actively participating in consensus then it doesn't
-	// need a keystore, regardless of which protocol we use below.
-	let keystore = if role.is_authority() {
-		Some(keystore_container.sync_keystore())
-	} else {
-		None
-	};
-
-	let config = sc_finality_grandpa::Config {
-		// FIXME #1578 make this available through chainspec
-		gossip_duration: std::time::Duration::from_millis(333),
-		justification_period: 512,
-		name: Some(name),
-		observer_enabled: false,
-		keystore,
-		is_authority: role.is_network_authority(),
-	};
-
-	if enable_grandpa {
-		// start the full GRANDPA voter
-		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
-		// this point the full voter should provide better guarantees of block
-		// and vote data availability than the observer. The observer has not
-		// been tested extensively yet and having most nodes in a network run it
-		// could lead to finality stalls.
-		let grandpa_config = sc_finality_grandpa::GrandpaParams {
-			config,
-			link: grandpa_link,
-			network: network.clone(),
-			telemetry_on_connect: Some(telemetry_connection_sinks.on_connect_stream()),
-			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry,
-			shared_voter_state,
+		let config = sc_finality_grandpa::Config {
+			// FIXME #1578 make this available through chainspec
+			gossip_duration: std::time::Duration::from_millis(333),
+			justification_period: 512,
+			name: Some(name),
+			observer_enabled: false,
+			keystore,
+			is_authority: role.is_network_authority(),
 		};
 
-		// the GRANDPA voter task is considered infallible, i.e.
-		// if it fails we take down the service with it.
-		task_manager
-			.spawn_essential_handle()
-			.spawn_blocking("grandpa-voter", sc_finality_grandpa::run_grandpa_voter(grandpa_config)?);
-	} else {
-		sc_finality_grandpa::setup_disabled_grandpa(network.clone())?;
+		if enable_grandpa {
+			// start the full GRANDPA voter
+			// NOTE: non-authorities could run the GRANDPA observer protocol, but at
+			// this point the full voter should provide better guarantees of block
+			// and vote data availability than the observer. The observer has not
+			// been tested extensively yet and having most nodes in a network run it
+			// could lead to finality stalls.
+			let grandpa_config = sc_finality_grandpa::GrandpaParams {
+				config,
+				link: grandpa_link,
+				network: network.clone(),
+				telemetry_on_connect: Some(telemetry_connection_sinks.on_connect_stream()),
+				voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
+				prometheus_registry,
+				shared_voter_state,
+			};
+
+			// the GRANDPA voter task is considered infallible, i.e.
+			// if it fails we take down the service with it.
+			task_manager
+				.spawn_essential_handle()
+				.spawn_blocking("grandpa-voter", sc_finality_grandpa::run_grandpa_voter(grandpa_config)?);
+		} else {
+			sc_finality_grandpa::setup_disabled_grandpa(network.clone())?;
+		}
 	}
 
 	network_starter.start_network();
@@ -547,7 +601,7 @@ pub fn new_chain_ops(
 				import_queue,
 				task_manager,
 				..
-			} = new_partial::<mandala_runtime::RuntimeApi, MandalaExecutor>(config, false)?;
+			} = new_partial::<mandala_runtime::RuntimeApi, MandalaExecutor>(config, false, false)?;
 			Ok((Arc::new(Client::Mandala(client)), backend, import_queue, task_manager))
 		}
 		#[cfg(not(feature = "with-mandala-runtime"))]
@@ -561,7 +615,7 @@ pub fn new_chain_ops(
 				import_queue,
 				task_manager,
 				..
-			} = new_partial::<karura_runtime::RuntimeApi, KaruraExecutor>(config, false)?;
+			} = new_partial::<karura_runtime::RuntimeApi, KaruraExecutor>(config, false, false)?;
 			Ok((Arc::new(Client::Karura(client)), backend, import_queue, task_manager))
 		}
 		#[cfg(not(feature = "with-kaura-runtime"))]
@@ -575,7 +629,7 @@ pub fn new_chain_ops(
 				import_queue,
 				task_manager,
 				..
-			} = new_partial::<acala_runtime::RuntimeApi, AcalaExecutor>(config, false)?;
+			} = new_partial::<acala_runtime::RuntimeApi, AcalaExecutor>(config, false, false)?;
 			Ok((Arc::new(Client::Acala(client)), backend, import_queue, task_manager))
 		}
 		#[cfg(not(feature = "with-acala-runtime"))]
@@ -605,13 +659,14 @@ pub fn build_light(config: Configuration) -> Result<TaskManager, ServiceError> {
 
 pub fn build_full(
 	config: Configuration,
+	instant_sealing: bool,
 	test: bool,
 ) -> Result<(Arc<Client>, sc_service::NetworkStatusSinks<Block>, TaskManager), ServiceError> {
 	if config.chain_spec.is_acala() {
 		#[cfg(feature = "with-acala-runtime")]
 		{
 			let (task_manager, _, client, _, _, network_status_sinks) =
-				new_full::<acala_runtime::RuntimeApi, AcalaExecutor>(config, test)?;
+				new_full::<acala_runtime::RuntimeApi, AcalaExecutor>(config, instant_sealing, test)?;
 			Ok((Arc::new(Client::Acala(client)), network_status_sinks, task_manager))
 		}
 		#[cfg(not(feature = "with-acala-runtime"))]
@@ -620,7 +675,7 @@ pub fn build_full(
 		#[cfg(feature = "with-kaura-runtime")]
 		{
 			let (task_manager, _, client, _, _, network_status_sinks) =
-				new_full::<karura_runtime::RuntimeApi, KaruraExecutor>(config, test)?;
+				new_full::<karura_runtime::RuntimeApi, KaruraExecutor>(config, instant_sealing, test)?;
 			Ok((Arc::new(Client::Karura(client)), network_status_sinks, task_manager))
 		}
 		#[cfg(not(feature = "with-kaura-runtime"))]
@@ -629,7 +684,7 @@ pub fn build_full(
 		#[cfg(feature = "with-mandala-runtime")]
 		{
 			let (task_manager, _, client, _, _, network_status_sinks) =
-				new_full::<mandala_runtime::RuntimeApi, MandalaExecutor>(config, test)?;
+				new_full::<mandala_runtime::RuntimeApi, MandalaExecutor>(config, instant_sealing, test)?;
 			Ok((Arc::new(Client::Mandala(client)), network_status_sinks, task_manager))
 		}
 		#[cfg(not(feature = "with-mandala-runtime"))]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -376,7 +376,7 @@ where
 				task_manager.spawn_handle(),
 				client.clone(),
 				transaction_pool.clone(),
-				prometheus_registry.clone().as_ref(),
+				prometheus_registry.as_ref(),
 			);
 
 			let can_author_with = sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());

--- a/service/src/mock_timestamp_data_provider.rs
+++ b/service/src/mock_timestamp_data_provider.rs
@@ -1,13 +1,6 @@
 use sp_inherents::{InherentData, InherentIdentifier, ProvideInherentData};
 use std::cell::RefCell;
 
-#[cfg(feature = "with-acala-runtime")]
-use acala_runtime::SLOT_DURATION;
-#[cfg(feature = "with-karura-runtime")]
-use karura_runtime::SLOT_DURATION;
-#[cfg(feature = "with-mandala-runtime")]
-use mandala_runtime::SLOT_DURATION;
-
 /// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
 /// Each call will increment timestamp by slot_duration making block importer
 /// think time has passed.
@@ -24,7 +17,7 @@ impl ProvideInherentData for MockTimestampInherentDataProvider {
 
 	fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), sp_inherents::Error> {
 		TIMESTAMP.with(|x| {
-			*x.borrow_mut() += SLOT_DURATION;
+			*x.borrow_mut() += 4_000;
 			inherent_data.put_data(INHERENT_IDENTIFIER, &*x.borrow())
 		})
 	}

--- a/service/src/mock_timestamp_data_provider.rs
+++ b/service/src/mock_timestamp_data_provider.rs
@@ -1,0 +1,35 @@
+use sp_inherents::{InherentData, InherentIdentifier, ProvideInherentData};
+use std::cell::RefCell;
+
+#[cfg(feature = "with-acala-runtime")]
+use acala_runtime::SLOT_DURATION;
+#[cfg(feature = "with-karura-runtime")]
+use karura_runtime::SLOT_DURATION;
+#[cfg(feature = "with-mandala-runtime")]
+use mandala_runtime::SLOT_DURATION;
+
+/// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
+/// Each call will increment timestamp by slot_duration making block importer
+/// think time has passed.
+pub struct MockTimestampInherentDataProvider;
+
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"timstap0";
+
+thread_local!(static TIMESTAMP: RefCell<u64> = RefCell::new(0));
+
+impl ProvideInherentData for MockTimestampInherentDataProvider {
+	fn inherent_identifier(&self) -> &'static InherentIdentifier {
+		&INHERENT_IDENTIFIER
+	}
+
+	fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), sp_inherents::Error> {
+		TIMESTAMP.with(|x| {
+			*x.borrow_mut() += SLOT_DURATION;
+			inherent_data.put_data(INHERENT_IDENTIFIER, &*x.borrow())
+		})
+	}
+
+	fn error_to_string(&self, error: &[u8]) -> Option<String> {
+		Some(String::from_utf8_lossy(error).into())
+	}
+}


### PR DESCRIPTION
Add support for instant sealing. It will help running `evm` integration test instantly.
Run with `--instant-sealing` to enable it

Closes #542