### PR TITLE
sibling token rework

### DIFF
--- a/modules/asset-registry/src/lib.rs
+++ b/modules/asset-registry/src/lib.rs
@@ -103,6 +103,7 @@ pub mod module {
 		pub symbol: Vec<u8>,
 		pub decimals: u8,
 		pub minimal_balance: Balance,
+		// pub units_per_second: Option<Balance>,
 	}
 
 	#[pallet::error]
@@ -324,7 +325,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
-	fn do_register_foreign_asset(
+	pub fn do_register_foreign_asset(
 		location: &MultiLocation,
 		metadata: &AssetMetadata<BalanceOf<T>>,
 	) -> Result<ForeignAssetId, DispatchError> {

--- a/node/service/src/chain_spec/karura.rs
+++ b/node/service/src/chain_spec/karura.rs
@@ -30,7 +30,7 @@ use karura_runtime::{
 	DexConfig, FinancialCouncilMembershipConfig, GeneralCouncilMembershipConfig, HomaCouncilMembershipConfig,
 	OperatorMembershipAcalaConfig, OrmlNFTConfig, ParachainInfoConfig, PolkadotXcmConfig, SS58Prefix, SessionConfig,
 	SessionDuration, SessionKeys, SessionManagerConfig, SudoConfig, SystemConfig, TechnicalCommitteeMembershipConfig,
-	TokensConfig, VestingConfig, BNC, KAR, KSM, KUSD, LKSM, PHA, VSKSM,
+	TokensConfig, VestingConfig, KAR, KSM, KUSD, LKSM,
 };
 use runtime_common::TokenInfo;
 
@@ -46,7 +46,7 @@ fn karura_properties() -> Properties {
 	let mut properties = Map::new();
 	let mut token_symbol: Vec<String> = vec![];
 	let mut token_decimals: Vec<u32> = vec![];
-	[KAR, KUSD, KSM, LKSM, BNC, VSKSM, PHA].iter().for_each(|token| {
+	[KAR, KUSD, KSM, LKSM].iter().for_each(|token| {
 		token_symbol.push(token.symbol().unwrap().to_string());
 		token_decimals.push(token.decimals().unwrap() as u32);
 	});

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -200,11 +200,11 @@ create_currency_id! {
 		// 149: Reserved for renBTC
 		// 150: Reserved for CASH
 		// 168 - 255: Kusama parachain tokens
-		BNC("Bifrost Native Token", 12) = 168,
-		VSKSM("Bifrost Voucher Slot KSM", 12) = 169,
-		PHA("Phala Native Token", 12) = 170,
-		KINT("Kintsugi Native Token", 12) = 171,
-		KBTC("Kintsugi Wrapped BTC", 8) = 172,
+		// BNC("Bifrost Native Token", 12) = 168,
+		// VSKSM("Bifrost Voucher Slot KSM", 12) = 169,
+		// PHA("Phala Native Token", 12) = 170,
+		// KINT("Kintsugi Native Token", 12) = 171,
+		// KBTC("Kintsugi Wrapped BTC", 8) = 172,
 	}
 }
 

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -749,12 +749,12 @@ parameter_type_with_key! {
 				TokenSymbol::KSM |
 				TokenSymbol::LKSM |
 				TokenSymbol::RENBTC |
-				TokenSymbol::BNC |
-				TokenSymbol::PHA |
-				TokenSymbol::VSKSM |
+				// TokenSymbol::BNC |
+				// TokenSymbol::PHA |
+				// TokenSymbol::VSKSM |
 				TokenSymbol::ACA |
-				TokenSymbol::KBTC |
-				TokenSymbol::KINT |
+				// TokenSymbol::KBTC |
+				// TokenSymbol::KINT |
 				TokenSymbol::TAI |
 				TokenSymbol::CASH => Balance::max_value() // unsupported
 			},

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -59,7 +59,7 @@ pub use precompile::{
 	StateRentPrecompile,
 };
 pub use primitives::{
-	currency::{TokenInfo, ACA, AUSD, BNC, DOT, KAR, KBTC, KINT, KSM, KUSD, LDOT, LKSM, PHA, RENBTC, VSKSM},
+	currency::{TokenInfo, ACA, AUSD, DOT, KAR, KSM, KUSD, LDOT, LKSM, RENBTC},
 	AccountId,
 };
 use sp_std::{marker::PhantomData, prelude::*};

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -138,7 +138,7 @@ xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "4d3bb9
 acala-service = { path = "../../node/service", features = ["with-all-runtime"] }
 
 [features]
-default = ["std"]
+default = ["std", "with-karura-runtime"]
 no_std = []
 with-mandala-runtime = [
 	"acala-service/with-mandala-runtime",

--- a/runtime/integration-tests/src/runtime.rs
+++ b/runtime/integration-tests/src/runtime.rs
@@ -133,6 +133,9 @@ fn currency_id_convert() {
 				CurrencyIdConvert::convert(MultiLocation::sibling_parachain_general_key(id, LDOT.encode())),
 				None
 			);
+
+			initiate_asset_registry();
+
 			assert_eq!(
 				CurrencyIdConvert::convert(MultiLocation::sibling_parachain_general_key(
 					parachains::bifrost::ID,
@@ -146,6 +149,10 @@ fn currency_id_convert() {
 					parachains::bifrost::VSKSM_KEY.to_vec()
 				)),
 				Some(VSKSM)
+			);
+			assert_eq!(
+				CurrencyIdConvert::convert(MultiLocation::new(1, X1(Parachain(parachains::phala::ID)))),
+				Some(PHA)
 			);
 
 			assert_eq!(
@@ -161,6 +168,10 @@ fn currency_id_convert() {
 					parachains::bifrost::ID,
 					parachains::bifrost::VSKSM_KEY.to_vec()
 				))
+			);
+			assert_eq!(
+				CurrencyIdConvert::convert(PHA),
+				Some(MultiLocation::new(1, X1(Parachain(parachains::phala::ID))))
 			);
 
 			let native_currency: MultiAsset = (

--- a/runtime/integration-tests/src/setup.rs
+++ b/runtime/integration-tests/src/setup.rs
@@ -72,7 +72,7 @@ mod mandala_imports {
 pub use karura_imports::*;
 #[cfg(feature = "with-karura-runtime")]
 mod karura_imports {
-	pub use frame_support::{parameter_types, weights::Weight};
+	pub use frame_support::{assert_ok, parameter_types, weights::Weight};
 	pub use karura_runtime::{
 		constants::parachains, create_x2_parachain_multilocation, get_all_module_accounts, AcalaOracle, AccountId,
 		AssetRegistry, AuctionManager, Authority, AuthoritysOriginId, Balance, Balances, BlockNumber, Call, CdpEngine,
@@ -86,9 +86,11 @@ mod karura_imports {
 		TipPerWeightStep, TokenSymbol, Tokens, TreasuryPalletId, Utility, Vesting, XTokens, XcmConfig, XcmExecutor,
 		EVM, NFT,
 	};
+	pub use module_asset_registry::AssetMetadata;
 	pub use primitives::TradingPair;
 	pub use runtime_common::{calculate_asset_ratio, cent, dollar, millicent, KAR, KSM, KUSD, LKSM};
 	pub use sp_runtime::{traits::AccountIdConversion, FixedPointNumber};
+	pub use xcm::latest::prelude::*;
 
 	parameter_types! {
 		pub EnabledTradingPairs: Vec<TradingPair> = vec![
@@ -123,6 +125,56 @@ mod karura_imports {
 			(LKSM, NativeTokenExistentialDeposit::get() - 1),
 		];
 	}
+
+	pub fn initiate_asset_registry() {
+		// BNC: ForeignAsset(0)
+		assert_ok!(module_asset_registry::Pallet::<Runtime>::do_register_foreign_asset(
+			&(
+				1,
+				X2(
+					Parachain(parachains::bifrost::ID),
+					GeneralKey(parachains::bifrost::BNC_KEY.to_vec()),
+				)
+			)
+				.into(),
+			&AssetMetadata {
+				name: "BNC".as_bytes().to_vec(),
+				symbol: "BNC".as_bytes().to_vec(),
+				decimals: 12,
+				minimal_balance: 800 * (10u128.saturating_pow(12))
+			}
+		));
+		// VSKSM: ForeignAsset(1)
+		assert_ok!(module_asset_registry::Pallet::<Runtime>::do_register_foreign_asset(
+			&(
+				1,
+				X2(
+					Parachain(parachains::bifrost::ID),
+					GeneralKey(parachains::bifrost::VSKSM_KEY.to_vec()),
+				)
+			)
+				.into(),
+			&AssetMetadata {
+				name: "VSKSM".as_bytes().to_vec(),
+				symbol: "VSKSM".as_bytes().to_vec(),
+				decimals: 12,
+				minimal_balance: 10 * (10u128.saturating_pow(12))
+			}
+		));
+		// PHA: ForeignAsset(2)
+		assert_ok!(module_asset_registry::Pallet::<Runtime>::do_register_foreign_asset(
+			&(1, X1(Parachain(parachains::phala::ID))).into(),
+			&AssetMetadata {
+				name: "PHA".as_bytes().to_vec(),
+				symbol: "PHA".as_bytes().to_vec(),
+				decimals: 12,
+				minimal_balance: 4000 * (10u128.saturating_pow(12))
+			}
+		));
+	}
+	pub const BNC: CurrencyId = CurrencyId::ForeignAsset(0);
+	pub const VSKSM: CurrencyId = CurrencyId::ForeignAsset(1);
+	pub const PHA: CurrencyId = CurrencyId::ForeignAsset(2);
 }
 
 #[cfg(feature = "with-acala-runtime")]

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -778,15 +778,15 @@ parameter_type_with_key! {
 				TokenSymbol::AUSD => cent(*currency_id),
 				TokenSymbol::DOT => 10 * millicent(*currency_id),
 				TokenSymbol::LDOT => 50 * millicent(*currency_id),
-				TokenSymbol::BNC => 800 * millicent(*currency_id),  // 80BNC = 1KSM
-				TokenSymbol::VSKSM => 10 * millicent(*currency_id),  // 1VSKSM = 1KSM
-				TokenSymbol::PHA => 4000 * millicent(*currency_id), // 400PHA = 1KSM
+				// TokenSymbol::BNC => 800 * millicent(*currency_id),  // 80BNC = 1KSM
+				// TokenSymbol::VSKSM => 10 * millicent(*currency_id),  // 1VSKSM = 1KSM
+				// TokenSymbol::PHA => 4000 * millicent(*currency_id), // 400PHA = 1KSM
 				TokenSymbol::KUSD |
 				TokenSymbol::KSM |
 				TokenSymbol::LKSM |
 				TokenSymbol::RENBTC |
-				TokenSymbol::KINT |
-				TokenSymbol::KBTC |
+				// TokenSymbol::KINT |
+				// TokenSymbol::KBTC |
 				TokenSymbol::TAI => 10 * millicent(*currency_id),
 				TokenSymbol::ACA |
 				TokenSymbol::KAR |


### PR DESCRIPTION
relates to: https://github.com/AcalaNetwork/Acala/issues/1773

the `asset-registry` module could used for not only statemine/statemint assets, but also sibling token(i.e BNC, PHA etc). thus for new sibling token onboard to acala, now we can use `register_foreign_asset` dispatch call of `asset-registry` instead of merge PR to acala code base from parachain team.

a unconenient effect is `asset-registry` use `foreign-asset-id` which is number instead of `TokenSymbol` enum, thus in front/dapp we may need `TokenSymbol` mapping to `foreign-asset-id`, make sure the token mapping is correct.

todo list:
- [] Trader