### PR TITLE
expose some pallet constants

### DIFF
--- a/modules/auction_manager/src/mock.rs
+++ b/modules/auction_manager/src/mock.rs
@@ -165,7 +165,7 @@ impl PriceProvider<CurrencyId> for MockPriceSource {
 parameter_types! {
 	pub const DEXModuleId: ModuleId = ModuleId(*b"aca/dexm");
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs : Vec<TradingPair> = vec![TradingPair::new(AUSD, BTC)];
 }
 

--- a/modules/cdp_engine/src/mock.rs
+++ b/modules/cdp_engine/src/mock.rs
@@ -247,7 +247,7 @@ pub type CDPTreasuryModule = cdp_treasury::Module<Runtime>;
 parameter_types! {
 	pub const DEXModuleId: ModuleId = ModuleId(*b"aca/dexm");
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs : Vec<TradingPair> = vec![TradingPair::new(AUSD, BTC), TradingPair::new(AUSD, DOT)];
 }
 

--- a/modules/cdp_treasury/src/mock.rs
+++ b/modules/cdp_treasury/src/mock.rs
@@ -125,7 +125,7 @@ pub type Currencies = orml_currencies::Module<Runtime>;
 parameter_types! {
 	pub const GetStableCurrencyId: CurrencyId = AUSD;
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs : Vec<TradingPair> = vec![TradingPair::new(AUSD, BTC)];
 	pub const DEXModuleId: ModuleId = ModuleId(*b"aca/dexm");
 }

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -29,7 +29,7 @@ pub mod module {
 	use sp_core::U256;
 	use sp_runtime::{
 		traits::{AccountIdConversion, UniqueSaturatedInto, Zero},
-		DispatchError, DispatchResult, FixedPointNumber, ModuleId, RuntimeDebug,
+		DispatchError, DispatchResult, FixedPointNumber, ModuleId, RuntimeDebug, SaturatedConversion,
 	};
 	use sp_std::{convert::TryInto, prelude::*, vec};
 	use support::{DEXIncentives, DEXManager, Price, Ratio};
@@ -92,8 +92,9 @@ pub mod module {
 		/// operation.
 		type GetExchangeFee: Get<(u32, u32)>;
 
+		#[pallet::constant]
 		/// The limit for length of trading path
-		type TradingPathLimit: Get<usize>;
+		type TradingPathLimit: Get<u32>;
 
 		#[pallet::constant]
 		/// The DEX's module id, keep all assets in DEX.
@@ -820,7 +821,7 @@ pub mod module {
 		) -> sp_std::result::Result<Vec<Balance>, DispatchError> {
 			let path_length = path.len();
 			ensure!(
-				path_length >= 2 && path_length <= T::TradingPathLimit::get(),
+				path_length >= 2 && path_length <= T::TradingPathLimit::get().saturated_into(),
 				Error::<T>::InvalidTradingPathLength
 			);
 			let mut target_amounts: Vec<Balance> = vec![Zero::zero(); path_length];
@@ -864,7 +865,7 @@ pub mod module {
 		) -> sp_std::result::Result<Vec<Balance>, DispatchError> {
 			let path_length = path.len();
 			ensure!(
-				path_length >= 2 && path_length <= T::TradingPathLimit::get(),
+				path_length >= 2 && path_length <= T::TradingPathLimit::get().saturated_into(),
 				Error::<T>::InvalidTradingPathLength
 			);
 			let mut supply_amounts: Vec<Balance> = vec![Zero::zero(); path_length];

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -108,7 +108,7 @@ ord_parameter_types! {
 
 parameter_types! {
 	pub const GetExchangeFee: (u32, u32) = (1, 100);
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub const DEXModuleId: ModuleId = ModuleId(*b"aca/dexm");
 }
 

--- a/modules/nominees_election/src/lib.rs
+++ b/modules/nominees_election/src/lib.rs
@@ -15,7 +15,7 @@ pub mod module {
 	use primitives::{Balance, EraIndex};
 	use sp_runtime::{
 		traits::{MaybeDisplay, MaybeSerializeDeserialize, Member, Zero},
-		RuntimeDebug,
+		RuntimeDebug, SaturatedConversion,
 	};
 	use sp_std::{fmt::Debug, prelude::*};
 	use support::{NomineesProvider, OnNewEra};
@@ -106,8 +106,10 @@ pub mod module {
 		type MinBondThreshold: Get<Balance>;
 		#[pallet::constant]
 		type BondingDuration: Get<EraIndex>;
-		type NominateesCount: Get<usize>;
-		type MaxUnlockingChunks: Get<usize>;
+		#[pallet::constant]
+		type NominateesCount: Get<u32>;
+		#[pallet::constant]
+		type MaxUnlockingChunks: Get<u32>;
 	}
 
 	#[pallet::error]
@@ -178,7 +180,7 @@ pub mod module {
 
 			let mut ledger = Self::ledger(&who);
 			ensure!(
-				ledger.unlocking.len() < T::MaxUnlockingChunks::get(),
+				ledger.unlocking.len() < T::MaxUnlockingChunks::get().saturated_into(),
 				Error::<T>::TooManyChunks,
 			);
 
@@ -240,7 +242,7 @@ pub mod module {
 		pub fn nominate(origin: OriginFor<T>, targets: Vec<T::PolkadotAccountId>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			ensure!(
-				!targets.is_empty() && targets.len() <= T::NominateesCount::get(),
+				!targets.is_empty() && targets.len() <= T::NominateesCount::get().saturated_into(),
 				Error::<T>::InvalidTargetsLength,
 			);
 
@@ -311,7 +313,7 @@ pub mod module {
 
 			let new_nominees = voters
 				.into_iter()
-				.take(T::NominateesCount::get())
+				.take(T::NominateesCount::get().saturated_into())
 				.map(|(nominee, _)| nominee)
 				.collect::<Vec<_>>();
 

--- a/modules/nominees_election/src/mock.rs
+++ b/modules/nominees_election/src/mock.rs
@@ -105,8 +105,8 @@ impl orml_currencies::Config for Runtime {
 parameter_types! {
 	pub const MinBondThreshold: Balance = 5;
 	pub const BondingDuration: EraIndex = 4;
-	pub const NominateesCount: usize = 5;
-	pub const MaxUnlockingChunks: usize = 3;
+	pub const NominateesCount: u32 = 5;
+	pub const MaxUnlockingChunks: u32 = 3;
 }
 
 impl Config for Runtime {

--- a/modules/transaction_payment/src/mock.rs
+++ b/modules/transaction_payment/src/mock.rs
@@ -182,7 +182,7 @@ ord_parameter_types! {
 parameter_types! {
 	pub const DEXModuleId: ModuleId = ModuleId(*b"aca/dexm");
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs : Vec<TradingPair> = vec![TradingPair::new(AUSD, ACA), TradingPair::new(AUSD, DOT)];
 }
 

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -999,7 +999,7 @@ impl module_emergency_shutdown::Config for Runtime {
 
 parameter_types! {
 	pub const GetExchangeFee: (u32, u32) = (1, 1000);	// 0.1%
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs: Vec<TradingPair> = vec![
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::DOT)),
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::XBTC)),
@@ -1135,8 +1135,8 @@ impl module_homa::Config for Runtime {
 
 parameter_types! {
 	pub const MinCouncilBondThreshold: Balance = DOLLARS;
-	pub const NominateesCount: usize = 7;
-	pub const MaxUnlockingChunks: usize = 7;
+	pub const NominateesCount: u32 = 7;
+	pub const MaxUnlockingChunks: u32 = 7;
 	pub const NomineesElectionBondingDuration: EraIndex = 7;
 }
 

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -998,7 +998,7 @@ impl module_emergency_shutdown::Config for Runtime {
 
 parameter_types! {
 	pub const GetExchangeFee: (u32, u32) = (1, 1000);	// 0.1%
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs: Vec<TradingPair> = vec![
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::DOT)),
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::XBTC)),
@@ -1134,8 +1134,8 @@ impl module_homa::Config for Runtime {
 
 parameter_types! {
 	pub const MinCouncilBondThreshold: Balance = DOLLARS;
-	pub const NominateesCount: usize = 7;
-	pub const MaxUnlockingChunks: usize = 7;
+	pub const NominateesCount: u32 = 7;
+	pub const MaxUnlockingChunks: u32 = 7;
 	pub const NomineesElectionBondingDuration: EraIndex = 7;
 }
 

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -999,7 +999,7 @@ impl module_emergency_shutdown::Config for Runtime {
 
 parameter_types! {
 	pub const GetExchangeFee: (u32, u32) = (1, 1000);	// 0.1%
-	pub const TradingPathLimit: usize = 3;
+	pub const TradingPathLimit: u32 = 3;
 	pub EnabledTradingPairs: Vec<TradingPair> = vec![
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::DOT)),
 		TradingPair::new(CurrencyId::Token(TokenSymbol::AUSD), CurrencyId::Token(TokenSymbol::XBTC)),
@@ -1139,8 +1139,8 @@ impl module_homa::Config for Runtime {
 
 parameter_types! {
 	pub const MinCouncilBondThreshold: Balance = DOLLARS;
-	pub const NominateesCount: usize = 7;
-	pub const MaxUnlockingChunks: usize = 7;
+	pub const NominateesCount: u32 = 7;
+	pub const MaxUnlockingChunks: u32 = 7;
 	pub const NomineesElectionBondingDuration: EraIndex = 7;
 }
 


### PR DESCRIPTION
`#[pallet::constant]` cannot expose `Get<usize>`, so change these pallet constants type to `Get<u32>` so than can be exposed.