### PR TITLE
Removed the XCM weight paramter from the mint extrinsic.

### DIFF
--- a/modules/homa-lite/src/benchmarking.rs
+++ b/modules/homa-lite/src/benchmarking.rs
@@ -37,12 +37,15 @@ benchmarks! {
 		let caller: T::AccountId = account("caller", 0, SEED);
 		<T as module::Config>::Currency::deposit(T::StakingCurrencyId::get(), &caller, amount)?;
 		module::Pallet::<T>::set_minting_cap(RawOrigin::Root.into(), amount)?;
-	}: _(RawOrigin::Signed(caller), amount, 0)
+	}: _(RawOrigin::Signed(caller), amount)
 
 	set_total_staking_currency {}: _(RawOrigin::Root, 1_000_000_000_000)
 
 	set_minting_cap {
 	}: _(RawOrigin::Root, 1_000_000_000_000_000_000)
+
+	set_xcm_dest_weight {
+	}: _(RawOrigin::Root, 1_000_000_000)
 }
 
 #[cfg(test)]
@@ -233,6 +236,12 @@ mod tests {
 	fn test_set_minting_cap() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(test_benchmark_set_minting_cap::<Runtime>());
+		});
+	}
+	#[test]
+	fn test_set_xcm_dest_weight() {
+		ExtBuilder::default().build().execute_with(|| {
+			assert_ok!(test_benchmark_set_xcm_dest_weight::<Runtime>());
 		});
 	}
 }

--- a/modules/homa-lite/src/weights.rs
+++ b/modules/homa-lite/src/weights.rs
@@ -50,6 +50,7 @@ pub trait WeightInfo {
 	fn mint() -> Weight;
 	fn set_total_staking_currency() -> Weight;
 	fn set_minting_cap() -> Weight;
+	fn set_xcm_dest_weight() -> Weight;
 }
 
 /// Weights for module_homa_lite using the Acala node and recommended hardware.
@@ -68,6 +69,10 @@ impl<T: frame_system::Config> WeightInfo for AcalaWeight<T> {
 		(20_346_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn set_xcm_dest_weight() -> Weight {
+		(20_346_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -82,6 +87,10 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	fn set_minting_cap() -> Weight {
+		(20_346_000 as Weight)
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	fn set_xcm_dest_weight() -> Weight {
 		(20_346_000 as Weight)
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}

--- a/runtime/karura/src/weights/module_homa_lite.rs
+++ b/runtime/karura/src/weights/module_homa_lite.rs
@@ -60,4 +60,8 @@ impl<T: frame_system::Config> module_homa_lite::WeightInfo for WeightInfo<T> {
 		(11_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn set_xcm_dest_weight() -> Weight {
+		(20_346_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }

--- a/runtime/mandala/src/weights/module_homa_lite.rs
+++ b/runtime/mandala/src/weights/module_homa_lite.rs
@@ -60,4 +60,8 @@ impl<T: frame_system::Config> module_homa_lite::WeightInfo for WeightInfo<T> {
 		(11_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn set_xcm_dest_weight() -> Weight {
+		(20_346_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }


### PR DESCRIPTION
Replaced it with an storage that can be set by governance.

Closes #1323