### PR TITLE
Instant-sealing finalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "ecosystem-renvm-bridge",
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
+ "futures 0.3.14",
  "hex-literal 0.3.1",
  "jsonrpc-core",
  "karura-runtime",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = { version = "0.1.48" }
 hex-literal = "0.3.1"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
+futures = "0.3.9"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 
 jsonrpc-core = "15.1.0"

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -41,6 +41,7 @@ pub use mandala_runtime;
 use sc_consensus_aura::StartAuraParams;
 
 use acala_primitives::{Block, Hash};
+use futures::stream::StreamExt;
 use mock_inherent_data_provider::MockParachainInherentDataProvider;
 use polkadot_primitives::v0::CollatorPair;
 use sc_client_api::ExecutorProvider;
@@ -637,12 +638,23 @@ fn inner_mandala_dev(config: Configuration, instant_sealing: bool) -> Result<Tas
 		);
 
 		if instant_sealing {
+			let pool = transaction_pool.pool().clone();
+			let commands_stream = pool.validated_pool().import_notification_stream().map(|_| {
+				sc_consensus_manual_seal::rpc::EngineCommand::SealNewBlock {
+					create_empty: false,
+					finalize: true,
+					parent_hash: None,
+					sender: None,
+				}
+			});
+
 			let authorship_future =
-				sc_consensus_manual_seal::run_instant_seal(sc_consensus_manual_seal::InstantSealParams {
+				sc_consensus_manual_seal::run_manual_seal(sc_consensus_manual_seal::ManualSealParams {
 					block_import: client.clone(),
 					env: proposer_factory,
 					client: client.clone(),
-					pool: transaction_pool.pool().clone(),
+					pool,
+					commands_stream,
 					select_chain,
 					consensus_data_provider: None,
 					create_inherent_data_providers: |_, _| async {

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -41,6 +41,7 @@ pub use mandala_runtime;
 use sc_consensus_aura::StartAuraParams;
 
 use acala_primitives::{Block, Hash};
+#[cfg(feature = "with-mandala-runtime")]
 use futures::stream::StreamExt;
 use mock_inherent_data_provider::MockParachainInherentDataProvider;
 use polkadot_primitives::v0::CollatorPair;


### PR DESCRIPTION
We can run node with `--dev --instant-sealing`  to finalize the block.