### PR TITLE
return details when honzon authorize/unauthorize

### DIFF
--- a/modules/honzon/src/lib.rs
+++ b/modules/honzon/src/lib.rs
@@ -66,10 +66,14 @@ pub mod module {
 
 	#[pallet::error]
 	pub enum Error<T> {
-		// No authorization
-		NoAuthorization,
+		// No permisson
+		NoPermission,
 		// The system has been shutdown
 		AlreadyShutdown,
+		// Authorization not exists
+		AuthorizationNotExists,
+		// Have authorized already
+		AlreadyAuthorized,
 	}
 
 	#[pallet::event]
@@ -189,8 +193,10 @@ pub mod module {
 					<T as Config>::Currency::reserve(&from, reserve_amount)?;
 					*maybe_reserved = Some(reserve_amount);
 					Self::deposit_event(Event::Authorization(from.clone(), to.clone(), currency_id));
+					Ok(())
+				} else {
+					Err(Error::<T>::AlreadyAuthorized.into())
 				}
-				Ok(())
 			})?;
 			Ok(().into())
 		}
@@ -208,10 +214,10 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let from = ensure_signed(origin)?;
 			let to = T::Lookup::lookup(to)?;
-			if let Some(reserved) = Authorization::<T>::take(&from, (currency_id, &to)) {
-				<T as Config>::Currency::unreserve(&from, reserved);
-				Self::deposit_event(Event::UnAuthorization(from, to, currency_id));
-			}
+			let reserved =
+				Authorization::<T>::take(&from, (currency_id, &to)).ok_or(Error::<T>::AuthorizationNotExists)?;
+			<T as Config>::Currency::unreserve(&from, reserved);
+			Self::deposit_event(Event::UnAuthorization(from, to, currency_id));
 			Ok(().into())
 		}
 
@@ -236,7 +242,7 @@ impl<T: Config> Pallet<T> {
 	fn check_authorization(from: &T::AccountId, to: &T::AccountId, currency_id: CurrencyId) -> DispatchResult {
 		ensure!(
 			from == to || Authorization::<T>::contains_key(from, (currency_id, to)),
-			Error::<T>::NoAuthorization
+			Error::<T>::NoPermission
 		);
 		Ok(())
 	}

--- a/modules/honzon/src/tests.rs
+++ b/modules/honzon/src/tests.rs
@@ -35,8 +35,11 @@ fn authorize_should_work() {
 		assert_ok!(HonzonModule::authorize(Origin::signed(ALICE), BTC, BOB));
 		assert_eq!(PalletBalances::reserved_balance(ALICE), DepositPerAuthorization::get());
 		System::assert_last_event(Event::honzon(crate::Event::Authorization(ALICE, BOB, BTC)));
-
 		assert_ok!(HonzonModule::check_authorization(&ALICE, &BOB, BTC));
+		assert_noop!(
+			HonzonModule::authorize(Origin::signed(ALICE), BTC, BOB),
+			Error::<Runtime>::AlreadyAuthorized
+		);
 	});
 }
 
@@ -51,10 +54,13 @@ fn unauthorize_should_work() {
 		assert_ok!(HonzonModule::unauthorize(Origin::signed(ALICE), BTC, BOB));
 		assert_eq!(PalletBalances::reserved_balance(ALICE), 0);
 		System::assert_last_event(Event::honzon(crate::Event::UnAuthorization(ALICE, BOB, BTC)));
-
 		assert_noop!(
 			HonzonModule::check_authorization(&ALICE, &BOB, BTC),
-			Error::<Runtime>::NoAuthorization
+			Error::<Runtime>::NoPermission
+		);
+		assert_noop!(
+			HonzonModule::unauthorize(Origin::signed(ALICE), BTC, BOB),
+			Error::<Runtime>::AuthorizationNotExists
 		);
 	});
 }
@@ -72,11 +78,11 @@ fn unauthorize_all_should_work() {
 
 		assert_noop!(
 			HonzonModule::check_authorization(&ALICE, &BOB, BTC),
-			Error::<Runtime>::NoAuthorization
+			Error::<Runtime>::NoPermission
 		);
 		assert_noop!(
 			HonzonModule::check_authorization(&ALICE, &BOB, DOT),
-			Error::<Runtime>::NoAuthorization
+			Error::<Runtime>::NoPermission
 		);
 	});
 }
@@ -106,7 +112,7 @@ fn transfer_unauthorization_loans_should_not_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
 			HonzonModule::transfer_loan_from(Origin::signed(ALICE), BTC, BOB),
-			Error::<Runtime>::NoAuthorization,
+			Error::<Runtime>::NoPermission,
 		);
 	});
 }


### PR DESCRIPTION
return error when authorization was already done before (for the authorize function), or, if there were no authorization to be cancelled (for the unauthorize call)