### PR TITLE
merge-duplicated-endowed-accounts

### DIFF
--- a/bin/acala-dev/service/src/chain_spec/mandala.rs
+++ b/bin/acala-dev/service/src/chain_spec/mandala.rs
@@ -184,14 +184,16 @@ fn testnet_genesis(
 	enable_println: bool,
 ) -> mandala_runtime::GenesisConfig {
 	use mandala_runtime::{
-		get_all_module_accounts, AcalaOracleConfig, AirDropConfig, BabeConfig, BalancesConfig, BandOracleConfig,
-		CdpEngineConfig, CdpTreasuryConfig, ContractsConfig, CurrencyId, DexConfig, EVMConfig, EnabledTradingPairs,
-		GeneralCouncilMembershipConfig, GrandpaConfig, HomaCouncilMembershipConfig, HonzonCouncilMembershipConfig,
-		IndicesConfig, NativeTokenExistentialDeposit, OperatorMembershipAcalaConfig, OperatorMembershipBandConfig,
-		OrmlNFTConfig, RenVmBridgeConfig, SessionConfig, StakerStatus, StakingConfig, StakingPoolConfig, SudoConfig,
-		SystemConfig, TechnicalCommitteeMembershipConfig, TokenSymbol, TokensConfig, TradingPair, VestingConfig,
-		DOLLARS,
+		get_all_module_accounts, AcalaOracleConfig, AirDropConfig, BabeConfig, Balance, BalancesConfig,
+		BandOracleConfig, CdpEngineConfig, CdpTreasuryConfig, ContractsConfig, CurrencyId, DexConfig, EVMConfig,
+		EnabledTradingPairs, GeneralCouncilMembershipConfig, GrandpaConfig, HomaCouncilMembershipConfig,
+		HonzonCouncilMembershipConfig, IndicesConfig, NativeTokenExistentialDeposit, OperatorMembershipAcalaConfig,
+		OperatorMembershipBandConfig, OrmlNFTConfig, RenVmBridgeConfig, SessionConfig, StakerStatus, StakingConfig,
+		StakingPoolConfig, SudoConfig, SystemConfig, TechnicalCommitteeMembershipConfig, TokenSymbol, TokensConfig,
+		TradingPair, VestingConfig, DOLLARS,
 	};
+	#[cfg(feature = "std")]
+	use sp_std::collections::btree_map::BTreeMap;
 
 	let existential_deposit = NativeTokenExistentialDeposit::get();
 
@@ -200,7 +202,8 @@ fn testnet_genesis(
 
 	let (evm_genesis_accounts, network_contract_index) = evm_genesis();
 
-	let mut balances = initial_authorities
+	// merge duplicated
+	let balances = initial_authorities
 		.iter()
 		.map(|x| (x.0.clone(), INITIAL_STAKING + DOLLARS)) // bit more for fee
 		.chain(endowed_accounts.iter().cloned().map(|k| (k, INITIAL_BALANCE)))
@@ -209,10 +212,21 @@ fn testnet_genesis(
 				.iter()
 				.map(|x| (x.clone(), existential_deposit)),
 		)
-		.collect::<Vec<_>>();
-
-	balances.sort_by_key(|x| x.0.clone());
-	balances.dedup_by_key(|x| x.0.clone());
+		.fold(
+			BTreeMap::<AccountId, Balance>::new(),
+			|mut acc, (account_id, amount)| {
+				if let Some(balance) = acc.get_mut(&account_id) {
+					*balance = balance
+						.checked_add(amount)
+						.expect("balance cannot overflow when building genesis");
+				} else {
+					acc.insert(account_id.clone(), amount);
+				}
+				acc
+			},
+		)
+		.into_iter()
+		.collect::<Vec<(AccountId, Balance)>>();
 
 	mandala_runtime::GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -411,6 +425,8 @@ fn mandala_genesis(
 		StakingPoolConfig, SudoConfig, SystemConfig, TechnicalCommitteeMembershipConfig, TokenSymbol, TokensConfig,
 		VestingConfig, CENTS, DOLLARS,
 	};
+	#[cfg(feature = "std")]
+	use sp_std::collections::btree_map::BTreeMap;
 
 	let existential_deposit = NativeTokenExistentialDeposit::get();
 
@@ -419,7 +435,7 @@ fn mandala_genesis(
 
 	let (evm_genesis_accounts, network_contract_index) = evm_genesis();
 
-	let mut balances = initial_authorities
+	let balances = initial_authorities
 		.iter()
 		.map(|x| (x.0.clone(), INITIAL_STAKING + DOLLARS)) // bit more for fee
 		.chain(endowed_accounts.iter().cloned().map(|k| (k, INITIAL_BALANCE)))
@@ -428,10 +444,21 @@ fn mandala_genesis(
 				.iter()
 				.map(|x| (x.clone(), existential_deposit)),
 		)
-		.collect::<Vec<_>>();
-
-	balances.sort_by_key(|x| x.0.clone());
-	balances.dedup_by_key(|x| x.0.clone());
+		.fold(
+			BTreeMap::<AccountId, Balance>::new(),
+			|mut acc, (account_id, amount)| {
+				if let Some(balance) = acc.get_mut(&account_id) {
+					*balance = balance
+						.checked_add(amount)
+						.expect("balance cannot overflow when building genesis");
+				} else {
+					acc.insert(account_id.clone(), amount);
+				}
+				acc
+			},
+		)
+		.into_iter()
+		.collect::<Vec<(AccountId, Balance)>>();
 
 	mandala_runtime::GenesisConfig {
 		frame_system: Some(SystemConfig {

--- a/bin/acala/service/src/chain_spec/karura.rs
+++ b/bin/acala/service/src/chain_spec/karura.rs
@@ -1,4 +1,4 @@
-use acala_primitives::{AccountId, AirDropCurrencyId};
+use acala_primitives::AccountId;
 use hex_literal::hex;
 use sc_chain_spec::ChainType;
 use sc_telemetry::TelemetryEndpoints;
@@ -108,6 +108,8 @@ fn karura_genesis(
 		OrmlNFTConfig, RenVmBridgeConfig, SessionConfig, StakerStatus, StakingConfig, StakingPoolConfig, SudoConfig,
 		SystemConfig, TechnicalCommitteeMembershipConfig, TokenSymbol, TokensConfig, VestingConfig, CENTS, DOLLARS,
 	};
+	#[cfg(feature = "std")]
+	use sp_std::collections::btree_map::BTreeMap;
 
 	let existential_deposit = NativeTokenExistentialDeposit::get();
 	let airdrop_accounts_json = &include_bytes!("../../../../../resources/mandala-airdrop-KAR.json")[..];
@@ -134,7 +136,21 @@ fn karura_genesis(
 						.map(|x| (x.clone(), existential_deposit)),
 				)
 				.chain(airdrop_accounts)
-				.collect(),
+				.fold(
+					BTreeMap::<AccountId, Balance>::new(),
+					|mut acc, (account_id, amount)| {
+						if let Some(balance) = acc.get_mut(&account_id) {
+							*balance = balance
+								.checked_add(amount)
+								.expect("balance cannot overflow when building genesis");
+						} else {
+							acc.insert(account_id.clone(), amount);
+						}
+						acc
+					},
+				)
+				.into_iter()
+				.collect::<Vec<(AccountId, Balance)>>(),
 		}),
 		pallet_session: Some(SessionConfig {
 			keys: initial_authorities


### PR DESCRIPTION
close #691

There are some duplicate airdrop accounts, when build pallet_balances genesis,  should merge the balance that belonging to the same account instead of discarding the duplicate accounts