### PR TITLE
Homa-lite: use 'Any' network id for sovereign sub-account.

### DIFF
--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1458,7 +1458,7 @@ pub fn create_x2_parachain_multilocation(index: u16) -> MultiLocation {
 	MultiLocation::X2(
 		Junction::Parent,
 		Junction::AccountId32 {
-			network: RelayNetwork::get(),
+			network: NetworkId::Any,
 			id: Utility::derivative_account_id(ParachainInfo::get().into_account(), index).into(),
 		},
 	)


### PR DESCRIPTION
Closes #1324 