### PR TITLE
config reasonable motion duration for council governance

### DIFF
--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -325,7 +325,7 @@ type EnsureRootOrTwoThirdsTechnicalCommittee = EnsureOneOf<
 >;
 
 parameter_types! {
-	pub const GeneralCouncilMotionDuration: BlockNumber = 0;
+	pub const GeneralCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const GeneralCouncilMaxProposals: u32 = 100;
 	pub const GeneralCouncilMaxMembers: u32 = 100;
 }
@@ -355,7 +355,7 @@ impl pallet_membership::Config<GeneralCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HonzonCouncilMotionDuration: BlockNumber = 0;
+	pub const HonzonCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HonzonCouncilMaxProposals: u32 = 100;
 	pub const HonzonCouncilMaxMembers: u32 = 100;
 }
@@ -385,7 +385,7 @@ impl pallet_membership::Config<HonzonCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HomaCouncilMotionDuration: BlockNumber = 0;
+	pub const HomaCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HomaCouncilMaxProposals: u32 = 100;
 	pub const HomaCouncilMaxMembers: u32 = 100;
 }
@@ -415,7 +415,7 @@ impl pallet_membership::Config<HomaCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const TechnicalCommitteeMotionDuration: BlockNumber = 0;
+	pub const TechnicalCommitteeMotionDuration: BlockNumber = 7 * DAYS;
 	pub const TechnicalCommitteeMaxProposals: u32 = 100;
 	pub const TechnicalCouncilMaxMembers: u32 = 100;
 }

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -325,7 +325,7 @@ type EnsureRootOrTwoThirdsTechnicalCommittee = EnsureOneOf<
 >;
 
 parameter_types! {
-	pub const GeneralCouncilMotionDuration: BlockNumber = 0;
+	pub const GeneralCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const GeneralCouncilMaxProposals: u32 = 100;
 	pub const GeneralCouncilMaxMembers: u32 = 100;
 }
@@ -355,7 +355,7 @@ impl pallet_membership::Config<GeneralCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HonzonCouncilMotionDuration: BlockNumber = 0;
+	pub const HonzonCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HonzonCouncilMaxProposals: u32 = 100;
 	pub const HonzonCouncilMaxMembers: u32 = 100;
 }
@@ -385,7 +385,7 @@ impl pallet_membership::Config<HonzonCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HomaCouncilMotionDuration: BlockNumber = 0;
+	pub const HomaCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HomaCouncilMaxProposals: u32 = 100;
 	pub const HomaCouncilMaxMembers: u32 = 100;
 }
@@ -415,7 +415,7 @@ impl pallet_membership::Config<HomaCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const TechnicalCommitteeMotionDuration: BlockNumber = 0;
+	pub const TechnicalCommitteeMotionDuration: BlockNumber = 7 * DAYS;
 	pub const TechnicalCommitteeMaxProposals: u32 = 100;
 	pub const TechnicalCouncilMaxMembers: u32 = 100;
 }

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -326,7 +326,7 @@ type EnsureRootOrTwoThirdsTechnicalCommittee = EnsureOneOf<
 >;
 
 parameter_types! {
-	pub const GeneralCouncilMotionDuration: BlockNumber = 0;
+	pub const GeneralCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const GeneralCouncilMaxProposals: u32 = 100;
 	pub const GeneralCouncilMaxMembers: u32 = 100;
 }
@@ -356,7 +356,7 @@ impl pallet_membership::Config<GeneralCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HonzonCouncilMotionDuration: BlockNumber = 0;
+	pub const HonzonCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HonzonCouncilMaxProposals: u32 = 100;
 	pub const HonzonCouncilMaxMembers: u32 = 100;
 }
@@ -386,7 +386,7 @@ impl pallet_membership::Config<HonzonCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const HomaCouncilMotionDuration: BlockNumber = 0;
+	pub const HomaCouncilMotionDuration: BlockNumber = 7 * DAYS;
 	pub const HomaCouncilMaxProposals: u32 = 100;
 	pub const HomaCouncilMaxMembers: u32 = 100;
 }
@@ -416,7 +416,7 @@ impl pallet_membership::Config<HomaCouncilMembershipInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const TechnicalCommitteeMotionDuration: BlockNumber = 0;
+	pub const TechnicalCommitteeMotionDuration: BlockNumber = 7 * DAYS;
 	pub const TechnicalCommitteeMaxProposals: u32 = 100;
 	pub const TechnicalCouncilMaxMembers: u32 = 100;
 }


### PR DESCRIPTION
If `MotionDuration` is `0`, as long as there is a new proposal, anyone can maliciously immediately disprove it:

https://github.com/paritytech/substrate/blob/163412d6cf5a2df9eed9a5f78bac54ad7ef99982/frame/collective/src/lib.rs#L627-L656