### PR TITLE
add KBTC and KINT cross-chain assets

### DIFF
--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -204,6 +204,8 @@ create_currency_id! {
 		BNC("Bifrost Native Token", 12) = 168,
 		VSKSM("Bifrost Voucher Slot KSM", 12) = 169,
 		PHA("Phala Native Token", 12) = 170,
+		KINT("Kintsugi Native Token", 12) = 171,
+		KBTC("Kintsugi Wrapped BTC", 8) = 172,
 	}
 }
 

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -748,6 +748,8 @@ parameter_type_with_key! {
 				TokenSymbol::PHA |
 				TokenSymbol::VSKSM |
 				TokenSymbol::ACA |
+				TokenSymbol::KBTC |
+				TokenSymbol::KINT |
 				TokenSymbol::CASH => Balance::max_value() // unsupported
 			},
 			CurrencyId::DexShare(dex_share_0, _) => {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -56,7 +56,7 @@ pub use precompile::{
 	StateRentPrecompile,
 };
 pub use primitives::{
-	currency::{TokenInfo, ACA, AUSD, BNC, DOT, KAR, KSM, KUSD, LDOT, LKSM, PHA, RENBTC, VSKSM},
+	currency::{TokenInfo, ACA, AUSD, BNC, DOT, KAR, KBTC, KINT, KSM, KUSD, LDOT, LKSM, PHA, RENBTC, VSKSM},
 	AccountId,
 };
 use sp_std::{marker::PhantomData, prelude::*};

--- a/runtime/karura/src/constants.rs
+++ b/runtime/karura/src/constants.rs
@@ -104,4 +104,10 @@ pub mod parachains {
 	pub mod phala {
 		pub const ID: u32 = 2004;
 	}
+
+	pub mod kintsugi {
+		pub const ID: u32 = 2092;
+		pub const KBTC_KEY: &[u8] = &[4];
+		pub const KINT_KEY: &[u8] = &[5];
+	}
 }

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1502,7 +1502,7 @@ parameter_types! {
 	pub KintPerSecond: (AssetId, u128) = (
 		MultiLocation::new(
 			1,
-			X2(Parachain(parachains::kintsugi::ID), GeneralKey(parachains::kintsugi::KBTC_KEY.to_vec())),
+			X2(Parachain(parachains::kintsugi::ID), GeneralKey(parachains::kintsugi::KINT_KEY.to_vec())),
 		).into(),
 		// KINT:KSM = 4:3
 		(ksm_per_second() * 4) / 3

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -751,7 +751,7 @@ parameter_type_with_key! {
 				TokenSymbol::BNC => 800 * millicent(*currency_id),  // 80BNC = 1KSM
 				TokenSymbol::VSKSM => 10 * millicent(*currency_id),  // 1VSKSM = 1KSM
 				TokenSymbol::PHA => 4000 * millicent(*currency_id), // 400PHA = 1KSM
-				TokenSymbol::KINT => 10 * millicent(*currency_id),
+				TokenSymbol::KINT => 13333 * microcent(*currency_id), // 1.33 KINT = 1 KSM
 				TokenSymbol::KBTC => 66 * microcent(*currency_id), // 1KBTC = 150 KSM
 
 				TokenSymbol::ACA |
@@ -1504,8 +1504,8 @@ parameter_types! {
 			1,
 			X2(Parachain(parachains::kintsugi::ID), GeneralKey(parachains::kintsugi::KBTC_KEY.to_vec())),
 		).into(),
-		// KINT:KSM = 1:1
-		ksm_per_second()
+		// KINT:KSM = 4:3
+		(ksm_per_second() * 4) / 3
 	);
 }
 

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -114,7 +114,7 @@ pub use runtime_common::{
 	GeneralCouncilMembershipInstance, HomaCouncilInstance, HomaCouncilMembershipInstance,
 	OperatorMembershipInstanceAcala, Price, ProxyType, Rate, Ratio, RelayChainBlockNumberProvider,
 	RelayChainSubAccountId, RuntimeBlockLength, RuntimeBlockWeights, SystemContractsFilter, TechnicalCommitteeInstance,
-	TechnicalCommitteeMembershipInstance, TimeStampedPrice, BNC, KAR, KSM, KUSD, LKSM, PHA, RENBTC, VSKSM,
+	TechnicalCommitteeMembershipInstance, TimeStampedPrice, BNC, KAR, KBTC, KINT, KSM, KUSD, LKSM, PHA, RENBTC, VSKSM,
 };
 
 mod authority;
@@ -751,6 +751,8 @@ parameter_type_with_key! {
 				TokenSymbol::BNC => 800 * millicent(*currency_id),  // 80BNC = 1KSM
 				TokenSymbol::VSKSM => 10 * millicent(*currency_id),  // 1VSKSM = 1KSM
 				TokenSymbol::PHA => 4000 * millicent(*currency_id), // 400PHA = 1KSM
+				TokenSymbol::KINT => 10 * millicent(*currency_id),
+				TokenSymbol::KBTC => 66 * microcent(*currency_id), // 1KBTC = 150 KSM
 
 				TokenSymbol::ACA |
 				TokenSymbol::AUSD |
@@ -1488,6 +1490,23 @@ parameter_types! {
 		// VSKSM:KSM = 1:1
 		ksm_per_second()
 	);
+	pub KbtcPerSecond: (AssetId, u128) = (
+		MultiLocation::new(
+			1,
+			X2(Parachain(parachains::kintsugi::ID), GeneralKey(parachains::kintsugi::KBTC_KEY.to_vec())),
+		).into(),
+		// KBTC:KSM = 1:150 & Satoshi:Planck = 1:10_000
+		ksm_per_second() / 1_500_000
+	);
+
+	pub KintPerSecond: (AssetId, u128) = (
+		MultiLocation::new(
+			1,
+			X2(Parachain(parachains::kintsugi::ID), GeneralKey(parachains::kintsugi::KBTC_KEY.to_vec())),
+		).into(),
+		// KINT:KSM = 1:1
+		ksm_per_second()
+	);
 }
 
 pub type Trader = (
@@ -1498,6 +1517,8 @@ pub type Trader = (
 	FixedRateOfFungible<BncPerSecond, ToTreasury>,
 	FixedRateOfFungible<VsksmPerSecond, ToTreasury>,
 	FixedRateOfFungible<PHAPerSecond, ToTreasury>,
+	FixedRateOfFungible<KbtcPerSecond, ToTreasury>,
+	FixedRateOfFungible<KintPerSecond, ToTreasury>,
 	FixedRateOfForeignAsset<Runtime, ForeignAssetUnitsPerSecond, ToTreasury>,
 );
 
@@ -1678,6 +1699,22 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 			)),
 			// Phala Native token
 			Token(PHA) => Some(MultiLocation::new(1, X1(Parachain(parachains::phala::ID)))),
+			// Kintsugi Native token
+			Token(KINT) => Some(MultiLocation::new(
+				1,
+				X2(
+					Parachain(parachains::kintsugi::ID),
+					GeneralKey(parachains::kintsugi::KINT_KEY.to_vec()),
+				),
+			)),
+			// Kintsugi wrapped BTC
+			Token(KBTC) => Some(MultiLocation::new(
+				1,
+				X2(
+					Parachain(parachains::kintsugi::ID),
+					GeneralKey(parachains::kintsugi::KBTC_KEY.to_vec()),
+				),
+			)),
 			CurrencyId::ForeignAsset(foreign_asset_id) => {
 				XcmForeignAssetIdMapping::<Runtime>::get_multi_location(foreign_asset_id)
 			}
@@ -1706,6 +1743,8 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				match (para_id, &key[..]) {
 					(parachains::bifrost::ID, parachains::bifrost::BNC_KEY) => Some(Token(BNC)),
 					(parachains::bifrost::ID, parachains::bifrost::VSKSM_KEY) => Some(Token(VSKSM)),
+					(parachains::kintsugi::ID, parachains::kintsugi::KINT_KEY) => Some(Token(KINT)),
+					(parachains::kintsugi::ID, parachains::kintsugi::KBTC_KEY) => Some(Token(KBTC)),
 
 					(id, key) if id == u32::from(ParachainInfo::get()) => {
 						// Karura

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -786,6 +786,8 @@ parameter_type_with_key! {
 				TokenSymbol::LKSM |
 				TokenSymbol::RENBTC |
 				TokenSymbol::ACA |
+				TokenSymbol::KINT |
+				TokenSymbol::KBTC |
 				TokenSymbol::CASH => Balance::max_value() // unsupported
 			},
 			CurrencyId::DexShare(dex_share_0, _) => {


### PR DESCRIPTION
This adds support for the Kintsugi's KBTC and KINT tokens. Currently marked as draft since we still need to determine a reasonable value for the KINT:KSM ratio.

I tested this with a rococo-local instance.