### PR TITLE
refactor some calculation from saturating to checked

### DIFF
--- a/modules/cdp-engine/src/lib.rs
+++ b/modules/cdp-engine/src/lib.rs
@@ -750,7 +750,7 @@ impl<T: Config> Pallet<T> {
 		let locked_collateral_value = price.saturating_mul_int(collateral_balance);
 		let debit_value = Self::get_debit_value(currency_id, debit_balance);
 
-		Ratio::checked_from_rational(locked_collateral_value, debit_value).unwrap_or_else(Rate::max_value)
+		Ratio::checked_from_rational(locked_collateral_value, debit_value).unwrap_or_else(Ratio::max_value)
 	}
 
 	pub fn adjust_position(

--- a/modules/cdp-treasury/src/lib.rs
+++ b/modules/cdp-treasury/src/lib.rs
@@ -33,7 +33,7 @@ use frame_system::pallet_prelude::*;
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
 use primitives::{Balance, CurrencyId};
 use sp_runtime::{
-	traits::{AccountIdConversion, One, Zero},
+	traits::{AccountIdConversion, Bounded, One, Zero},
 	ArithmeticError, DispatchError, DispatchResult, FixedPointNumber,
 };
 use support::{AuctionManager, CDPTreasury, CDPTreasuryExtended, DEXManager, Ratio};
@@ -285,7 +285,7 @@ impl<T: Config> CDPTreasury<T::AccountId> for Pallet<T> {
 
 	fn get_debit_proportion(amount: Self::Balance) -> Ratio {
 		let stable_total_supply = T::Currency::total_issuance(T::GetStableCurrencyId::get());
-		Ratio::checked_from_rational(amount, stable_total_supply).unwrap_or_default()
+		Ratio::checked_from_rational(amount, stable_total_supply).unwrap_or_else(Ratio::max_value)
 	}
 
 	fn on_system_debit(amount: Self::Balance) -> DispatchResult {

--- a/modules/cdp-treasury/src/lib.rs
+++ b/modules/cdp-treasury/src/lib.rs
@@ -33,7 +33,7 @@ use frame_system::pallet_prelude::*;
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
 use primitives::{Balance, CurrencyId};
 use sp_runtime::{
-	traits::{AccountIdConversion, Bounded, One, Zero},
+	traits::{AccountIdConversion, One, Zero},
 	ArithmeticError, DispatchError, DispatchResult, FixedPointNumber,
 };
 use support::{AuctionManager, CDPTreasury, CDPTreasuryExtended, DEXManager, Ratio};
@@ -285,7 +285,7 @@ impl<T: Config> CDPTreasury<T::AccountId> for Pallet<T> {
 
 	fn get_debit_proportion(amount: Self::Balance) -> Ratio {
 		let stable_total_supply = T::Currency::total_issuance(T::GetStableCurrencyId::get());
-		Ratio::checked_from_rational(amount, stable_total_supply).unwrap_or_else(Ratio::max_value)
+		Ratio::checked_from_rational(amount, stable_total_supply).unwrap_or_default()
 	}
 
 	fn on_system_debit(amount: Self::Balance) -> DispatchResult {

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -780,10 +780,14 @@ fn _swap_work() {
 			LiquidityPool::<Runtime>::insert(AUSDDOTPair::get(), (50000, 10000));
 
 			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (50000, 10000));
-			DexModule::_swap(AUSD, DOT, 1000, 1000);
-			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (51000, 9000));
-			DexModule::_swap(DOT, AUSD, 100, 800);
-			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (50200, 9100));
+			assert_noop!(
+				DexModule::_swap(AUSD, DOT, 50000, 5001),
+				Error::<Runtime>::InvariantCheckFailed
+			);
+			assert_ok!(DexModule::_swap(AUSD, DOT, 50000, 5000));
+			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (100000, 5000));
+			assert_ok!(DexModule::_swap(DOT, AUSD, 100, 800));
+			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (99200, 5100));
 		});
 }
 
@@ -798,11 +802,11 @@ fn _swap_by_path_work() {
 
 			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (50000, 10000));
 			assert_eq!(DexModule::get_liquidity(AUSD, BTC), (100000, 10));
-			DexModule::_swap_by_path(&vec![DOT, AUSD], &vec![10000, 25000]);
+			assert_ok!(DexModule::_swap_by_path(&vec![DOT, AUSD], &vec![10000, 25000]));
 			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (25000, 20000));
-			DexModule::_swap_by_path(&vec![DOT, AUSD, BTC], &vec![4000, 10000, 2]);
-			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (15000, 24000));
-			assert_eq!(DexModule::get_liquidity(AUSD, BTC), (110000, 8));
+			assert_ok!(DexModule::_swap_by_path(&vec![DOT, AUSD, BTC], &vec![100000, 20000, 1]));
+			assert_eq!(DexModule::get_liquidity(AUSD, DOT), (5000, 120000));
+			assert_eq!(DexModule::get_liquidity(AUSD, BTC), (120000, 9));
 		});
 }
 

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -886,6 +886,11 @@ fn add_liquidity_work() {
 			assert_eq!(Tokens::free_balance(DOT, &BOB), 1_000_000_000_000_000_000);
 
 			assert_noop!(
+				DexModule::add_liquidity(Origin::signed(BOB), AUSD, DOT, 4, 1, 0, true,),
+				Error::<Runtime>::InvalidLiquidityIncrement,
+			);
+
+			assert_noop!(
 				DexModule::add_liquidity(
 					Origin::signed(BOB),
 					AUSD,
@@ -897,6 +902,7 @@ fn add_liquidity_work() {
 				),
 				Error::<Runtime>::UnacceptableShareIncrement
 			);
+
 			assert_ok!(DexModule::add_liquidity(
 				Origin::signed(BOB),
 				AUSD,

--- a/modules/homa-validator-list/src/lib.rs
+++ b/modules/homa-validator-list/src/lib.rs
@@ -40,7 +40,7 @@ use primitives::Balance;
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
 	offchain::storage_lock::BlockNumberProvider,
-	traits::{MaybeDisplay, MaybeSerializeDeserialize, Member, Zero},
+	traits::{Bounded, MaybeDisplay, MaybeSerializeDeserialize, Member, Zero},
 	DispatchResult, FixedPointNumber, RuntimeDebug,
 };
 use sp_std::{fmt::Debug, vec::Vec};
@@ -455,7 +455,7 @@ pub mod module {
 					// NOTE: ignoring result because the closure will not throw err.
 					let res = Self::update_guarantee(&guarantor, &validator, |guarantee| -> DispatchResult {
 						let should_slashing = Ratio::checked_from_rational(guarantee.total, total_insurance)
-							.unwrap_or_default()
+							.unwrap_or_else(Ratio::max_value)
 							.saturating_mul_int(insurance_loss);
 						let gap = T::LiquidTokenCurrency::slash(&guarantor, should_slashing);
 						let actual_slashing = should_slashing.saturating_sub(gap);

--- a/modules/staking-pool/src/lib.rs
+++ b/modules/staking-pool/src/lib.rs
@@ -26,7 +26,7 @@ use primitives::{Balance, CurrencyId, EraIndex};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
-	traits::{AccountIdConversion, Bounded, CheckedDiv, Saturating, Zero},
+	traits::{AccountIdConversion, CheckedDiv, Saturating, Zero},
 	ArithmeticError, DispatchError, DispatchResult, FixedPointNumber, RuntimeDebug,
 };
 use sp_std::prelude::*;
@@ -113,15 +113,13 @@ impl Ledger {
 
 	/// The ratio of `free_pool` in `total_belong_to_liquid_holders`.
 	fn free_pool_ratio(&self) -> Ratio {
-		Ratio::checked_from_rational(self.free_pool, self.total_belong_to_liquid_holders())
-			.unwrap_or_else(Ratio::max_value)
+		Ratio::checked_from_rational(self.free_pool, self.total_belong_to_liquid_holders()).unwrap_or_default()
 	}
 
 	/// The ratio of `unbonding_to_free` in
 	/// `total_belong_to_liquid_holders`.
 	fn unbonding_to_free_ratio(&self) -> Ratio {
-		Ratio::checked_from_rational(self.unbonding_to_free, self.total_belong_to_liquid_holders())
-			.unwrap_or_else(Ratio::max_value)
+		Ratio::checked_from_rational(self.unbonding_to_free, self.total_belong_to_liquid_holders()).unwrap_or_default()
 	}
 }
 


### PR DESCRIPTION
related to #1192 

If DEX opens trading pair registration in the future, especially for these ERC20 tokens, many saturation calculations which use `FixedU128` as multiper are actually easy to overflow, which will bring malicious attacks. So it's necessary to modify those saturation calculations to checked calculations.