### PR TITLE
Fix/repatriate emit event

### DIFF
--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -476,7 +476,7 @@ pub mod module {
 					// Immediately redeem from the available_staking_balances
 					let actual_staking_amount = Self::convert_liquid_to_staking(actual_liquid_amount)?;
 
-					// Redeem from the available_staking_balances costs no extra fee.
+					// Redeem from the available_staking_balances costs additional fee for Xcm unbond.
 					T::Currency::deposit(
 						T::StakingCurrencyId::get(),
 						&who,

--- a/modules/homa-lite/src/tests.rs
+++ b/modules/homa-lite/src/tests.rs
@@ -834,6 +834,77 @@ fn mint_can_match_requested_redeem() {
 
 		// XCM will cost some fee
 		assert_eq!(Currencies::free_balance(LKSM, &CHARLIE), 993_897_000_000_000);
+
+		assert_eq!(RedeemRequests::<Runtime>::get(&ALICE), None);
+		assert_eq!(RedeemRequests::<Runtime>::get(&BOB), None);
+		assert_eq!(
+			RedeemRequests::<Runtime>::get(&ROOT),
+			Some((dollar(999) / 10, Permill::zero()))
+		);
+
+		let events = System::events();
+
+		// Matching CHARLIE's mint with ALICE's redeem
+		assert_eq!(
+			events[events.len() - 8].event,
+			Event::Tokens(orml_tokens::Event::Repatriated(
+				LKSM,
+				ALICE,
+				CHARLIE,
+				199_800_000_000_000,
+				BalanceStatus::Free
+			))
+		);
+		assert_eq!(
+			events[events.len() - 7].event,
+			Event::Currencies(module_currencies::Event::Transferred(
+				KSM,
+				CHARLIE,
+				ALICE,
+				19_980_000_000_000
+			))
+		);
+		assert_eq!(
+			events[events.len() - 6].event,
+			Event::HomaLite(crate::Event::Redeemed(ALICE, 19_980_000_000_000, 199_800_000_000_000))
+		);
+
+		// Matching CHARLIE's mint with BOB's redeem
+		assert_eq!(
+			events[events.len() - 5].event,
+			Event::Tokens(orml_tokens::Event::Repatriated(
+				LKSM,
+				BOB,
+				CHARLIE,
+				199_800_000_000_000,
+				BalanceStatus::Free
+			))
+		);
+		assert_eq!(
+			events[events.len() - 4].event,
+			Event::Currencies(module_currencies::Event::Transferred(
+				KSM,
+				CHARLIE,
+				BOB,
+				19_980_000_000_000
+			))
+		);
+		assert_eq!(
+			events[events.len() - 3].event,
+			Event::HomaLite(crate::Event::Redeemed(BOB, 19_980_000_000_000, 199_800_000_000_000))
+		);
+
+		// Mint via XCM: 600 LKSM - XCM fee
+		assert_eq!(
+			events[events.len() - 2].event,
+			Event::Currencies(module_currencies::Event::Deposited(LKSM, CHARLIE, 594_297_000_000_000))
+		);
+
+		// Finally the minted event that contains total KSM and LKSM minted
+		assert_eq!(
+			events[events.len() - 1].event,
+			Event::HomaLite(crate::Event::Minted(CHARLIE, 100000000000000, 993_897_000_000_000))
+		);
 	});
 }
 
@@ -1374,18 +1445,28 @@ fn mint_can_handle_rounding_error_dust() {
 
 		let events = System::events();
 		assert_eq!(
+			events[events.len() - 5].event,
+			Event::Tokens(orml_tokens::Event::Repatriated(
+				LKSM,
+				ALICE,
+				ROOT,
+				9_987_632_930_985,
+				BalanceStatus::Free
+			))
+		);
+		assert_eq!(
 			events[events.len() - 3].event,
-			Event::Currencies(module_currencies::Event::Transferred(KSM, ROOT, ALICE, 999999999998))
+			Event::Currencies(module_currencies::Event::Transferred(KSM, ROOT, ALICE, 999_999_999_998))
 		);
 		// actual staking transfered is off due to rounding error
 		assert_eq!(
 			events[events.len() - 2].event,
-			Event::HomaLite(crate::Event::Redeemed(ALICE, 999999999998, 9_987_632_930_985))
+			Event::HomaLite(crate::Event::Redeemed(ALICE, 999_999_999_998, 9_987_632_930_985))
 		);
 		// total amount minted includes dust caused by rounding error
 		assert_eq!(
 			events[events.len() - 1].event,
-			Event::HomaLite(crate::Event::Minted(ROOT, 999999999999, 9_987_632_930_985))
+			Event::HomaLite(crate::Event::Minted(ROOT, 999_999_999_999, 9_987_632_930_985))
 		);
 	});
 }

--- a/modules/homa-lite/src/tests.rs
+++ b/modules/homa-lite/src/tests.rs
@@ -847,7 +847,7 @@ fn mint_can_match_requested_redeem() {
 		// Matching CHARLIE's mint with ALICE's redeem
 		assert_eq!(
 			events[events.len() - 8].event,
-			Event::Tokens(orml_tokens::Event::Repatriated(
+			Event::Tokens(orml_tokens::Event::RepatriatedReserve(
 				LKSM,
 				ALICE,
 				CHARLIE,
@@ -872,7 +872,7 @@ fn mint_can_match_requested_redeem() {
 		// Matching CHARLIE's mint with BOB's redeem
 		assert_eq!(
 			events[events.len() - 5].event,
-			Event::Tokens(orml_tokens::Event::Repatriated(
+			Event::Tokens(orml_tokens::Event::RepatriatedReserve(
 				LKSM,
 				BOB,
 				CHARLIE,
@@ -1446,7 +1446,7 @@ fn mint_can_handle_rounding_error_dust() {
 		let events = System::events();
 		assert_eq!(
 			events[events.len() - 5].event,
-			Event::Tokens(orml_tokens::Event::Repatriated(
+			Event::Tokens(orml_tokens::Event::RepatriatedReserve(
 				LKSM,
 				ALICE,
 				ROOT,


### PR DESCRIPTION
orml_tokens module now emit event when funds are repatriated.
Updated homa-lite unit tests to ensure the events are correctly emitted when a Mint request is matched with a Redeem request.

Closes #1573