### PR TITLE
Allow atomic conversion of Staking Currency CDPs to Liquid Currency CDPs 

### DIFF
--- a/modules/cdp-engine/src/lib.rs
+++ b/modules/cdp-engine/src/lib.rs
@@ -224,6 +224,8 @@ pub mod module {
 		MustAfterShutdown,
 		/// Failed to swap debit by default path list
 		SwapDebitFailed,
+		/// CDP does not exist
+		NoOpenPosition,
 	}
 
 	#[pallet::event]
@@ -1043,11 +1045,12 @@ fn pick_u32<R: RngCore>(rng: &mut R, max: u32) -> u32 {
 	rng.next_u32() % max
 }
 
+// Allows for homa-lite module to access cdp functionality
 impl<T: Config> UpdateLoan<T::AccountId, Amount> for Pallet<T> {
 	fn get_position(who: &T::AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError> {
 		match loans::Positions::<T>::try_get(staking_id, who) {
 			Ok(val) => Ok(val),
-			Err(_e) => Err(DispatchError::Other("No Loan Present")),
+			Err(_e) => Err(Error::<T>::NoOpenPosition.into()),
 		}
 	}
 

--- a/modules/cdp-engine/src/lib.rs
+++ b/modules/cdp-engine/src/lib.rs
@@ -1059,11 +1059,13 @@ impl<T: Config> UpdateLoan<T::AccountId, Amount> for Pallet<T> {
 
 	fn swap_position_to_liquid(
 		who: &T::AccountId,
-		currency_id: CurrencyId,
-		collateral_adjustment: Amount,
+		staking_id: CurrencyId,
+		liquid_id: CurrencyId,
+		liquid_adjustment: Amount,
+		staking_adjustment: Amount,
 		debit_adjustment: Amount,
 	) -> DispatchResult {
-		Self::adjust_position(who, currency_id, collateral_adjustment, debit_adjustment)?;
-		loans::Pallet::<T>::update_loan(who, currency_id, -collateral_adjustment, -debit_adjustment)
+		Self::adjust_position(who, liquid_id, liquid_adjustment, debit_adjustment)?;
+		loans::Pallet::<T>::update_loan(who, staking_id, -staking_adjustment, -debit_adjustment)
 	}
 }

--- a/modules/cdp-engine/src/lib.rs
+++ b/modules/cdp-engine/src/lib.rs
@@ -1056,7 +1056,7 @@ impl<T: Config> UpdateLoan<T::AccountId, Amount> for Pallet<T> {
 
 	fn transfer_collateral_from_loan(currency_id: CurrencyId, to: &T::AccountId, balance: Balance) -> DispatchResult {
 		let module_id = loans::Pallet::<T>::account_id();
-		T::Currency::transfer(currency_id, &module_id, &to, balance)?;
+		T::Currency::transfer(currency_id, &module_id, to, balance)?;
 		Ok(())
 	}
 

--- a/modules/homa-lite/Cargo.toml
+++ b/modules/homa-lite/Cargo.toml
@@ -22,6 +22,11 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 module-currencies = { path = "../../modules/currencies" }
 orml-tokens = { path = "../../orml/tokens" }
+module-loans = { path = "../loans" }
+cdp-treasury = { package = "module-cdp-treasury", path = "../cdp-treasury" }
+dex = { package = "module-dex", path = "../dex"}
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+cdp-engine = { package = "module-cdp-engine", path = "../cdp-engine" }
 
 [features]
 default = ["std"]

--- a/modules/homa-lite/src/benchmarking.rs
+++ b/modules/homa-lite/src/benchmarking.rs
@@ -171,6 +171,7 @@ mod benchmark_mock {
 		type LiquidCurrencyId = LiquidCurrencyId;
 		type GovernanceOrigin = EnsureRoot<AccountId>;
 		type MinimumMintThreshold = MinimumMintThreshold;
+		type Loan = ();
 		type XcmTransfer = MockXcm;
 		type SovereignSubAccountLocation = MockXcmDestination;
 		type DefaultExchangeRate = DefaultExchangeRate;

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -224,11 +224,16 @@ pub mod module {
 
 			// transfers collateral from loan to user to be able to mint Liquid Currency
 			T::Loan::transfer_collateral_from_loan(staking_id, &who, position.collateral)?;
-
+			let pre_mint_liquid_amount = T::Currency::free_balance(liquid_id, &who);
 			Self::mint(origin, position.collateral)?;
+			let post_mint_liquid_amount = T::Currency::free_balance(liquid_id, &who);
+			let liquid_collateral = post_mint_liquid_amount - pre_mint_liquid_amount;
+
 			T::Loan::swap_position_to_liquid(
 				&who,
+				staking_id,
 				liquid_id,
+				liquid_collateral.saturated_into(),
 				position.collateral.saturated_into(),
 				position.debit.saturated_into(),
 			)?;

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -30,8 +30,8 @@ use module_support::{ExchangeRate, ExchangeRateProvider, Ratio, UpdateLoan};
 use orml_traits::{arithmetic::Signed, MultiCurrency, MultiCurrencyExtended, XcmTransfer};
 use primitives::{Amount, Balance, CurrencyId};
 use sp_runtime::{
-	traits::{Bounded, Zero},
-	ArithmeticError, FixedPointNumber, Permill, SaturatedConversion,
+	traits::{Bounded, CheckedConversion, Zero},
+	ArithmeticError, FixedPointNumber, Permill,
 };
 use sp_std::{convert::TryInto, ops::Mul, prelude::*};
 use xcm::opaque::v0::MultiLocation;
@@ -101,6 +101,8 @@ pub mod module {
 		MintAmountBelowMinimumThreshold,
 		/// The amount of Staking currency used has exceeded the cap allowed.
 		ExceededStakingCurrencyMintCap,
+		/// Too large of a cdp position was attempted to move from Staking currency to Liquid currency
+		TooLargePosition,
 	}
 
 	#[pallet::event]
@@ -227,15 +229,19 @@ pub mod module {
 			let pre_mint_liquid_amount = T::Currency::free_balance(liquid_id, &who);
 			Self::mint(origin, position.collateral)?;
 			let post_mint_liquid_amount = T::Currency::free_balance(liquid_id, &who);
-			let liquid_collateral = post_mint_liquid_amount - pre_mint_liquid_amount;
+			let liquid_collateral: Amount = (post_mint_liquid_amount - pre_mint_liquid_amount)
+				.checked_into()
+				.ok_or(Error::<T>::TooLargePosition)?;
+			let staking_collateral: Amount = position.collateral.checked_into().ok_or(Error::<T>::TooLargePosition)?;
+			let debt_amount: Amount = position.debit.checked_into().ok_or(Error::<T>::TooLargePosition)?;
 
 			T::Loan::swap_position_to_liquid(
 				&who,
 				staking_id,
 				liquid_id,
-				liquid_collateral.saturated_into(),
-				position.collateral.saturated_into(),
-				position.debit.saturated_into(),
+				liquid_collateral,
+				staking_collateral,
+				debt_amount,
 			)?;
 
 			Ok(())

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -231,6 +231,8 @@ pub mod module {
 			let liquid_id = T::LiquidCurrencyId::get();
 			// Gets the users current active position using Staking currency as collateral
 			let position = T::Loan::get_position(&who, staking_id)?;
+			let staking_collateral: Amount = position.collateral.checked_into().ok_or(Error::<T>::TooLargePosition)?;
+			let debt_amount: Amount = position.debit.checked_into().ok_or(Error::<T>::TooLargePosition)?;
 
 			// transfers collateral from loan to user to be able to mint Liquid Currency
 			T::Loan::transfer_collateral_from_loan(staking_id, &who, position.collateral)?;
@@ -242,8 +244,6 @@ pub mod module {
 			let liquid_collateral: Amount = (post_mint_liquid_amount - pre_mint_liquid_amount)
 				.checked_into()
 				.ok_or(Error::<T>::TooLargePosition)?;
-			let staking_collateral: Amount = position.collateral.checked_into().ok_or(Error::<T>::TooLargePosition)?;
-			let debt_amount: Amount = position.debit.checked_into().ok_or(Error::<T>::TooLargePosition)?;
 
 			// Adjust loans so Liquid Currency is now backing same debt, while staking currency CDP is closed
 			T::Loan::swap_position_to_liquid(

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -101,7 +101,8 @@ pub mod module {
 		MintAmountBelowMinimumThreshold,
 		/// The amount of Staking currency used has exceeded the cap allowed.
 		ExceededStakingCurrencyMintCap,
-		/// Too large of a cdp position was attempted to move from Staking currency to Liquid currency
+		/// Too large of a cdp position was attempted to move from Staking currency to Liquid
+		/// currency
 		TooLargePosition,
 	}
 

--- a/modules/homa-lite/src/tests.rs
+++ b/modules/homa-lite/src/tests.rs
@@ -371,8 +371,8 @@ fn mint_from_cdp_loan_works() {
 		assert_eq!(Loans::positions(KSM, &ALICE).collateral, 0);
 		assert_eq!(Loans::positions(KSM, &ALICE).debit, 0);
 		assert_eq!(Loans::positions(LKSM, &ALICE).debit, dollar(500));
-		// About the default exchange rate of (10 Liquid / 1 Staking), or in practice mints just under dollar(1000)
-		// LKSM for collateral
+		// About the default exchange rate of (10 Liquid / 1 Staking), or in practice mints just under
+		// dollar(1000) LKSM for collateral
 		let liquid_collateral_alice = Loans::positions(LKSM, &ALICE).collateral;
 		assert_eq!(liquid_collateral_alice, 989901000000000);
 		assert_eq!(Currencies::free_balance(LKSM, &ALICE), 0);

--- a/modules/loans/src/lib.rs
+++ b/modules/loans/src/lib.rs
@@ -27,30 +27,20 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::collapsible_if)]
 
-use codec::MaxEncodedLen;
 use frame_support::{log, pallet_prelude::*, transactional, PalletId};
 use orml_traits::{Happened, MultiCurrency, MultiCurrencyExtended};
 use primitives::{Amount, Balance, CurrencyId};
 use sp_runtime::{
 	traits::{AccountIdConversion, Convert, Zero},
-	ArithmeticError, DispatchResult, RuntimeDebug,
+	ArithmeticError, DispatchResult,
 };
 use sp_std::{convert::TryInto, result};
-use support::{CDPTreasury, RiskManager};
+use support::{CDPTreasury, Position, RiskManager};
 
 mod mock;
 mod tests;
 
 pub use module::*;
-
-/// A collateralized debit position.
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, Default, MaxEncodedLen)]
-pub struct Position {
-	/// The amount of collateral.
-	pub collateral: Balance,
-	/// The amount of debit.
-	pub debit: Balance,
-}
 
 #[frame_support::pallet]
 pub mod module {
@@ -268,7 +258,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// mutate records of collaterals and debits
-	fn update_loan(
+	pub fn update_loan(
 		who: &T::AccountId,
 		currency_id: CurrencyId,
 		collateral_adjustment: Amount,

--- a/modules/support/Cargo.toml
+++ b/modules/support/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 impl-trait-for-tuples = "0.1.3"
-codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -590,6 +590,7 @@ pub trait UpdateLoan<AccountId> {
 	) -> Result<(), DispatchError>;
 }
 
+#[cfg(feature = "std")]
 impl<AccountId> UpdateLoan<AccountId> for () {
 	fn get_position(_who: &AccountId, _staking_id: CurrencyId) -> Result<Position, DispatchError> {
 		Err(DispatchError::Other("unimplemented update loan trait"))

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -563,9 +563,13 @@ pub trait CompoundCashTrait<Balance, Moment> {
 	fn set_future_yield(next_cash_yield: Balance, yield_index: u128, timestamp_effective: Moment) -> DispatchResult;
 }
 
+/// Allows homa modules to atomically swap loans from Staking currency to Liquid Currency
 pub trait UpdateLoan<AccountId, Amount> {
+	// Gets active CDPs collateralized with Staking currency for user
 	fn get_position(who: &AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError>;
 
+	// Swaps loan to Liquid currency while closing out Staking currency position
+	// Unsafe as it closes out position without refunding user's collateral (assumed to have already occured)
 	fn swap_position_to_liquid(
 		who: &AccountId,
 		staking_id: CurrencyId,
@@ -575,6 +579,8 @@ pub trait UpdateLoan<AccountId, Amount> {
 		debit_adjustment: Amount,
 	) -> Result<(), DispatchError>;
 
+	// Transfers collateral from Staking currency loan to user.
+	// Unsafe as it does not close out loan
 	fn transfer_collateral_from_loan(
 		currency_id: CurrencyId,
 		to: &AccountId,

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -565,24 +565,24 @@ pub trait CompoundCashTrait<Balance, Moment> {
 
 /// Allows homa modules to atomically swap loans from Staking currency to Liquid Currency
 /// These functions are unsafe individually and should not be used outside homa modules
-pub trait UpdateLoan<AccountId, Amount> {
-	// Gets active CDPs collateralized with Staking currency for user
+pub trait UpdateLoan<AccountId> {
+	/// Gets active CDPs collateralized with Staking currency for user
 	fn get_position(who: &AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError>;
 
-	// Swaps loan to Liquid currency while closing out Staking currency position
-	// Unsafe as it closes out position without refunding user's collateral (assumed to have already
-	// occured)
+	/// Swaps loan to Liquid currency while closing out Staking currency position
+	/// Unsafe as it closes out position without refunding user's collateral (assumed to have
+	/// already occured)
 	fn swap_position_to_liquid(
 		who: &AccountId,
 		staking_id: CurrencyId,
 		liquid_id: CurrencyId,
-		liquid_adjustment: Amount,
-		collateral_adjustment: Amount,
-		debit_adjustment: Amount,
+		liquid_adjustment: Balance,
+		collateral_adjustment: Balance,
+		debit_adjustment: Balance,
 	) -> Result<(), DispatchError>;
 
-	// Transfers collateral from loan to user.
-	// Unsafe as it does not close out loan
+	/// Transfers collateral from loan to user.
+	/// Unsafe as it does not close out loan
 	fn transfer_collateral_from_loan(
 		currency_id: CurrencyId,
 		to: &AccountId,
@@ -590,7 +590,7 @@ pub trait UpdateLoan<AccountId, Amount> {
 	) -> Result<(), DispatchError>;
 }
 
-impl<AccountId, Amount> UpdateLoan<AccountId, Amount> for () {
+impl<AccountId> UpdateLoan<AccountId> for () {
 	fn get_position(_who: &AccountId, _staking_id: CurrencyId) -> Result<Position, DispatchError> {
 		Err(DispatchError::Other("unimplemented update loan trait"))
 	}
@@ -599,9 +599,9 @@ impl<AccountId, Amount> UpdateLoan<AccountId, Amount> for () {
 		_who: &AccountId,
 		_staking_id: CurrencyId,
 		_liquid_id: CurrencyId,
-		_liquid_adjustment: Amount,
-		_collateral_adjustment: Amount,
-		_debit_adjustment: Amount,
+		_liquid_adjustment: Balance,
+		_collateral_adjustment: Balance,
+		_debit_adjustment: Balance,
 	) -> Result<(), DispatchError> {
 		Err(DispatchError::Other("unimplemented update loan trait"))
 	}

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -19,11 +19,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::upper_case_acronyms)]
 
-use codec::{Decode, Encode, FullCodec, HasCompact};
+use codec::{Decode, Encode, FullCodec, HasCompact, MaxEncodedLen};
 use frame_support::pallet_prelude::{DispatchClass, Pays, Weight};
 use primitives::{
 	evm::{CallInfo, EvmAddress},
-	CurrencyId,
+	Balance, CurrencyId,
 };
 use sp_core::H160;
 use sp_runtime::{
@@ -561,4 +561,30 @@ impl CurrencyIdMapping for () {
 /// Used to interface with the Compound's Cash module
 pub trait CompoundCashTrait<Balance, Moment> {
 	fn set_future_yield(next_cash_yield: Balance, yield_index: u128, timestamp_effective: Moment) -> DispatchResult;
+}
+
+pub trait UpdateLoan<AccountId, Amount> {
+	fn get_position(who: &AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError>;
+
+	fn swap_position_to_liquid(
+		who: &AccountId,
+		currency_id: CurrencyId,
+		collateral_adjustment: Amount,
+		debit_adjustment: Amount,
+	) -> Result<(), DispatchError>;
+
+	fn transfer_collateral_from_loan(
+		currency_id: CurrencyId,
+		to: &AccountId,
+		balance: Balance,
+	) -> Result<(), DispatchError>;
+}
+
+/// A collateralized debit position.
+#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, Default, MaxEncodedLen)]
+pub struct Position {
+	/// The amount of collateral.
+	pub collateral: Balance,
+	/// The amount of debit.
+	pub debit: Balance,
 }

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -569,7 +569,8 @@ pub trait UpdateLoan<AccountId, Amount> {
 	fn get_position(who: &AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError>;
 
 	// Swaps loan to Liquid currency while closing out Staking currency position
-	// Unsafe as it closes out position without refunding user's collateral (assumed to have already occured)
+	// Unsafe as it closes out position without refunding user's collateral (assumed to have already
+	// occured)
 	fn swap_position_to_liquid(
 		who: &AccountId,
 		staking_id: CurrencyId,

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -564,6 +564,7 @@ pub trait CompoundCashTrait<Balance, Moment> {
 }
 
 /// Allows homa modules to atomically swap loans from Staking currency to Liquid Currency
+/// These functions are unsafe individually and should not be used outside homa modules
 pub trait UpdateLoan<AccountId, Amount> {
 	// Gets active CDPs collateralized with Staking currency for user
 	fn get_position(who: &AccountId, staking_id: CurrencyId) -> Result<Position, DispatchError>;
@@ -580,13 +581,38 @@ pub trait UpdateLoan<AccountId, Amount> {
 		debit_adjustment: Amount,
 	) -> Result<(), DispatchError>;
 
-	// Transfers collateral from Staking currency loan to user.
+	// Transfers collateral from loan to user.
 	// Unsafe as it does not close out loan
 	fn transfer_collateral_from_loan(
 		currency_id: CurrencyId,
 		to: &AccountId,
 		balance: Balance,
 	) -> Result<(), DispatchError>;
+}
+
+impl<AccountId, Amount> UpdateLoan<AccountId, Amount> for () {
+	fn get_position(_who: &AccountId, _staking_id: CurrencyId) -> Result<Position, DispatchError> {
+		Err(DispatchError::Other("unimplemented update loan trait"))
+	}
+
+	fn swap_position_to_liquid(
+		_who: &AccountId,
+		_staking_id: CurrencyId,
+		_liquid_id: CurrencyId,
+		_liquid_adjustment: Amount,
+		_collateral_adjustment: Amount,
+		_debit_adjustment: Amount,
+	) -> Result<(), DispatchError> {
+		Err(DispatchError::Other("unimplemented update loan trait"))
+	}
+
+	fn transfer_collateral_from_loan(
+		_currency_id: CurrencyId,
+		_to: &AccountId,
+		_balance: Balance,
+	) -> Result<(), DispatchError> {
+		Err(DispatchError::Other("unimplemented update loan trait"))
+	}
 }
 
 /// A collateralized debit position.

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -568,7 +568,9 @@ pub trait UpdateLoan<AccountId, Amount> {
 
 	fn swap_position_to_liquid(
 		who: &AccountId,
-		currency_id: CurrencyId,
+		staking_id: CurrencyId,
+		liquid_id: CurrencyId,
+		liquid_adjustment: Amount,
 		collateral_adjustment: Amount,
 		debit_adjustment: Amount,
 	) -> Result<(), DispatchError>;

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1582,7 +1582,7 @@ impl module_homa_lite::Config for Runtime {
 	type LiquidCurrencyId = LKSMCurrencyId;
 	type GovernanceOrigin = EnsureRootOrHalfGeneralCouncil;
 	type MinimumMintThreshold = MinimumMintThreshold;
-	type Loan = ();
+	type Loan = CdpEngine;
 	type XcmTransfer = XTokens;
 	type SovereignSubAccountLocation = RelaychainSovereignSubAccount;
 	type DefaultExchangeRate = DefaultExchangeRate;

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1582,6 +1582,7 @@ impl module_homa_lite::Config for Runtime {
 	type LiquidCurrencyId = LKSMCurrencyId;
 	type GovernanceOrigin = EnsureRootOrHalfGeneralCouncil;
 	type MinimumMintThreshold = MinimumMintThreshold;
+	type Loan = ();
 	type XcmTransfer = XTokens;
 	type SovereignSubAccountLocation = RelaychainSovereignSubAccount;
 	type DefaultExchangeRate = DefaultExchangeRate;

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1297,6 +1297,7 @@ impl module_homa_lite::Config for Runtime {
 	type LiquidCurrencyId = GetLiquidCurrencyId;
 	type GovernanceOrigin = EnsureRootOrHalfGeneralCouncil;
 	type MinimumMintThreshold = MinimumMintThreshold;
+	type Loan = CdpEngine;
 	type XcmTransfer = XTokens;
 	type SovereignSubAccountLocation = RelaychainSovereignSubAccount;
 	type DefaultExchangeRate = DefaultExchangeRate;


### PR DESCRIPTION
Fixes #1173, 

Needs a lot more tests

Also this current PR makes the swap all or nothing perhaps we should implement ability to choose how much collateral/debit to move over to staking

Edit: This also currently doesn't follow Verify First, Write Last but my understanding is the `#[transactional]` attribute makes it acceptable