### PR TITLE
try-runtime works only on dev

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -206,9 +206,10 @@ fn set_default_ss58_version(spec: &Box<dyn service::ChainSpec>) {
 	sp_core::crypto::set_default_ss58_version(ss58_version.into());
 }
 
-const DEV_ONLY_ERROR_PATTERN: &'static str =
-	"can only use subcommand with --chain [karura-dev, acala-dev, pc-dev, dev], got ";
+#[allow(dead_code)]
+const DEV_ONLY_ERROR_PATTERN: &str = "can only use subcommand with --chain [karura-dev, acala-dev, pc-dev, dev], got ";
 
+#[allow(dead_code)]
 fn ensure_dev(spec: &Box<dyn service::ChainSpec>) -> std::result::Result<(), String> {
 	if spec.is_dev() {
 		Ok(())

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -145,6 +145,9 @@ pub trait IdentifyVariant {
 
 	/// Returns `true` if this is a configuration for the `Mandala` dev network.
 	fn is_mandala_dev(&self) -> bool;
+
+	/// Returns `true` if this is a configuration for the dev network.
+	fn is_dev(&self) -> bool;
 }
 
 impl IdentifyVariant for Box<dyn ChainSpec> {
@@ -162,6 +165,10 @@ impl IdentifyVariant for Box<dyn ChainSpec> {
 
 	fn is_mandala_dev(&self) -> bool {
 		self.id().starts_with("mandala-dev")
+	}
+
+	fn is_dev(&self) -> bool {
+		self.id().ends_with("dev")
 	}
 }
 


### PR DESCRIPTION
closes: https://github.com/AcalaNetwork/Acala/issues/1566

example:
```
 cargo run --features with-karura-runtime --features try-runtime try-runtime --chain=karura on-runtime-upgrade live --uri wss://karura-rpc-0.aca-api.network:443
    Finished dev [unoptimized + debuginfo] target(s) in 0.82s
     Running `target/debug/acala try-runtime --chain=karura on-runtime-upgrade live --uri 'wss://karura-rpc-0.aca-api.network:443'`
Error: Input("try-runtime error: can only use subcommand with --chain [karura-dev, acala-dev, pc-dev, dev], got karura")
```