### PR TITLE
Add predeployed contract tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,7 @@ jobs:
       run: |
         npm install -g yarn
         make test-ts
+    - name: Run predeploy contracts tests
+      run: |
+        npm install -g yarn
+        make test-predeployed

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ test-ts:
 	cargo build --features with-mandala-runtime
 	cd ts-tests && yarn && yarn run build && yarn run test
 
+.PHONY: test-predeployed
+test-predeployed:
+	cargo build --features with-mandala-runtime
+	cd predeploy-contracts && yarn && yarn build && yarn test
+
 .PHONY: test-benchmarking
 test-benchmarking:
 	cargo test --features runtime-benchmarks --features with-all-runtime --features --all benchmarking


### PR DESCRIPTION
Added predeloyed tests to be run by the CI.

This should only be merged after the reference to predeployed-contracts is updated, so that they include the end to end tests.