### PR TITLE
check required collateral ratio when withdraw collateral or issue more debit

### DIFF
--- a/modules/cdp-engine/src/mock.rs
+++ b/modules/cdp-engine/src/mock.rs
@@ -160,7 +160,7 @@ impl PriceProvider<CurrencyId> for MockPriceSource {
 	}
 
 	fn get_price(_currency_id: CurrencyId) -> Option<Price> {
-		Some(Price::one())
+		unimplemented!()
 	}
 }
 

--- a/modules/loans/src/lib.rs
+++ b/modules/loans/src/lib.rs
@@ -214,7 +214,12 @@ impl<T: Config> Pallet<T> {
 
 		// ensure pass risk check
 		let Position { collateral, debit } = Self::positions(currency_id, who);
-		T::RiskManager::check_position_valid(currency_id, collateral, debit)?;
+		T::RiskManager::check_position_valid(
+			currency_id,
+			collateral,
+			debit,
+			collateral_adjustment.is_negative() || debit_adjustment.is_positive(),
+		)?;
 
 		Self::deposit_event(Event::PositionUpdated(
 			who.clone(),
@@ -242,7 +247,7 @@ impl<T: Config> Pallet<T> {
 			.expect("existing debit balance cannot overflow; qed");
 
 		// check new position
-		T::RiskManager::check_position_valid(currency_id, new_to_collateral_balance, new_to_debit_balance)?;
+		T::RiskManager::check_position_valid(currency_id, new_to_collateral_balance, new_to_debit_balance, true)?;
 
 		// balance -> amount
 		let collateral_adjustment = Self::amount_try_from_balance(collateral)?;

--- a/modules/loans/src/mock.rs
+++ b/modules/loans/src/mock.rs
@@ -194,11 +194,20 @@ impl RiskManager<AccountId, CurrencyId, Balance, Balance> for MockRiskManager {
 		currency_id: CurrencyId,
 		_collateral_balance: Balance,
 		_debit_balance: Balance,
+		check_required_ratio: bool,
 	) -> DispatchResult {
 		match currency_id {
-			DOT => Err(sp_runtime::DispatchError::Other("mock invalid position error")),
+			DOT => {
+				if check_required_ratio {
+					Err(sp_runtime::DispatchError::Other(
+						"mock below required collateral ratio error",
+					))
+				} else {
+					Err(sp_runtime::DispatchError::Other("mock below liquidation ratio error"))
+				}
+			}
 			BTC => Ok(()),
-			_ => Err(sp_runtime::DispatchError::Other("mock invalid position error")),
+			_ => Err(sp_runtime::DispatchError::Other("mock below liquidation ratio error")),
 		}
 	}
 

--- a/modules/loans/src/tests.rs
+++ b/modules/loans/src/tests.rs
@@ -65,10 +65,16 @@ fn adjust_position_should_work() {
 			orml_tokens::Error::<Runtime>::BalanceTooLow
 		);
 
-		// mock can't pass position valid check
+		// mock can't pass liquidation ratio check
 		assert_noop!(
 			LoansModule::adjust_position(&ALICE, DOT, 500, 0),
-			sp_runtime::DispatchError::Other("mock invalid position error")
+			sp_runtime::DispatchError::Other("mock below liquidation ratio error")
+		);
+
+		// mock can't pass required ratio check
+		assert_noop!(
+			LoansModule::adjust_position(&ALICE, DOT, 500, 1),
+			sp_runtime::DispatchError::Other("mock below required collateral ratio error")
 		);
 
 		// mock exceed debit value cap
@@ -103,12 +109,9 @@ fn adjust_position_should_work() {
 		System::assert_last_event(Event::LoansModule(crate::Event::PositionUpdated(ALICE, BTC, 500, 300)));
 
 		// collateral_adjustment is negatives
-		// remove module account.
 		assert_eq!(Currencies::total_balance(BTC, &LoansModule::account_id()), 500);
-		assert_eq!(System::account_exists(&LoansModule::account_id()), true);
 		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, -500, 0));
 		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
-		assert_eq!(System::account_exists(&LoansModule::account_id()), false);
 	});
 }
 

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -56,6 +56,7 @@ pub trait RiskManager<AccountId, CurrencyId, Balance, DebitBalance> {
 		currency_id: CurrencyId,
 		collateral_balance: Balance,
 		debit_balance: DebitBalance,
+		check_required_ratio: bool,
 	) -> DispatchResult;
 
 	fn check_debit_cap(currency_id: CurrencyId, total_debit_balance: DebitBalance) -> DispatchResult;
@@ -72,6 +73,7 @@ impl<AccountId, CurrencyId, Balance: Default, DebitBalance> RiskManager<AccountI
 		_currency_id: CurrencyId,
 		_collateral_balance: Balance,
 		_debit_balance: DebitBalance,
+		_check_required_ratio: bool,
 	) -> DispatchResult {
 		Ok(())
 	}


### PR DESCRIPTION
If a CDP is safe but below the required collateral ratio, user wants to deposit collateral or repay debt but the collateral ratio will be still below the required collateral ratio,  the operation will fail. That's not reasonable, should only check the required collateral ratio if the collateral ratio may increase.