### PR TITLE
CI fix: benchmarking tests run twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ jobs:
       run: rustup component add clippy
     - name: Run clippy
       run: cargo clippy -- -D warnings
-    - name: Run tests
-      run: make test-all
-    - name: Run test-eth
+    - name: Run runtime tests
+      run: make test-runtimes
+    - name: Run eth tests
       run: make test-eth
     - name: Run benchmarking tests
       run: make test-benchmarking

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ test: githooks
 test-eth: githooks
 	SKIP_WASM_BUILD= cargo test test_evm_module --features with-ethereum-compatibility -p mandala-runtime
 
-.PHONY: test-all
-test-all: test-runtimes test-benchmarking
-
 .PHONY: test-runtimes
 test-runtimes:
 	SKIP_WASM_BUILD= cargo test --all --features with-all-runtime
@@ -64,6 +61,9 @@ test-runtimes:
 .PHONY: test-benchmarking
 test-benchmarking:
 	SKIP_WASM_BUILD= cargo test --features runtime-benchmarks --features with-all-runtime --features --all benchmarking
+
+.PHONY: test-all
+test-all: test-runtimes test-eth test-benchmarking
 
 .PHONY: purge
 purge: target/debug/acala-dev


### PR DESCRIPTION
- CI fix: benchmarking tests run twice, once in `test-all`, the other in `test-bechmarking`.
- Makefile update: include all tests in `test-all`.