### PR TITLE
rm runtime upgrade

### DIFF
--- a/modules/transaction-payment/src/mock.rs
+++ b/modules/transaction-payment/src/mock.rs
@@ -234,7 +234,7 @@ impl PriceProvider<CurrencyId> for MockPriceSource {
 parameter_types! {
 	// DO NOT CHANGE THIS VALUE, AS IT EFFECT THE TESTCASES.
 	pub const FeePoolSize: Balance = 10_000;
-	pub const SwapBalanceThreshold: Balance = 20;
+	pub const SwapThreshold: Balance = 20;
 	pub const TransactionPaymentPalletId: PalletId = PalletId(*b"aca/fees");
 	pub const TreasuryPalletId: PalletId = PalletId(*b"aca/trsy");
 	pub KaruraTreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
@@ -303,21 +303,6 @@ construct_runtime!(
 		DEXModule: module_dex::{Pallet, Storage, Call, Event<T>, Config<T>},
 	}
 );
-
-pub struct MockTransactionPaymentUpgrade;
-
-impl frame_support::traits::OnRuntimeUpgrade for MockTransactionPaymentUpgrade {
-	fn on_runtime_upgrade() -> Weight {
-		for asset in FeePoolExchangeTokens::get() {
-			let _ = <transaction_payment::Pallet<Runtime>>::initialize_pool(
-				asset,
-				FeePoolSize::get(),
-				SwapBalanceThreshold::get(),
-			);
-		}
-		0
-	}
-}
 
 pub struct ExtBuilder {
 	balances: Vec<(AccountId, CurrencyId, Balance)>,

--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -21,8 +21,6 @@
 #![cfg(test)]
 
 use super::*;
-use crate::mock::MockTransactionPaymentUpgrade;
-use frame_support::traits::OnRuntimeUpgrade;
 use frame_support::{
 	assert_noop, assert_ok, parameter_types,
 	weights::{DispatchClass, DispatchInfo, Pays},
@@ -118,7 +116,10 @@ fn do_runtime_upgrade_and_init_balance() {
 		false
 	));
 
-	MockTransactionPaymentUpgrade::on_runtime_upgrade();
+	for asset in crate::mock::FeePoolExchangeTokens::get() {
+		let _ = Pallet::<Runtime>::initialize_pool(asset, FeePoolSize::get(), crate::mock::SwapThreshold::get());
+	}
+	// MockTransactionPaymentUpgrade::on_runtime_upgrade();
 
 	vec![AUSD, DOT].iter().for_each(|token| {
 		let ed = (<Currencies as MultiCurrency<AccountId>>::minimum_balance(token.clone())).unique_saturated_into();

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -1099,13 +1099,6 @@ impl module_transaction_pause::Config for Runtime {
 parameter_types! {
 	// Sort by fee charge order
 	pub DefaultFeeSwapPathList: Vec<Vec<CurrencyId>> = vec![vec![AUSD, DOT, ACA], vec![DOT, ACA], vec![LDOT, DOT, ACA]];
-	// Initial fee pool size. one extrinsic=0.0025 ACA, one block=100 extrinsics.
-	// 20 blocks trigger an swap, so total balance=0.0025*100*20=5 ACA
-	pub FeePoolSize: Balance = 5 * dollar(ACA);
-	// one extrinsic fee=0.0025ACA, one block=100 extrinsics, threshold=0.25+0.1=0.35ACA
-	pub SwapBalanceThreshold: Balance = Ratio::saturating_from_rational(35, 100).saturating_mul_int(dollar(ACA));
-	// tokens used as fee charge. the token should have corresponding dex swap pool enabled.
-	pub FeePoolExchangeTokens: Vec<CurrencyId> = vec![AUSD, DOT];
 }
 
 type NegativeImbalance = <Balances as PalletCurrency<AccountId>>::NegativeImbalance;
@@ -1878,33 +1871,8 @@ pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllPallets,
-	TransactionPaymentUpgrade,
->;
-
-pub struct TransactionPaymentUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for TransactionPaymentUpgrade {
-	fn on_runtime_upgrade() -> Weight {
-		let initial_rates = FeePoolExchangeTokens::get();
-		if initial_rates.is_empty() {
-			0
-		} else {
-			for asset in initial_rates {
-				let _ = <module_transaction_payment::Pallet<Runtime>>::initialize_pool(
-					asset,
-					FeePoolSize::get(),
-					SwapBalanceThreshold::get(),
-				);
-			}
-			<Runtime as frame_system::Config>::BlockWeights::get().max_block
-		}
-	}
-}
+pub type Executive =
+	frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPallets, ()>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/runtime/integration-tests/src/setup.rs
+++ b/runtime/integration-tests/src/setup.rs
@@ -123,20 +123,6 @@ mod karura_imports {
 			(LKSM, NativeTokenExistentialDeposit::get() - 1),
 		];
 	}
-
-	pub struct MockRuntimeUpgrade;
-	impl frame_support::traits::OnRuntimeUpgrade for MockRuntimeUpgrade {
-		fn on_runtime_upgrade() -> Weight {
-			for asset in InitialTokenFeePool::get() {
-				let _ = <module_transaction_payment::Pallet<Runtime>>::initialize_pool(
-					asset.0,
-					asset.1,
-					SwapBalanceThreshold::get(),
-				);
-			}
-			0
-		}
-	}
 }
 
 #[cfg(feature = "with-acala-runtime")]

--- a/runtime/integration-tests/src/setup.rs
+++ b/runtime/integration-tests/src/setup.rs
@@ -72,24 +72,23 @@ mod mandala_imports {
 pub use karura_imports::*;
 #[cfg(feature = "with-karura-runtime")]
 mod karura_imports {
-	pub use frame_support::parameter_types;
-	use frame_support::weights::Weight;
+	pub use frame_support::{parameter_types, weights::Weight};
 	pub use karura_runtime::{
 		constants::parachains, create_x2_parachain_multilocation, get_all_module_accounts, AcalaOracle, AccountId,
 		AssetRegistry, AuctionManager, Authority, AuthoritysOriginId, Balance, Balances, BlockNumber, Call, CdpEngine,
 		CdpTreasury, CreateClassDeposit, CreateTokenDeposit, Currencies, CurrencyId, CurrencyIdConvert,
 		DataDepositPerByte, DefaultExchangeRate, Dex, EmergencyShutdown, Event, EvmAccounts, ExistentialDeposits,
-		FeePoolSize, FinancialCouncil, Get, GetNativeCurrencyId, Homa, HomaXcm, Honzon, IdleScheduler, KarPerSecond,
+		FinancialCouncil, Get, GetNativeCurrencyId, Homa, HomaXcm, Honzon, IdleScheduler, KarPerSecond,
 		KaruraFoundationAccounts, KsmPerSecond, KusamaBondingDuration, KusdPerSecond, Loans, MaxTipsOfPriority,
 		MinimumDebitValue, MultiLocation, NativeTokenExistentialDeposit, NetworkId, NftPalletId, OneDay, Origin,
 		OriginCaller, ParachainAccount, ParachainInfo, ParachainSystem, PolkadotXcm, Proxy, ProxyType, Ratio,
-		RelayChainBlockNumberProvider, Runtime, Scheduler, Session, SessionManager, SevenDays, SwapBalanceThreshold,
-		System, Timestamp, TipPerWeightStep, TokenSymbol, Tokens, TreasuryPalletId, Utility, Vesting, XTokens,
-		XcmConfig, XcmExecutor, EVM, NFT,
+		RelayChainBlockNumberProvider, Runtime, Scheduler, Session, SessionManager, SevenDays, System, Timestamp,
+		TipPerWeightStep, TokenSymbol, Tokens, TreasuryPalletId, Utility, Vesting, XTokens, XcmConfig, XcmExecutor,
+		EVM, NFT,
 	};
 	pub use primitives::TradingPair;
 	pub use runtime_common::{calculate_asset_ratio, cent, dollar, millicent, KAR, KSM, KUSD, LKSM};
-	pub use sp_runtime::traits::AccountIdConversion;
+	pub use sp_runtime::{traits::AccountIdConversion, FixedPointNumber};
 
 	parameter_types! {
 		pub EnabledTradingPairs: Vec<TradingPair> = vec![
@@ -111,9 +110,16 @@ mod karura_imports {
 	);
 
 	parameter_types! {
-		pub TokenExchangeRates: Vec<(CurrencyId, Balance)> = vec![
+		// Initial fee pool size. one extrinsic=0.0025 KAR, one block=100 extrinsics.
+		// 20 blocks trigger an swap, so total balance=0.0025*100*20=5 KAR
+		pub FeePoolSize: Balance = 5 * dollar(KAR);
+		// one extrinsic fee=0.0025KAR, one block=100 extrinsics, threshold=0.25+0.1=0.35KAR
+		pub SwapBalanceThreshold: Balance = Ratio::saturating_from_rational(35, 100).saturating_mul_int(dollar(KAR));
+		// tokens used as fee charge. the token should have corresponding dex swap pool enabled.
+		pub InitialTokenFeePool: Vec<(CurrencyId, Balance)> = vec![
 			(KSM, FeePoolSize::get()),
 			(KUSD, FeePoolSize::get()),
+			// this one is to simulate not enough native asset so wouldn't take effect
 			(LKSM, NativeTokenExistentialDeposit::get() - 1),
 		];
 	}
@@ -121,7 +127,7 @@ mod karura_imports {
 	pub struct MockRuntimeUpgrade;
 	impl frame_support::traits::OnRuntimeUpgrade for MockRuntimeUpgrade {
 		fn on_runtime_upgrade() -> Weight {
-			for asset in TokenExchangeRates::get() {
+			for asset in InitialTokenFeePool::get() {
 				let _ = <module_transaction_payment::Pallet<Runtime>>::initialize_pool(
 					asset.0,
 					asset.1,

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1116,13 +1116,6 @@ parameter_types! {
 		vec![LKSM, KSM, KAR],
 		vec![BNC, KUSD, KSM, KAR],
 	];
-	// Initial fee pool size. one extrinsic=0.0025 KAR, one block=100 extrinsics.
-	// 20 blocks trigger an swap, so total balance=0.0025*100*20=5 KAR
-	pub FeePoolSize: Balance = 5 * dollar(KAR);
-	// one extrinsic fee=0.0025KAR, one block=100 extrinsics, threshold=0.25+0.1=0.35KAR
-	pub SwapBalanceThreshold: Balance = Ratio::saturating_from_rational(35, 100).saturating_mul_int(dollar(KAR));
-	// tokens used as fee charge. the token should have corresponding dex swap pool enabled.
-	pub FeePoolExchangeTokens: Vec<CurrencyId> = vec![KUSD, KSM, LKSM, BNC];
 }
 
 type NegativeImbalance = <Balances as PalletCurrency<AccountId>>::NegativeImbalance;
@@ -1997,33 +1990,8 @@ pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllPallets,
-	TransactionPaymentUpgrade,
->;
-
-pub struct TransactionPaymentUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for TransactionPaymentUpgrade {
-	fn on_runtime_upgrade() -> Weight {
-		let initial_rates = FeePoolExchangeTokens::get();
-		if initial_rates.is_empty() {
-			0
-		} else {
-			for asset in initial_rates {
-				let _ = <module_transaction_payment::Pallet<Runtime>>::initialize_pool(
-					asset,
-					FeePoolSize::get(),
-					SwapBalanceThreshold::get(),
-				);
-			}
-			<Runtime as frame_system::Config>::BlockWeights::get().max_block
-		}
-	}
-}
+pub type Executive =
+	frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPallets, ()>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/runtime/mandala/src/benchmarking/transaction_payment.rs
+++ b/runtime/mandala/src/benchmarking/transaction_payment.rs
@@ -18,8 +18,8 @@
 
 use super::utils::set_balance;
 use crate::{
-	dollar, AccountId, Balance, Currencies, CurrencyId, Dex, Event, FeePoolSize, GetNativeCurrencyId,
-	GetStableCurrencyId, NativeTokenExistentialDeposit, Origin, Runtime, System, TransactionPayment, TreasuryPalletId,
+	dollar, AccountId, Balance, Currencies, CurrencyId, Dex, Event, GetNativeCurrencyId, GetStableCurrencyId,
+	NativeTokenExistentialDeposit, Origin, Runtime, System, TransactionPayment, TreasuryPalletId,
 };
 use frame_benchmarking::{account, whitelisted_caller};
 use frame_support::traits::OnFinalize;
@@ -91,7 +91,7 @@ runtime_benchmarks! {
 		let sub_account: AccountId = <Runtime as module_transaction_payment::Config>::PalletId::get().into_sub_account(STABLECOIN);
 		let native_ed: Balance = <Currencies as MultiCurrency<AccountId>>::minimum_balance(NATIVECOIN);
 		let stable_ed: Balance = <Currencies as MultiCurrency<AccountId>>::minimum_balance(STABLECOIN);
-		let pool_size: Balance = FeePoolSize::get();
+		let pool_size: Balance = native_ed * 50;
 		let swap_threshold: Balance = native_ed * 2;
 
 		let path = vec![STABLECOIN, NATIVECOIN];

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1119,13 +1119,6 @@ impl module_transaction_pause::Config for Runtime {
 parameter_types! {
 	// Sort by fee charge order
 	pub DefaultFeeSwapPathList: Vec<Vec<CurrencyId>> = vec![vec![AUSD, ACA], vec![AUSD, LDOT, ACA], vec![AUSD, DOT, ACA], vec![AUSD, RENBTC, ACA]];
-	// Initial fee pool size. one extrinsic=0.0025 ACA, one block=100 extrinsics.
-	// 20 blocks trigger an swap, so total balance=0.0025*100*20=5 ACA
-	pub FeePoolSize: Balance = 5 * dollar(ACA);
-	// one extrinsic fee=0.0025ACA, one block=100 extrinsics, threshold=0.25+0.1=0.35ACA
-	pub SwapBalanceThreshold: Balance = Ratio::saturating_from_rational(35, 100).saturating_mul_int(dollar(ACA));
-	// tokens used as fee charge. the token should have corresponding dex swap pool enabled.
-	pub FeePoolExchangeTokens: Vec<CurrencyId> = vec![DOT];
 }
 
 type NegativeImbalance = <Balances as PalletCurrency<AccountId>>::NegativeImbalance;
@@ -1997,33 +1990,8 @@ pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllPallets,
-	TransactionPaymentUpgrade,
->;
-
-pub struct TransactionPaymentUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for TransactionPaymentUpgrade {
-	fn on_runtime_upgrade() -> Weight {
-		let initial_rates = FeePoolExchangeTokens::get();
-		if initial_rates.is_empty() {
-			0
-		} else {
-			for asset in initial_rates {
-				let _ = <module_transaction_payment::Pallet<Runtime>>::initialize_pool(
-					asset,
-					FeePoolSize::get(),
-					SwapBalanceThreshold::get(),
-				);
-			}
-			<Runtime as frame_system::Config>::BlockWeights::get().max_block
-		}
-	}
-}
+pub type Executive =
+	frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPallets, ()>;
 
 construct_runtime! {
 	pub enum Runtime where


### PR DESCRIPTION
rm transaction payment fee runtime upgrades.
later on when acala need enable charge fee pool, can invoke `enable_charge_fee_pool` dispatch call.