### PR TITLE
weight template update

### DIFF
--- a/templates/module-weight-template.hbs
+++ b/templates/module-weight-template.hbs
@@ -10,9 +10,10 @@
 // {{arg}}
 {{/each}}
 
-#![rustfmt::skip]
+#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
+#![allow(clippy::unnecessary_cast)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use sp_std::marker::PhantomData;


### PR DESCRIPTION
replace `#![rustfmt::skip]` with `#![cfg_attr(rustfmt, rustfmt_skip)]` to avoid warnings