### PR TITLE
Rename init to input

### DIFF
--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -725,7 +725,7 @@ pub mod module {
 		/// Issue an EVM create operation. This is similar to a contract
 		/// creation transaction in Ethereum.
 		///
-		/// - `init`: the data supplied for the contract's constructor
+		/// - `input`: the data supplied for the contract's constructor
 		/// - `value`: the amount sent to the contract upon creation
 		/// - `gas_limit`: the maximum gas the call can use
 		/// - `storage_limit`: the total bytes the contract's storage can increase by
@@ -733,7 +733,7 @@ pub mod module {
 		#[transactional]
 		pub fn create(
 			origin: OriginFor<T>,
-			init: Vec<u8>,
+			input: Vec<u8>,
 			#[pallet::compact] value: BalanceOf<T>,
 			#[pallet::compact] gas_limit: u64,
 			#[pallet::compact] storage_limit: u32,
@@ -744,7 +744,7 @@ pub mod module {
 
 			match T::Runner::create(
 				source,
-				init,
+				input,
 				value,
 				gas_limit,
 				storage_limit,
@@ -790,7 +790,7 @@ pub mod module {
 		/// Issue an EVM create2 operation.
 		///
 		/// - `target`: the contract address to call
-		/// - `init`: the data supplied for the contract's constructor
+		/// - `input`: the data supplied for the contract's constructor
 		/// - `salt`: used for generating the new contract's address
 		/// - `value`: the amount sent for payable calls
 		/// - `gas_limit`: the maximum gas the call can use
@@ -799,7 +799,7 @@ pub mod module {
 		#[transactional]
 		pub fn create2(
 			origin: OriginFor<T>,
-			init: Vec<u8>,
+			input: Vec<u8>,
 			salt: H256,
 			#[pallet::compact] value: BalanceOf<T>,
 			#[pallet::compact] gas_limit: u64,
@@ -811,7 +811,7 @@ pub mod module {
 
 			match T::Runner::create2(
 				source,
-				init,
+				input,
 				salt,
 				value,
 				gas_limit,
@@ -858,7 +858,7 @@ pub mod module {
 		/// Create mirrored NFT contract. The next available system contract
 		/// address will be used as created contract address.
 		///
-		/// - `init`: the data supplied for the contract's constructor
+		/// - `input`: the data supplied for the contract's constructor
 		/// - `value`: the amount sent for payable calls
 		/// - `gas_limit`: the maximum gas the call can use
 		/// - `storage_limit`: the total bytes the contract's storage can increase by
@@ -866,7 +866,7 @@ pub mod module {
 		#[transactional]
 		pub fn create_nft_contract(
 			origin: OriginFor<T>,
-			init: Vec<u8>,
+			input: Vec<u8>,
 			#[pallet::compact] value: BalanceOf<T>,
 			#[pallet::compact] gas_limit: u64,
 			#[pallet::compact] storage_limit: u32,
@@ -892,7 +892,7 @@ pub mod module {
 			match T::Runner::create_at_address(
 				source,
 				address,
-				init,
+				input,
 				value,
 				gas_limit,
 				storage_limit,
@@ -941,11 +941,11 @@ pub mod module {
 		/// will be used as created contract address.
 		///
 		/// - `target`: the address specified by the contract
-		/// - `init`: the data supplied for the contract's constructor
+		/// - `input`: the data supplied for the contract's constructor
 		/// - `value`: the amount sent for payable calls
 		/// - `gas_limit`: the maximum gas the call can use
 		/// - `storage_limit`: the total bytes the contract's storage can increase by
-		#[pallet::weight(if init.is_empty() {
+		#[pallet::weight(if input.is_empty() {
 			<T as Config>::WeightInfo::create_predeploy_mirror_token_contract()
 		} else {
 			create_predeploy_contract::<T>(*gas_limit)
@@ -954,7 +954,7 @@ pub mod module {
 		pub fn create_predeploy_contract(
 			origin: OriginFor<T>,
 			target: EvmAddress,
-			init: Vec<u8>,
+			input: Vec<u8>,
 			#[pallet::compact] value: BalanceOf<T>,
 			#[pallet::compact] gas_limit: u64,
 			#[pallet::compact] storage_limit: u32,
@@ -980,7 +980,7 @@ pub mod module {
 				)?;
 			}
 
-			if init.is_empty() {
+			if input.is_empty() {
 				// This is mirror token, get the code of token predeployed contract.
 				let code = Self::code_at_address(&PREDEPLOY_ADDRESS_START);
 				ensure!(!code.is_empty(), Error::<T>::ContractNotFound);
@@ -1008,7 +1008,7 @@ pub mod module {
 				match T::Runner::create_at_address(
 					source,
 					target,
-					init,
+					input,
 					value,
 					gas_limit,
 					storage_limit,

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -1925,7 +1925,7 @@ impl_runtime_apis! {
 						access_list: Some(access_list)
 					})
 				}
-				Call::EVM(module_evm::Call::create{init, value, gas_limit, storage_limit, access_list}) => {
+				Call::EVM(module_evm::Call::create{input, value, gas_limit, storage_limit, access_list}) => {
 					// use MAX_VALUE for no limit
 					let gas_limit = if gas_limit < u64::MAX { Some(gas_limit) } else { None };
 					let storage_limit = if storage_limit < u32::MAX { Some(storage_limit) } else { None };
@@ -1935,7 +1935,7 @@ impl_runtime_apis! {
 						gas_limit,
 						storage_limit,
 						value: Some(value),
-						data: Some(init),
+						data: Some(input),
 						access_list: Some(access_list)
 					})
 				}

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -2006,7 +2006,7 @@ impl_runtime_apis! {
 						access_list: Some(access_list)
 					})
 				}
-				Call::EVM(module_evm::Call::create{init, value, gas_limit, storage_limit, access_list}) => {
+				Call::EVM(module_evm::Call::create{input, value, gas_limit, storage_limit, access_list}) => {
 					// use MAX_VALUE for no limit
 					let gas_limit = if gas_limit < u64::MAX { Some(gas_limit) } else { None };
 					let storage_limit = if storage_limit < u32::MAX { Some(storage_limit) } else { None };
@@ -2016,7 +2016,7 @@ impl_runtime_apis! {
 						gas_limit,
 						storage_limit,
 						value: Some(value),
-						data: Some(init),
+						data: Some(input),
 						access_list: Some(access_list)
 					})
 				}

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -2172,7 +2172,7 @@ impl_runtime_apis! {
 						access_list: Some(access_list)
 					})
 				}
-				Call::EVM(module_evm::Call::create{init, value, gas_limit, storage_limit, access_list}) => {
+				Call::EVM(module_evm::Call::create{input, value, gas_limit, storage_limit, access_list}) => {
 					// use MAX_VALUE for no limit
 					let gas_limit = if gas_limit < u64::MAX { Some(gas_limit) } else { None };
 					let storage_limit = if storage_limit < u32::MAX { Some(storage_limit) } else { None };
@@ -2182,7 +2182,7 @@ impl_runtime_apis! {
 						gas_limit,
 						storage_limit,
 						value: Some(value),
-						data: Some(init),
+						data: Some(input),
 						access_list: Some(access_list)
 					})
 				}


### PR DESCRIPTION
Keep the same as `call`
https://github.com/AcalaNetwork/Acala/blob/bf3d860f388117b8bb74502795be38704fdacfcd/modules/evm/src/lib.rs#L564-L572


It was used https://github.com/AcalaNetwork/bodhi.js/pull/285/files#diff-8e05d01e1b336d3501a54605915fd1c9116c51bc23417352c54359c4ca197119R439
