### PR TITLE
Added new Redeem extrinsics

### DIFF
--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -27,10 +27,14 @@ pub mod weights;
 use frame_support::{pallet_prelude::*, transactional};
 use frame_system::{ensure_signed, pallet_prelude::*};
 use module_support::{ExchangeRate, Ratio};
-use orml_traits::{MultiCurrency, XcmTransfer};
-use primitives::{Balance, CurrencyId};
-use sp_runtime::{traits::Zero, ArithmeticError, FixedPointNumber, Permill};
-use sp_std::{ops::Mul, prelude::*};
+use orml_traits::{BalanceStatus, MultiCurrency, MultiReservableCurrency, XcmTransfer};
+use primitives::{Balance, CurrencyId, ReserveIdentifier};
+use sp_runtime::{
+	offchain::storage_lock::BlockNumberProvider,
+	traits::{Saturating, Zero},
+	ArithmeticError, FixedPointNumber, Permill,
+};
+use sp_std::{cmp::min, ops::Mul, prelude::*};
 use xcm::opaque::v0::MultiLocation;
 
 pub use module::*;
@@ -40,6 +44,8 @@ pub use weights::WeightInfo;
 pub mod module {
 	use super::*;
 
+	pub type RelaychainBlockNumberOf<T> = <<T as Config>::RelaychainBlockNumber as BlockNumberProvider>::BlockNumber;
+
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
@@ -48,7 +54,8 @@ pub mod module {
 		type WeightInfo: WeightInfo;
 
 		/// Multi-currency support for asset management
-		type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>;
+		type Currency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>
+			+ MultiReservableCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>;
 
 		/// The Currency ID for the Staking asset
 		#[pallet::constant]
@@ -83,6 +90,20 @@ pub mod module {
 		/// The fixed cost of transaction fee for XCM transfers.
 		#[pallet::constant]
 		type MintFee: Get<Balance>;
+
+		/// The fixed cost of withdrawing Staking currency via redeem.
+		#[pallet::constant]
+		type BaseWithdrawFee: Get<Permill>;
+
+		/// TODO: ???
+		type Reserveldentifier: Get<ReserveIdentifier>;
+
+		/// Block number provider for the relaychain.
+		type RelaychainBlockNumber: BlockNumberProvider<BlockNumber = Self::BlockNumber>;
+
+		/// The account ID to redeem from on the relaychain.
+		#[pallet::constant]
+		type ParachainAccount: Get<Self::AccountId>;
 	}
 
 	#[pallet::error]
@@ -93,13 +114,19 @@ pub mod module {
 		MintAmountBelowMinimumThreshold,
 		/// The amount of Staking currency used has exceeded the cap allowed.
 		ExceededStakingCurrencyMintCap,
+		/// There isn't enough reserved currencies to cancel the redeem request.
+		InsufficientReservedBalances,
+		/// Amount redeemed is above total amount staked.
+		InsufficientTotalStakingCurrency,
+		/// The user does not have enough liquid balance to redeem.
+		InsufficientLiquidBalance,
 	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	#[pallet::metadata(T::AccountId = "AccountId")]
 	pub enum Event<T: Config> {
-		/// The user has requested some Staking currency to be used to mint Liquid Currency.
+		/// The user has Staked some currencies to mint Liquid Currency.
 		/// \[user, amount_staked, amount_minted\]
 		Minted(T::AccountId, Balance, Balance),
 
@@ -112,6 +139,18 @@ pub mod module {
 
 		/// A new weight for XCM transfers has been set.\[new_weight\]
 		XcmDestWeightSet(Weight),
+
+		/// The redeem request has been cancelled, and funds un-reserved.
+		/// \[who, liquid_amount_unreserved\]
+		RedeemRequestCancelled(T::AccountId, Balance),
+
+		/// A new Redeem request has been registered.
+		/// \[who, liquid_amount\]
+		RedeemRequested(T::AccountId, Balance),
+
+		/// The user has redeemed some Liquid currency back to Staking currency.
+		/// \[user, staking_amount_redeemed, liquid_amount_deducted\]
+		Redeemed(T::AccountId, Balance, Balance),
 	}
 
 	/// The total amount of the staking currency on the relaychain.
@@ -133,80 +172,61 @@ pub mod module {
 	#[pallet::getter(fn xcm_dest_weight)]
 	pub type XcmDestWeight<T: Config> = StorageValue<_, Weight, ValueQuery>;
 
+	/// Requests to redeem staked currencies.
+	/// RedeemRequests: Map: AccountId => (liquid_amount: Balance, addtional_fee: Permill)
+	#[pallet::storage]
+	#[pallet::getter(fn redeem_requests)]
+	pub type RedeemRequests<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, (Balance, Permill), OptionQuery>;
+
+	/// The amount of staking currency that is available to be redeemed.
+	/// AvailableStakingBalance: value: Balance
+	#[pallet::storage]
+	#[pallet::getter(fn available_staking_balance)]
+	pub type AvailableStakingBalance<T: Config> = StorageValue<_, Balance, ValueQuery>;
+
+	/// Funds that will be unbounded in the future
+	/// ScheduledUnbound:
+	#[pallet::storage]
+	#[pallet::getter(fn scheduled_unbound)]
+	pub type ScheduledUnbound<T: Config> = StorageValue<_, Vec<(Balance, RelaychainBlockNumberOf<T>)>, ValueQuery>;
+
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Mint some Liquid currency, by locking up the given amount of Staking currency.
+		/// Will try to match Redeem Requests if available. Remaining amount is minted via XCM.
+		///
 		/// The exchange rate is calculated using the ratio of the total amount of the staking and
-		/// liquid currency. A portion is reducted (defined as T::MaxRewardPerEra) to make up for
-		/// the fact that staking is only effective from the next era on (on the relaychain).
+		/// liquid currency.
+		///
+		/// If any amount is minted through XCM, a portion of that amount (T::MintFee and
+		/// T::MaxRewardPerEra) is reducted as fee.
 		///
 		/// Parameters:
 		/// - `amount`: The amount of Staking currency to be exchanged.
 		#[pallet::weight(< T as Config >::WeightInfo::mint())]
 		#[transactional]
 		pub fn mint(origin: OriginFor<T>, amount: Balance) -> DispatchResult {
-			let who = ensure_signed(origin)?;
-			// Ensure the amount is above the minimum, after the MintFee is deducted.
-			ensure!(
-				amount > T::MinimumMintThreshold::get().saturating_add(T::MintFee::get()),
-				Error::<T>::MintAmountBelowMinimumThreshold
-			);
+			let minter = ensure_signed(origin)?;
 
-			// Ensure the total amount staked doesn't exceed the cap.
-			let new_total_staked = Self::total_staking_currency()
-				.checked_add(amount)
-				.ok_or(ArithmeticError::Overflow)?;
-			ensure!(
-				new_total_staked <= Self::staking_currency_mint_cap(),
-				Error::<T>::ExceededStakingCurrencyMintCap
-			);
+			Self::do_mint_with_requests(&minter, amount, vec![])
+		}
 
-			let staking_currency = T::StakingCurrencyId::get();
+		/// Mint some Liquid currency, by locking up the given amount of Staking currency.
+		/// This is similar with the mint() extrinsic, except that the given Redeem Requests are
+		/// matched with priority.
+		///
+		/// Parameters:
+		/// - `amount`: The amount of Staking currency to be exchanged.
+		/// - `requests`: The redeem requests that are prioritized to match.
+		#[pallet::weight(< T as Config >::WeightInfo::mint_for_requests())]
+		#[transactional]
+		pub fn mint_for_requests(origin: OriginFor<T>, amount: Balance, requests: Vec<T::AccountId>) -> DispatchResult {
+			let minter = ensure_signed(origin)?;
 
-			// ensure the user has enough funds on their account.
-			T::Currency::ensure_can_withdraw(staking_currency, &who, amount)?;
-
-			// Calculate how much Liquid currency is to be minted.
-			// Gets the current exchange rate
-			let staking_total = Self::total_staking_currency();
-			let liquid_total = T::Currency::total_issuance(T::LiquidCurrencyId::get());
-			let exchange_rate =
-				Ratio::checked_from_rational(liquid_total, staking_total).unwrap_or_else(T::DefaultExchangeRate::get);
-
-			// liquid_to_mint = ( (staked_amount - MintFee) * liquid_total / staked_total ) * (1 -
-			// MaxRewardPerEra)
-			let mut liquid_to_mint = exchange_rate
-				.checked_mul_int(
-					amount
-						.checked_sub(T::MintFee::get())
-						.expect("Mint amount is ensured to be greater than T::MintFee; qed"),
-				)
-				.ok_or(ArithmeticError::Overflow)?;
-
-			liquid_to_mint = liquid_to_mint
-				.checked_sub(T::MaxRewardPerEra::get().mul(liquid_to_mint))
-				.expect("Max rewards cannot be above 100%; qed");
-
-			// All checks pass. Proceed with Xcm transfer.
-			T::XcmTransfer::transfer(
-				who.clone(),
-				staking_currency,
-				amount,
-				T::SovereignSubAccountLocation::get(),
-				Self::xcm_dest_weight(),
-			)?;
-
-			// Mint the liquid currency into the user's account.
-			T::Currency::deposit(T::LiquidCurrencyId::get(), &who, liquid_to_mint)?;
-
-			TotalStakingCurrency::<T>::put(new_total_staked);
-
-			Self::deposit_event(Event::<T>::Minted(who, amount, liquid_to_mint));
-
-			Ok(())
+			Self::do_mint_with_requests(&minter, amount, requests)
 		}
 
 		/// Sets the total amount of the Staking currency that are currently on the relaychain.
@@ -254,6 +274,305 @@ pub mod module {
 
 			XcmDestWeight::<T>::put(xcm_dest_weight);
 			Self::deposit_event(Event::<T>::XcmDestWeightSet(xcm_dest_weight));
+			Ok(())
+		}
+
+		/// Put in an request to redeem Staking currencies used to mint Liquid currency.
+		/// The redemption will happen after the currencies are unbounded on the relaychain.
+		///
+		/// Parameters:
+		/// -
+		#[pallet::weight(< T as Config >::WeightInfo::request_redeem())]
+		#[transactional]
+		pub fn request_redeem(origin: OriginFor<T>, liquid_amount: Balance, additional_fee: Permill) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			if liquid_amount.is_zero() {
+				// If the maount is zero, cancel previuos redeem request.
+				if let Some((_, _)) = Self::redeem_requests(&who) {
+					// Unreserve the liquid fee and remove the redeem request.
+					ensure!(
+						T::Currency::unreserve(T::LiquidCurrencyId::get(), &who, liquid_amount) == liquid_amount,
+						Error::<T>::InsufficientReservedBalances
+					);
+					RedeemRequests::<T>::remove(&who);
+
+					Self::deposit_event(Event::<T>::RedeemRequestCancelled(who, liquid_amount));
+				}
+			} else {
+				// Put in an redeem request, or add additional amounts to be redeemed
+				let (redeemed_amount, _) = Self::redeem_requests(&who).unwrap_or((0, Permill::zero()));
+
+				ensure!(
+					liquid_amount < Self::convert_staking_to_liquid(Self::total_staking_currency())?,
+					Error::<T>::InsufficientTotalStakingCurrency
+				);
+
+				let actual_redeem_amount = min(
+					liquid_amount,
+					Self::convert_staking_to_liquid(Self::available_staking_balance())?,
+				);
+				if !actual_redeem_amount.is_zero() {
+					let new_redeemed_amount = redeemed_amount
+						.checked_add(actual_redeem_amount)
+						.ok_or(ArithmeticError::Overflow)?;
+					let new_fee = additional_fee;
+
+					// Reserve the liquid currencies to be redeem.
+					ensure!(
+						T::Currency::can_reserve(T::LiquidCurrencyId::get(), &who, actual_redeem_amount),
+						Error::<T>::InsufficientLiquidBalance
+					);
+					T::Currency::reserve(T::LiquidCurrencyId::get(), &who, actual_redeem_amount)?;
+
+					// override RedeemRequests
+					RedeemRequests::<T>::insert(&who, (new_redeemed_amount, new_fee));
+
+					Self::deposit_event(Event::<T>::RedeemRequested(who, liquid_amount));
+				}
+			}
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Calculate the exchange rate between the Staking and Liquid currency.
+		/// returns Ratio(liquid : staking) = liquid_total_issuance / total_staking_amount
+		/// If the exchange rate cannot be calculated, T::DefaultExchangeRate is used
+		fn get_exchange_rate() -> Ratio {
+			let staking_total = Self::total_staking_currency();
+			let liquid_total = T::Currency::total_issuance(T::LiquidCurrencyId::get());
+			Ratio::checked_from_rational(liquid_total, staking_total).unwrap_or_else(T::DefaultExchangeRate::get)
+		}
+
+		/// Calculate the amount of Staking currency converted from Liquid currency.
+		/// staking_amount = (1 / (total_staking_amount / liquid_total_issuance) * liquid_amount
+		/// If the exchange rate cannot be calculated, T::DefaultExchangeRate is used
+		fn convert_liquid_to_staking(liquid_amount: Balance) -> Result<Balance, DispatchError> {
+			Self::get_exchange_rate()
+				.reciprocal()
+				.unwrap_or_else(T::DefaultExchangeRate::get)
+				.checked_mul_int(liquid_amount)
+				.ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))
+		}
+
+		/// Calculate the amount of Liquid currency converted from Staking currency.
+		/// liquid_amount = (liquid_total_issuance / total_staking_amount) * staking_amount
+		/// If the exchange rate cannot be calculated, T::DefaultExchangeRate is used
+		fn convert_staking_to_liquid(staking_amount: Balance) -> Result<Balance, DispatchError> {
+			Self::get_exchange_rate()
+				.checked_mul_int(staking_amount)
+				.ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))
+		}
+
+		/// Match a redeem request with a mint request. Attempt to redeem as much as possible.
+		/// Transfer a reduced amount of Staking currency from the Minter to the Redeemer.
+		/// Transfer the full amount of Liquid currency from Redeemer to Minter.
+		/// Modify `liquid_amount_remaining` and store new RedeemRequest balances in `new_balances`.
+		/// Deposit the "Redeemed" event.
+		///
+		/// NOTE: the `RedeemRequest` storage is NOT updated. New balance is pushed into
+		/// `new_balances`, and should be processed after this.
+		///
+		/// Param:
+		/// - `minter`: The AccountId requested the Mint
+		/// - `redeemer`: The AccountId requested the Redeem
+		/// - `request_amount`: The RedeemRequest's amount
+		/// - `request_extra_fee`: The RedeemRequest's extra fee
+		/// - `liquid_amount_remaining`: The amount of liquid currency still remain to be minted.
+		///   Only redeem up to this amount.
+		/// - `new_balances`: Stores the new `RedeemRequest` balances. This should be iterated after
+		///   to update the actual storage in bulk. Actual `RedeemRequest` storage is NOT modified
+		///   here.
+		fn match_mint_with_redeem_request(
+			minter: &T::AccountId,
+			redeemer: &T::AccountId,
+			request_amount: Balance,
+			request_extra_fee: Permill,
+			liquid_amount_remaining: &mut Balance,
+			new_balances: &mut Vec<(T::AccountId, Balance, Permill)>,
+		) -> DispatchResult {
+			let liquid_amount_can_be_redeemed = min(request_amount, *liquid_amount_remaining);
+
+			let new_amount = request_amount
+				.checked_sub(liquid_amount_can_be_redeemed)
+				.expect("min() guarantees that the amount deducted is less than the current balance; qed");
+			*liquid_amount_remaining = liquid_amount_remaining
+				.checked_sub(liquid_amount_can_be_redeemed)
+				.expect("min() guarantees that the amount deducted is less than the total balance; qed");
+
+			// Full amount of Liquid is transferred to the minter.
+			let amount_repatriated = T::Currency::repatriate_reserved(
+				T::LiquidCurrencyId::get(),
+				redeemer,
+				minter,
+				liquid_amount_can_be_redeemed,
+				BalanceStatus::Free,
+			)?;
+			ensure!(
+				amount_repatriated == liquid_amount_can_be_redeemed,
+				Error::<T>::InsufficientReservedBalances
+			);
+
+			// Fee is charged on the staking currency that is to be transferred.
+			// staking_amount = original_staking_amount * ( 1 - base_with_fee - additional_fee )
+			let mut staking_amount = Self::convert_liquid_to_staking(liquid_amount_can_be_redeemed)?;
+			let fee_deducted_percentage = Permill::one()
+				.saturating_sub(T::BaseWithdrawFee::get())
+				.saturating_sub(request_extra_fee);
+			staking_amount = fee_deducted_percentage.mul(staking_amount);
+
+			// Transfer the reduced staking currency from Minter to Redeemer
+			T::Currency::transfer(T::StakingCurrencyId::get(), minter, redeemer, staking_amount)?;
+
+			new_balances.push((redeemer.clone(), new_amount, request_extra_fee));
+			Self::deposit_event(Event::<T>::Redeemed(
+				redeemer.clone(),
+				staking_amount,
+				liquid_amount_can_be_redeemed,
+			));
+
+			Ok(())
+		}
+
+		/// Mint some Liquid currency, by locking up the given amount of Staking currency.
+		/// The redeem requests given in `requests` are prioritized to be matched. All other redeem
+		/// requests are matched after. The remaining amount is minted through Staking on the
+		/// Relaychain (via XCM).
+		///
+		/// Parameters:
+		/// - `amount`: The amount of Staking currency to be exchanged.
+		/// - `requests`: The redeem requests that are prioritized to match.
+		fn do_mint_with_requests(
+			minter: &T::AccountId,
+			amount: Balance,
+			requests: Vec<T::AccountId>,
+		) -> DispatchResult {
+			// Ensure the amount is above the minimum, after the MintFee is deducted.
+			ensure!(
+				amount > T::MinimumMintThreshold::get().saturating_add(T::MintFee::get()),
+				Error::<T>::MintAmountBelowMinimumThreshold
+			);
+
+			let staking_currency = T::StakingCurrencyId::get();
+
+			// ensure the user has enough funds on their account.
+			T::Currency::ensure_can_withdraw(staking_currency, &minter, amount)?;
+
+			// Attempt to match redeem requests if there are any.
+			let total_liquid_to_mint = Self::convert_staking_to_liquid(amount)?;
+
+			// The amount of liquid currency to be redeemed for the mint reuqest.
+			let mut liquid_remaining = total_liquid_to_mint;
+
+			// New balances after redeem requests are fullfilled.
+			let mut new_balances: Vec<(T::AccountId, Balance, Permill)> = vec![];
+
+			// Iterate through the prioritized requests first
+			for redeemer in requests {
+				// If all the currencies are minted, return.
+				if liquid_remaining.is_zero() {
+					break;
+				}
+
+				// Check if the redeem request exists
+				if let Some((request_amount, extra_fee)) = Self::redeem_requests(&redeemer) {
+					Self::match_mint_with_redeem_request(
+						&minter,
+						&redeemer,
+						request_amount,
+						extra_fee,
+						&mut liquid_remaining,
+						&mut new_balances,
+					)?;
+				}
+			}
+
+			// Update storage to the new balances. Remove Redeem requests that have been filled.
+			for (redeemer, new_balance, extra_fee) in &new_balances {
+				if new_balance.is_zero() {
+					RedeemRequests::<T>::remove(&redeemer);
+				} else {
+					RedeemRequests::<T>::insert(&redeemer, (new_balance, extra_fee));
+				}
+			}
+			// Redeem request storage has now been updated.
+			new_balances.clear();
+
+			// Iterate all remaining redeem requests now.
+			for (redeemer, (request_amount, extra_fee)) in RedeemRequests::<T>::iter() {
+				// If all the currencies are minted, return.
+				if liquid_remaining.is_zero() {
+					break;
+				}
+				Self::match_mint_with_redeem_request(
+					&minter,
+					&redeemer,
+					request_amount,
+					extra_fee,
+					&mut liquid_remaining,
+					&mut new_balances,
+				)?;
+			}
+
+			// Update storage to the new balances. Remove Redeem requests that have been filled.
+			for (redeemer, new_balance, extra_fee) in new_balances {
+				if new_balance.is_zero() {
+					RedeemRequests::<T>::remove(&redeemer);
+				} else {
+					RedeemRequests::<T>::insert(&redeemer, (new_balance, extra_fee));
+				}
+			}
+
+			// If significant balance is left over, the remaining liquid currencies are minted through XCM.
+			let mut staking_remaining = Self::convert_liquid_to_staking(liquid_remaining)?;
+			if staking_remaining > T::MinimumMintThreshold::get().saturating_add(T::MintFee::get()) {
+				// Calculate how much Liquid currency is to be minted.
+				// liquid_to_mint = convert_to_liquid( (staked_amount - MintFee) * (1 - MaxRewardPerEra) )
+				let mut liquid_to_mint = staking_remaining
+					.checked_sub(T::MintFee::get())
+					.expect("Mint amount is ensured to be greater than T::MintFee; qed");
+				liquid_to_mint = (Permill::one().saturating_sub(T::MaxRewardPerEra::get())).mul(liquid_to_mint);
+				liquid_to_mint = Self::convert_staking_to_liquid(liquid_to_mint)?;
+
+				// Ensure the total amount staked doesn't exceed the cap.
+				let new_total_staking_currency = Self::total_staking_currency()
+					.checked_add(staking_remaining)
+					.ok_or(ArithmeticError::Overflow)?;
+				ensure!(
+					new_total_staking_currency <= Self::staking_currency_mint_cap(),
+					Error::<T>::ExceededStakingCurrencyMintCap
+				);
+
+				TotalStakingCurrency::<T>::put(new_total_staking_currency);
+
+				// All checks pass. Proceed with Xcm transfer.
+				T::XcmTransfer::transfer(
+					minter.clone(),
+					staking_currency,
+					staking_remaining,
+					T::SovereignSubAccountLocation::get(),
+					Self::xcm_dest_weight(),
+				)?;
+
+				// Mint the liquid currency into the user's account.
+				T::Currency::deposit(T::LiquidCurrencyId::get(), &minter, liquid_to_mint)?;
+
+				staking_remaining = Balance::zero();
+				liquid_remaining = liquid_remaining
+					.checked_sub(liquid_to_mint)
+					.expect("Liquid amount cannot be higher after fees are deducted; qed");
+			}
+
+			let actual_staked = amount
+				.checked_sub(staking_remaining)
+				.expect("Staking remaining cannot be more than the original; qed");
+			let actual_liquid = total_liquid_to_mint
+				.checked_sub(liquid_remaining)
+				.expect("Liquid remaining cannot be more than the original; qed");
+
+			Self::deposit_event(Event::<T>::Minted(minter.clone(), actual_staked, actual_liquid));
+
 			Ok(())
 		}
 	}

--- a/modules/homa-lite/src/weights.rs
+++ b/modules/homa-lite/src/weights.rs
@@ -48,15 +48,22 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for module_homa_lite.
 pub trait WeightInfo {
 	fn mint() -> Weight;
+	fn mint_for_requests() -> Weight;
 	fn set_total_staking_currency() -> Weight;
 	fn set_minting_cap() -> Weight;
 	fn set_xcm_dest_weight() -> Weight;
+	fn request_redeem() -> Weight;
 }
 
 /// Weights for module_homa_lite using the Acala node and recommended hardware.
 pub struct AcalaWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for AcalaWeight<T> {
 	fn mint() -> Weight {
+		(250_414_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(12 as Weight))
+			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+	}
+	fn mint_for_requests() -> Weight {
 		(250_414_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
@@ -73,11 +80,20 @@ impl<T: frame_system::Config> WeightInfo for AcalaWeight<T> {
 		(20_346_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn request_redeem() -> Weight {
+		(250_414_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn mint() -> Weight {
+		(250_414_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(12 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+	}
+	fn mint_for_requests() -> Weight {
 		(250_414_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(12 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
@@ -92,6 +108,10 @@ impl WeightInfo for () {
 	}
 	fn set_xcm_dest_weight() -> Weight {
 		(20_346_000 as Weight)
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	fn request_redeem() -> Weight {
+		(250_414_000 as Weight)
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }


### PR DESCRIPTION
Modified existing Mint extrinsics to match with Redeem requests first, and only do XCM transfer if no redeem requests can be matched.