### PR TITLE
Support crosschain transaction between Acala and Manta.

### DIFF
--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -189,6 +189,9 @@ create_currency_id! {
 
 		// External Ecosystem
 		CASH("Compound CASH", 8) = 140,
+
+		// Manta Parachain
+		MA("Manta", 12) = 5,
 	}
 }
 

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -179,6 +179,7 @@ create_currency_id! {
 		DOT("Polkadot", 10) = 2,
 		LDOT("Liquid DOT", 10) = 3,
 		RENBTC("Ren Protocol BTC", 8) = 4,
+		MA("Manta", 12) = 5,
 
 		// Kusama Ecosystem
 		KAR("Karura", 12) = 128,
@@ -186,12 +187,10 @@ create_currency_id! {
 		KSM("Kusama", 12) = 130,
 		LKSM("Liquid KSM", 12) = 131,
 		// Reserve for RENBTC = 132
+		KMA("Calamari", 12) = 133,
 
 		// External Ecosystem
 		CASH("Compound CASH", 8) = 140,
-
-		// Manta Parachain
-		MA("Manta", 12) = 5,
 	}
 }
 

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1510,7 +1510,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 		use TokenSymbol::*;
 		match id {
 			Token(KSM) => Some(X1(Parent)),
-			Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) => Some(native_currency_location(id)),
+			Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) | Token(KMA) => Some(native_currency_location(id)),
 			_ => None,
 		}
 	}
@@ -1526,7 +1526,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				if let Ok(currency_id) = CurrencyId::decode(&mut &key[..]) {
 					// check `currency_id` is cross-chain asset
 					match currency_id {
-						Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) => Some(currency_id),
+						Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) | Token(KMA) => Some(currency_id),
 						_ => None,
 					}
 				} else {

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -737,6 +737,7 @@ parameter_type_with_key! {
 				TokenSymbol::RENBTC |
 				TokenSymbol::KAR |
 				TokenSymbol::MA |
+				TokenSymbol::KMA |
 				TokenSymbol::CASH => Balance::max_value() // unsupported
 			},
 			CurrencyId::DexShare(dex_share_0, _) => {

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -736,6 +736,7 @@ parameter_type_with_key! {
 				TokenSymbol::LDOT |
 				TokenSymbol::RENBTC |
 				TokenSymbol::KAR |
+				TokenSymbol::MA |
 				TokenSymbol::CASH => Balance::max_value() // unsupported
 			},
 			CurrencyId::DexShare(dex_share_0, _) => {
@@ -1375,6 +1376,10 @@ parameter_types! {
 	// One XCM operation is 200_000_000 weight, cross-chain transfer ~= 2x of transfer.
 	pub const UnitWeightCost: Weight = 200_000_000;
 	pub KsmPerSecond: (MultiLocation, u128) = (X1(Parent), ksm_per_second());
+	pub MantaLocation: (MultiLocation, u128) = (
+		X3(Parent, Parachain(2084), GeneralKey(CurrencyId::Token(TokenSymbol::MA).encode())),
+		ksm_per_second()
+	);
 }
 
 pub type Barrier = (TakeWeightCredit, AllowTopLevelPaidExecutionFrom<All<MultiLocation>>);
@@ -1406,7 +1411,7 @@ impl xcm_executor::Config for XcmConfig {
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call>;
 	// Only receiving KSM is handled, and all fees must be paid in KSM.
-	type Trader = FixedRateOfConcreteFungible<KsmPerSecond, ToTreasury>;
+	type Trader = FixedRateOfConcreteFungible<MantaLocation, ToTreasury>;
 	type ResponseHandler = (); // Don't handle responses for now.
 }
 
@@ -1505,7 +1510,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 		use TokenSymbol::*;
 		match id {
 			Token(KSM) => Some(X1(Parent)),
-			Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) => Some(native_currency_location(id)),
+			Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) => Some(native_currency_location(id)),
 			_ => None,
 		}
 	}
@@ -1521,7 +1526,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				if let Ok(currency_id) = CurrencyId::decode(&mut &key[..]) {
 					// check `currency_id` is cross-chain asset
 					match currency_id {
-						Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) => Some(currency_id),
+						Token(KAR) | Token(KUSD) | Token(LKSM) | Token(RENBTC) | Token(MA) => Some(currency_id),
 						_ => None,
 					}
 				} else {


### PR DESCRIPTION
1. Add `MA` to `CurrencyId`.
2. Add manta `MultiLocation` to fix `TooExpense` error.
Originally, karura runtime only supports `X1(Parent)` multiLocation, but the multilocation is `X3` while sending transaction to manta parachain. So it will get nothing because this id is `X1`(https://github.com/paritytech/polkadot/blob/release-v0.9.8/xcm/xcm-executor/src/assets.rs#L250).
And this field `fungible` just saves data like:
```rust
// amount is how many tokens you send to parachain.
X3(Parent, Parachain(2084), GeneralKey(CurrencyId::Token(TokenSymbol::MA).encode())) => amount,
// others multilocation => amount
// ...
```
