### PR TITLE
Only update points of candidates in validators

### DIFF
--- a/modules/collator-selection/src/lib.rs
+++ b/modules/collator-selection/src/lib.rs
@@ -363,7 +363,9 @@ pub mod pallet {
 				author,
 				<frame_system::Pallet<T>>::block_number(),
 			);
-			<SessionPoints<T>>::mutate(author, |point| *point += 1);
+			if <SessionPoints<T>>::contains_key(&author) {
+				<SessionPoints<T>>::mutate(author, |point| *point += 1);
+			}
 
 			frame_system::Pallet::<T>::register_extra_weight_unchecked(
 				T::WeightInfo::note_author(),


### PR DESCRIPTION
Closes: #1067 

Here only remove the candidate in `Candidates` storage.

The `Invulnerables` will not be removed and a minimum number of candidates can be kept.