### PR TITLE
Adjust xcm execution fee in Karura.

### DIFF
--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1351,7 +1351,7 @@ pub type XcmOriginToCallOrigin = (
 );
 
 parameter_types! {
-	// One XCM operation is 200_000_000 weight, ~= 2x of transfer.
+	// One XCM operation is 200_000_000 weight, cross-chain transfer ~= 2x of transfer.
 	pub const UnitWeightCost: Weight = 200_000_000;
 	pub KsmPerSecond: (MultiLocation, u128) = (X1(Parent), ksm_per_second());
 }

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1351,8 +1351,8 @@ pub type XcmOriginToCallOrigin = (
 );
 
 parameter_types! {
-	// One XCM operation is 1_000_000 weight - almost certainly a conservative estimate.
-	pub const UnitWeightCost: Weight = 1_000_000;
+	// One XCM operation is 200_000_000 weight, ~= 2x of transfer.
+	pub const UnitWeightCost: Weight = 200_000_000;
 	pub KsmPerSecond: (MultiLocation, u128) = (X1(Parent), ksm_per_second());
 }
 


### PR DESCRIPTION
The fee of receiving a KSM cross-chain transfer would be the double of transfer within Karura.