### PR TITLE
Fixed a redeem bug and added more Homa lite tests

### DIFF
--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -707,7 +707,7 @@ pub mod module {
 			let liquid_amount_can_be_redeemed = min(request_amount, *liquid_amount_remaining);
 
 			// Ensure the redeemer have enough liquid currency in their account.
-			if T::Currency::reserved_balance(T::LiquidCurrencyId::get(), &redeemer) >= liquid_amount_can_be_redeemed {
+			if T::Currency::reserved_balance(T::LiquidCurrencyId::get(), redeemer) >= liquid_amount_can_be_redeemed {
 				let new_amount = request_amount.saturating_sub(liquid_amount_can_be_redeemed);
 				*liquid_amount_remaining = liquid_amount_remaining.saturating_sub(liquid_amount_can_be_redeemed);
 

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -476,6 +476,7 @@ pub mod module {
 				Error::<T>::AmountBelowMinimumThreshold
 			);
 
+			// Deduct base withdraw fee and add the redeem request to the queue.
 			let _ = RedeemRequests::<T>::try_mutate(&who, |request| -> DispatchResult {
 				let old_amount = request.take().map(|(amount, _)| amount).unwrap_or_default();
 
@@ -491,6 +492,7 @@ pub mod module {
 				// Deduct BaseWithdrawFee from the liquid amount.
 				let liquid_amount = liquid_amount.saturating_sub(base_withdraw_fee);
 
+				// Reserve/unreserve the difference amount.
 				match liquid_amount.cmp(&old_amount) {
 					// Lock more liquid currency.
 					Ordering::Greater => T::Currency::reserve(
@@ -510,6 +512,7 @@ pub mod module {
 					_ => Ok(()),
 				}?;
 
+				// Set the new amount into storage.
 				*request = Some((liquid_amount, additional_fee));
 
 				Self::deposit_event(Event::<T>::RedeemRequested(

--- a/modules/homa-lite/src/lib.rs
+++ b/modules/homa-lite/src/lib.rs
@@ -22,6 +22,9 @@
 pub mod benchmarking;
 mod mock;
 mod tests;
+
+mod mock_no_fees;
+mod tests_no_fees;
 pub mod weights;
 
 use frame_support::{log, pallet_prelude::*, transactional, weights::Weight, BoundedVec};

--- a/modules/homa-lite/src/mock.rs
+++ b/modules/homa-lite/src/mock.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Mocks for the Starport module.
+//! Mocks for the HomaLite module.
 
 #![cfg(test)]
 

--- a/modules/homa-lite/src/mock_no_fees.rs
+++ b/modules/homa-lite/src/mock_no_fees.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Mocks for the Starport module.
+//! Mocks for the HomaLite module that costs no Fees.
 
 #![cfg(test)]
 

--- a/modules/homa-lite/src/mock_no_fees.rs
+++ b/modules/homa-lite/src/mock_no_fees.rs
@@ -20,64 +20,12 @@
 
 #![cfg(test)]
 
-pub use super::*;
-pub use frame_support::{
-	ord_parameter_types, parameter_types,
-	traits::{Everything, Nothing},
-};
-pub use frame_system::{EnsureRoot, EnsureSignedBy, RawOrigin};
-pub use module_relaychain::RelayChainCallBuilder;
-pub use module_support::mocks::MockAddressMapping;
-pub use orml_traits::{parameter_type_with_key, XcmTransfer};
-pub use primitives::{Amount, TokenSymbol};
-pub use sp_core::H256;
-pub use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
-
-pub use cumulus_primitives_core::ParaId;
-pub use xcm::latest::prelude::*;
-pub use xcm_executor::traits::{InvertLocation, WeightBounds};
-
-pub type AccountId = AccountId32;
-pub type BlockNumber = u64;
 pub use crate as module_homa_lite;
+pub use crate::mock::*;
 
 mod homa_lite {
 	pub use super::super::*;
 }
-
-pub const DAVE: AccountId = AccountId32::new([255u8; 32]);
-pub const ALICE: AccountId = AccountId32::new([1u8; 32]);
-pub const BOB: AccountId = AccountId32::new([2u8; 32]);
-pub const CHARLIE: AccountId = AccountId32::new([3u8; 32]);
-pub const INVALID_CALLER: AccountId = AccountId32::new([254u8; 32]);
-pub const ACALA: CurrencyId = CurrencyId::Token(TokenSymbol::ACA);
-pub const KSM: CurrencyId = CurrencyId::Token(TokenSymbol::KSM);
-pub const LKSM: CurrencyId = CurrencyId::Token(TokenSymbol::LKSM);
-pub const INITIAL_BALANCE: Balance = 1_000_000;
-pub const MOCK_XCM_DESTINATION: MultiLocation = X1(Junction::AccountId32 {
-	network: NetworkId::Kusama,
-	id: [1u8; 32],
-})
-.into();
-pub const MOCK_XCM_ACCOUNTID: AccountId = AccountId32::new([255u8; 32]);
-pub const PARACHAIN_ID: u32 = 2000;
-
-/// For testing only. Does not check for overflow.
-pub fn dollar(b: Balance) -> Balance {
-	b * 1_000_000_000_000
-}
-
-/// For testing only. Does not check for overflow.
-pub fn millicent(b: Balance) -> Balance {
-	b * 10_000_000
-}
-
-parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-}
-
-/// A mock XCM transfer.
-/// Only fails if it is called by "INVALID_CALLER". Otherwise returns OK with 0 weight.
 pub struct MockXcm;
 impl XcmTransfer<AccountId, Balance, CurrencyId> for MockXcm {
 	fn transfer(
@@ -157,7 +105,7 @@ impl WeightBounds<Call> for MockWeigher {
 	}
 }
 
-impl pallet_xcm::Config for Runtime {
+impl pallet_xcm::Config for NoFeeRuntime {
 	type Event = Event;
 	type SendXcmOrigin = MockEnsureXcmOrigin;
 	type XcmRouter = MockXcm;
@@ -174,7 +122,7 @@ impl pallet_xcm::Config for Runtime {
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl frame_system::Config for Runtime {
+impl frame_system::Config for NoFeeRuntime {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -206,7 +154,7 @@ parameter_type_with_key! {
 	};
 }
 
-impl orml_tokens::Config for Runtime {
+impl orml_tokens::Config for NoFeeRuntime {
 	type Event = Event;
 	type Balance = Balance;
 	type Amount = Amount;
@@ -222,25 +170,26 @@ parameter_types! {
 	pub const NativeTokenExistentialDeposit: Balance = 0;
 }
 
-impl pallet_balances::Config for Runtime {
+impl pallet_balances::Config for NoFeeRuntime {
 	type Balance = Balance;
 	type DustRemoval = ();
 	type Event = Event;
 	type ExistentialDeposit = NativeTokenExistentialDeposit;
-	type AccountStore = frame_system::Pallet<Runtime>;
+	type AccountStore = frame_system::Pallet<NoFeeRuntime>;
 	type MaxLocks = ();
 	type WeightInfo = ();
 	type MaxReserves = ();
 	type ReserveIdentifier = ();
 }
 
-pub type AdaptedBasicCurrency = module_currencies::BasicCurrencyAdapter<Runtime, PalletBalances, Amount, BlockNumber>;
+pub type AdaptedBasicCurrency =
+	module_currencies::BasicCurrencyAdapter<NoFeeRuntime, PalletBalances, Amount, BlockNumber>;
 
 parameter_types! {
 	pub const GetNativeCurrencyId: CurrencyId = ACALA;
 }
 
-impl module_currencies::Config for Runtime {
+impl module_currencies::Config for NoFeeRuntime {
 	type Event = Event;
 	type MultiCurrency = Tokens;
 	type NativeCurrency = AdaptedBasicCurrency;
@@ -255,17 +204,17 @@ impl module_currencies::Config for Runtime {
 parameter_types! {
 	pub const StakingCurrencyId: CurrencyId = KSM;
 	pub const LiquidCurrencyId: CurrencyId = LKSM;
-	pub MinimumMintThreshold: Balance = millicent(1000);
-	pub MinimumRedeemThreshold: Balance = millicent(1000);
+	pub MinimumMintThreshold: Balance = 0;
+	pub MinimumRedeemThreshold: Balance = 0;
 	pub const MockXcmDestination: MultiLocation = MOCK_XCM_DESTINATION;
 	pub const MockXcmAccountId: AccountId = MOCK_XCM_ACCOUNTID;
 	pub DefaultExchangeRate: ExchangeRate = ExchangeRate::saturating_from_rational(1, 10);
-	pub const MaxRewardPerEra: Permill = Permill::from_percent(1);
-	pub MintFee: Balance = millicent(1000);
-	pub BaseWithdrawFee: Permill = Permill::from_rational(1u32, 1_000u32); // 0.1%
-	pub XcmUnbondFee: Balance = dollar(1);
+	pub const MaxRewardPerEra: Permill = Permill::zero();
+	pub MintFee: Balance = 0;
+	pub BaseWithdrawFee: Permill = Permill::zero(); // 0.1%
+	pub XcmUnbondFee: Balance = 0;
 	pub const ParachainAccount: AccountId = DAVE;
-	pub const MaximumRedeemRequestMatchesForMint: u32 = 2;
+	pub const MaximumRedeemRequestMatchesForMint: u32 = 100;
 	pub static MockRelayBlockNumberProvider: u64 = 0;
 	pub const RelayChainUnbondingSlashingSpans: u32 = 5;
 	pub const MaxScheduledUnbonds: u32 = 14;
@@ -285,7 +234,7 @@ impl BlockNumberProvider for MockRelayBlockNumberProvider {
 	}
 }
 
-impl Config for Runtime {
+impl Config for NoFeeRuntime {
 	type Event = Event;
 	type WeightInfo = ();
 	type Currency = Currencies;
@@ -300,7 +249,7 @@ impl Config for Runtime {
 	type DefaultExchangeRate = DefaultExchangeRate;
 	type MaxRewardPerEra = MaxRewardPerEra;
 	type MintFee = MintFee;
-	type RelayChainCallBuilder = RelayChainCallBuilder<Runtime, ParachainId>;
+	type RelayChainCallBuilder = RelayChainCallBuilder<NoFeeRuntime, ParachainId>;
 	type BaseWithdrawFee = BaseWithdrawFee;
 	type XcmUnbondFee = XcmUnbondFee;
 	type RelayChainBlockNumber = MockRelayBlockNumberProvider;
@@ -311,11 +260,11 @@ impl Config for Runtime {
 	type StakingUpdateFrequency = StakingUpdateFrequency;
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
-type Block = frame_system::mocking::MockBlock<Runtime>;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<NoFeeRuntime>;
+type Block = frame_system::mocking::MockBlock<NoFeeRuntime>;
 
 frame_support::construct_runtime!(
-	pub enum Runtime where
+	pub enum NoFeeRuntime where
 		Block = Block,
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
@@ -366,16 +315,16 @@ impl Default for ExtBuilder {
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default()
-			.build_storage::<Runtime>()
+			.build_storage::<NoFeeRuntime>()
 			.unwrap();
 
-		pallet_balances::GenesisConfig::<Runtime> {
+		pallet_balances::GenesisConfig::<NoFeeRuntime> {
 			balances: self.native_balances,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		orml_tokens::GenesisConfig::<Runtime> {
+		orml_tokens::GenesisConfig::<NoFeeRuntime> {
 			balances: self.tokens_balances,
 		}
 		.assimilate_storage(&mut t)

--- a/modules/homa-lite/src/mock_no_fees.rs
+++ b/modules/homa-lite/src/mock_no_fees.rs
@@ -283,6 +283,7 @@ pub struct ExtBuilder {
 	native_balances: Vec<(AccountId, Balance)>,
 }
 
+#[allow(dead_code)]
 impl ExtBuilder {
 	pub fn empty() -> Self {
 		Self {

--- a/modules/homa-lite/src/tests_no_fees.rs
+++ b/modules/homa-lite/src/tests_no_fees.rs
@@ -23,10 +23,7 @@
 
 use super::*;
 use frame_support::assert_ok;
-use mock_no_fees::{
-	dollar, Currencies, Event, ExtBuilder, HomaLite, MockRelayBlockNumberProvider, NoFeeRuntime, Origin, System, ALICE,
-	BOB, CHARLIE, DAVE, KSM, LKSM,
-};
+use mock_no_fees::{dollar, Currencies, Event, ExtBuilder, HomaLite, Origin, System, ALICE, BOB, DAVE, KSM, LKSM};
 
 #[test]
 fn no_fee_runtime_has_no_fees() {
@@ -70,6 +67,7 @@ fn no_fee_runtime_has_no_fees() {
 			BOB,
 			dollar(50_000),
 			Permill::zero(),
+			0,
 		)));
 		assert_ok!(HomaLite::mint(Origin::signed(ALICE), dollar(5_000)));
 
@@ -103,25 +101,165 @@ fn no_fee_runtime_has_no_fees() {
 
 		let events = System::events();
 		assert_eq!(
-			events[events.len() - 5].event,
+			events[events.len() - 9].event,
 			Event::HomaLite(crate::Event::ScheduledUnbondAdded(dollar(50_000), 0))
 		);
 		assert_eq!(
+			events[events.len() - 8].event,
+			Event::HomaLite(crate::Event::ScheduledUnbondWithdrew(dollar(50_000)))
+		);
+		assert_eq!(
+			events[events.len() - 7].event,
+			Event::Tokens(orml_tokens::Event::Reserved(LKSM, DAVE, dollar(100_000)))
+		);
+		assert_eq!(
+			events[events.len() - 6].event,
+			Event::HomaLite(crate::Event::RedeemRequested(DAVE, dollar(100_000), Permill::zero(), 0))
+		);
+		assert_eq!(
+			events[events.len() - 5].event,
+			Event::HomaLite(crate::Event::TotalStakingCurrencySet(dollar(96_000)))
+		);
+		assert_eq!(
 			events[events.len() - 4].event,
-			Event::HomaLite(crate::Event::ScheduledUnbondWithdrew(dollar(50_000),))
+			Event::Tokens(orml_tokens::Event::Endowed(KSM, DAVE, dollar(10_000)))
 		);
 		assert_eq!(
 			events[events.len() - 3].event,
-			Event::Tokens(orml_tokens::Event::Endowed(KSM, DAVE, dollar(10_000),))
+			Event::Currencies(module_currencies::Event::Deposited(KSM, DAVE, dollar(10_000)))
 		);
 		assert_eq!(
 			events[events.len() - 2].event,
-			Event::Currencies(module_currencies::Event::Deposited(KSM, DAVE, dollar(10_000),))
+			Event::Tokens(orml_tokens::Event::Unreserved(LKSM, DAVE, dollar(100_000)))
 		);
-
 		assert_eq!(
 			events[events.len() - 1].event,
-			Event::HomaLite(crate::Event::Redeemed(DAVE, dollar(10_000), dollar(100_000),))
+			Event::HomaLite(crate::Event::Redeemed(DAVE, dollar(10_000), dollar(100_000)))
 		);
+	});
+}
+
+#[test]
+fn mint_with_xcm_does_not_change_exchange_rate() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(HomaLite::set_total_staking_currency(
+			Origin::root(),
+			Currencies::total_issuance(LKSM) / 10
+		));
+		assert_ok!(HomaLite::set_minting_cap(Origin::root(), dollar(1_000_000)));
+
+		let exchange_rate = HomaLite::get_exchange_rate();
+
+		for _ in 0..100 {
+			assert_ok!(HomaLite::mint(Origin::signed(ALICE), dollar(500)));
+			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
+		}
+
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(950_000));
+		assert_eq!(Currencies::free_balance(LKSM, &ALICE), dollar(500_000));
+	});
+}
+
+#[test]
+fn mint_with_redeem_does_not_change_exchange_rate() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(HomaLite::set_total_staking_currency(
+			Origin::root(),
+			Currencies::total_issuance(LKSM) / 10
+		));
+		assert_ok!(HomaLite::set_minting_cap(Origin::root(), dollar(1_000_000)));
+		assert_ok!(HomaLite::request_redeem(
+			Origin::signed(DAVE),
+			dollar(1_000_000),
+			Permill::zero()
+		));
+		let exchange_rate = HomaLite::get_exchange_rate();
+
+		for _ in 0..100 {
+			assert_ok!(HomaLite::mint(Origin::signed(ALICE), dollar(500)));
+			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
+		}
+
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(950_000));
+		assert_eq!(Currencies::free_balance(LKSM, &ALICE), dollar(500_000));
+
+		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(50_000));
+		assert_eq!(Currencies::free_balance(LKSM, &DAVE), 0);
+		assert_eq!(Currencies::reserved_balance(LKSM, &DAVE), dollar(500_000));
+
+		assert_ok!(HomaLite::request_redeem(
+			Origin::signed(ALICE),
+			dollar(500_000),
+			Permill::zero()
+		));
+
+		for _ in 0..100 {
+			assert_ok!(HomaLite::mint(Origin::signed(BOB), dollar(1_000)));
+			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
+		}
+
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(1_000_000));
+		assert_eq!(Currencies::free_balance(LKSM, &ALICE), 0);
+
+		assert_eq!(Currencies::free_balance(KSM, &BOB), dollar(900_000));
+		assert_eq!(Currencies::free_balance(LKSM, &BOB), dollar(1_000_000));
+
+		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(100_000));
+		assert_eq!(Currencies::free_balance(LKSM, &DAVE), 0);
+		assert_eq!(Currencies::reserved_balance(LKSM, &DAVE), 0);
+	});
+}
+
+#[test]
+fn redeem_with_available_staking_does_not_change_exchange_rate() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(HomaLite::set_total_staking_currency(
+			Origin::root(),
+			Currencies::total_issuance(LKSM) / 10
+		));
+		assert_ok!(HomaLite::set_minting_cap(Origin::root(), dollar(1_000_000)));
+
+		assert_ok!(HomaLite::adjust_available_staking_balance(
+			Origin::root(),
+			dollar(100) as i128,
+			100
+		));
+
+		let exchange_rate = HomaLite::get_exchange_rate();
+
+		// test repeated redeem using available staking
+		for _ in 0..100 {
+			assert_ok!(HomaLite::request_redeem(
+				Origin::signed(DAVE),
+				dollar(10),
+				Permill::zero()
+			));
+			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
+		}
+
+		assert_eq!(HomaLite::available_staking_balance(), 0);
+		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(100));
+		assert_eq!(Currencies::free_balance(LKSM, &DAVE), dollar(999_000));
+		assert_eq!(Currencies::reserved_balance(LKSM, &DAVE), 0);
+
+		// Test repeated adjust_available_staking_balance with a queued redeem request.
+		assert_ok!(HomaLite::request_redeem(
+			Origin::signed(DAVE),
+			dollar(10_000),
+			Permill::zero()
+		));
+		for _ in 0..100 {
+			assert_ok!(HomaLite::adjust_available_staking_balance(
+				Origin::root(),
+				dollar(10) as i128,
+				100
+			));
+			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
+		}
+
+		assert_eq!(HomaLite::available_staking_balance(), 0);
+		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(1100));
+		assert_eq!(Currencies::free_balance(LKSM, &DAVE), dollar(989_000));
+		assert_eq!(Currencies::reserved_balance(LKSM, &DAVE), 0);
 	});
 }

--- a/modules/homa-lite/src/tests_no_fees.rs
+++ b/modules/homa-lite/src/tests_no_fees.rs
@@ -1,0 +1,127 @@
+// This file is part of Acala.
+
+// Copyright (C) 2020-2021 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Unit tests using a mock with no fees.
+//! This is mainly used to test economic model.
+
+#![cfg(test)]
+
+use super::*;
+use frame_support::assert_ok;
+use mock_no_fees::{
+	dollar, Currencies, Event, ExtBuilder, HomaLite, MockRelayBlockNumberProvider, NoFeeRuntime, Origin, System, ALICE,
+	BOB, CHARLIE, DAVE, KSM, LKSM,
+};
+
+#[test]
+fn no_fee_runtime_has_no_fees() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(HomaLite::set_total_staking_currency(
+			Origin::root(),
+			Currencies::total_issuance(LKSM) / 10
+		));
+		assert_ok!(HomaLite::set_minting_cap(Origin::root(), dollar(1_000_000)));
+
+		// Mint costs no fees
+		assert_ok!(HomaLite::mint(Origin::signed(ALICE), dollar(1_000)));
+		assert_eq!(
+			HomaLite::get_exchange_rate(),
+			ExchangeRate::saturating_from_rational(1, 10)
+		);
+		System::assert_last_event(Event::HomaLite(crate::Event::Minted(
+			ALICE,
+			dollar(1_000),
+			dollar(10_000),
+		)));
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(999_000));
+		assert_eq!(Currencies::free_balance(LKSM, &ALICE), dollar(10_000));
+
+		assert_ok!(HomaLite::mint(Origin::signed(BOB), dollar(5_000)));
+		System::assert_last_event(Event::HomaLite(crate::Event::Minted(
+			BOB,
+			dollar(5_000),
+			dollar(50_000),
+		)));
+		assert_eq!(Currencies::free_balance(KSM, &BOB), dollar(995_000));
+		assert_eq!(Currencies::free_balance(LKSM, &BOB), dollar(50_000));
+
+		//Redeem costs no fees
+		assert_ok!(HomaLite::request_redeem(
+			Origin::signed(BOB),
+			dollar(50_000),
+			Permill::zero()
+		));
+		System::assert_last_event(Event::HomaLite(crate::Event::RedeemRequested(
+			BOB,
+			dollar(50_000),
+			Permill::zero(),
+		)));
+		assert_ok!(HomaLite::mint(Origin::signed(ALICE), dollar(5_000)));
+
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(994_000));
+		assert_eq!(Currencies::free_balance(LKSM, &ALICE), dollar(60_000));
+		assert_eq!(Currencies::free_balance(KSM, &BOB), dollar(1_000_000));
+		assert_eq!(Currencies::free_balance(LKSM, &BOB), 0);
+		let events = System::events();
+		assert_eq!(
+			events[events.len() - 2].event,
+			Event::HomaLite(crate::Event::Redeemed(BOB, dollar(5000), dollar(50000),))
+		);
+		assert_eq!(
+			events[events.len() - 1].event,
+			Event::HomaLite(crate::Event::Minted(ALICE, dollar(5000), dollar(50000),))
+		);
+
+		// Redeem from AvailableStakingBalance costs no fees
+		assert_ok!(HomaLite::schedule_unbond(Origin::root(), dollar(50_000), 0));
+		let _ = HomaLite::on_idle(0, 5_000_000_000);
+
+		assert_ok!(HomaLite::request_redeem(
+			Origin::signed(DAVE),
+			dollar(100_000),
+			Permill::zero()
+		));
+
+		assert_eq!(HomaLite::available_staking_balance(), dollar(40_000));
+		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(10_000));
+		assert_eq!(Currencies::free_balance(LKSM, &DAVE), dollar(900_000));
+
+		let events = System::events();
+		assert_eq!(
+			events[events.len() - 5].event,
+			Event::HomaLite(crate::Event::ScheduledUnbondAdded(dollar(50_000), 0))
+		);
+		assert_eq!(
+			events[events.len() - 4].event,
+			Event::HomaLite(crate::Event::ScheduledUnbondWithdrew(dollar(50_000),))
+		);
+		assert_eq!(
+			events[events.len() - 3].event,
+			Event::Tokens(orml_tokens::Event::Endowed(KSM, DAVE, dollar(10_000),))
+		);
+		assert_eq!(
+			events[events.len() - 2].event,
+			Event::Currencies(module_currencies::Event::Deposited(KSM, DAVE, dollar(10_000),))
+		);
+
+		assert_eq!(
+			events[events.len() - 1].event,
+			Event::HomaLite(crate::Event::Redeemed(DAVE, dollar(10_000), dollar(100_000),))
+		);
+	});
+}

--- a/modules/homa-lite/src/tests_no_fees.rs
+++ b/modules/homa-lite/src/tests_no_fees.rs
@@ -187,10 +187,11 @@ fn mint_with_redeem_does_not_change_exchange_rate() {
 		assert_eq!(Currencies::free_balance(LKSM, &DAVE), 0);
 		assert_eq!(Currencies::reserved_balance(LKSM, &DAVE), dollar(500_000));
 
+		// Add redeem with 50% extra reward.
 		assert_ok!(HomaLite::request_redeem(
 			Origin::signed(ALICE),
 			dollar(500_000),
-			Permill::zero()
+			Permill::from_percent(50)
 		));
 
 		for _ in 0..100 {
@@ -198,10 +199,12 @@ fn mint_with_redeem_does_not_change_exchange_rate() {
 			assert_eq!(exchange_rate, HomaLite::get_exchange_rate());
 		}
 
-		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(1_000_000));
+		// 950_000 + 50_000 * 50%, since the other 50% went to the minter as rewards.
+		assert_eq!(Currencies::free_balance(KSM, &ALICE), dollar(975_000));
 		assert_eq!(Currencies::free_balance(LKSM, &ALICE), 0);
 
-		assert_eq!(Currencies::free_balance(KSM, &BOB), dollar(900_000));
+		// Got 25_000 extra as extra rewards
+		assert_eq!(Currencies::free_balance(KSM, &BOB), dollar(925_000));
 		assert_eq!(Currencies::free_balance(LKSM, &BOB), dollar(1_000_000));
 
 		assert_eq!(Currencies::free_balance(KSM, &DAVE), dollar(100_000));


### PR DESCRIPTION
Fixed a bug where when redeeming with available staking balance the staking total is not updated
Refactored the code so all redeem logic shares the same code
Added a new mock that have no fees to test economic model
Added tests to ensure that when no fees are charged, the exchange rate says the same throughout all operations.
Modified `RedeemRequested` event to include the fee being charged.