### PR TITLE
Simplify EVM handler

### DIFF
--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -82,10 +82,10 @@ pub struct GenesisAccount<Balance, Index> {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as EVM {
-		AccountNonces get(fn account_nonces): map hasher(blake2_128_concat) H160 => T::Index;
-		AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
+		AccountNonces get(fn account_nonces): map hasher(twox_64_concat) H160 => T::Index;
+		AccountCodes get(fn account_codes): map hasher(twox_64_concat) H160 => Vec<u8>;
 		AccountStorages get(fn account_storages):
-			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
+			double_map hasher(twox_64_concat) H160, hasher(blake2_128_concat) H256 => H256;
 	}
 
 	add_extra_genesis {

--- a/modules/evm/src/runner/handler.rs
+++ b/modules/evm/src/runner/handler.rs
@@ -277,11 +277,7 @@ impl<'vicinity, 'config, T: Trait> HandlerT for Handler<'vicinity, 'config, T> {
 	}
 
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError> {
-		Module::<T>::deposit_event(Event::<T>::Log(Log {
-			address,
-			topics: topics.clone(),
-			data: data.clone(),
-		}));
+		Module::<T>::deposit_event(Event::<T>::Log(Log { address, topics, data }));
 
 		Ok(())
 	}

--- a/modules/evm/src/runner/native.rs
+++ b/modules/evm/src/runner/native.rs
@@ -82,7 +82,6 @@ impl<T: Trait> Runner<T> {
 				address,
 				output: Vec::default(),
 				used_gas: U256::from(substate.used_gas()),
-				logs: substate.logs.clone(),
 			};
 
 			debug::debug!(
@@ -159,7 +158,6 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 				exit_reason: reason.clone(),
 				output: out,
 				used_gas: U256::from(substate.used_gas()),
-				logs: substate.logs.clone(),
 			};
 
 			debug::debug!(

--- a/primitives/src/evm.rs
+++ b/primitives/src/evm.rs
@@ -25,7 +25,6 @@ pub struct CreateInfo {
 	pub address: H160,
 	pub output: Vec<u8>,
 	pub used_gas: U256,
-	pub logs: Vec<Log>,
 }
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -34,7 +33,6 @@ pub struct CallInfo {
 	pub exit_reason: ExitReason,
 	pub output: Vec<u8>,
 	pub used_gas: U256,
-	pub logs: Vec<Log>,
 }
 
 /// A mapping between `AccountId` and `H160`.


### PR DESCRIPTION
The deleted BTreeSet is a nice to have optimization to avoid unnecessary storage changes on revert, but for now correctness is more important than performance. 