### PR TITLE
improve dex-support-tai-pool-asset

### DIFF
--- a/modules/asset-registry/src/lib.rs
+++ b/modules/asset-registry/src/lib.rs
@@ -621,6 +621,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				let name_0 = match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).name().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.name),
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
+					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LiquidCrowdloan-{}-{}",
@@ -631,14 +634,14 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.name)
-					}
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
 					}
 				}?;
 				let name_1 = match symbol_1 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).name().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.name),
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
+					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LiquidCrowdloan-{}-{}",
@@ -649,9 +652,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.name)
-					}
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
 					}
 				}?;
 
@@ -697,6 +697,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				let token_symbol_0 = match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).symbol().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.symbol),
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
+					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LC{}-{}",
@@ -709,14 +712,14 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.symbol)
-					}
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
 					}
 				}?;
 				let token_symbol_1 = match symbol_1 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).symbol().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.symbol),
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
+					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LC{}-{}",
@@ -729,9 +732,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.symbol)
-					}
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
 					}
 				}?;
 
@@ -781,12 +781,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).decimals(),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.decimals),
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.decimals)
+					}
 					DexShare::LiquidCrowdloan(_) => T::StakingCurrencyId::get().decimals(),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.decimals)
-					}
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.decimals)
 					}
 				}
 			}
@@ -813,9 +813,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|_| ())?;
 					}
 					DexShare::Token(_)
+					| DexShare::StableAssetPoolToken(_)
 					| DexShare::LiquidCrowdloan(_)
-					| DexShare::ForeignAsset(_)
-					| DexShare::StableAssetPoolToken(_) => {}
+					| DexShare::ForeignAsset(_) => {}
 				};
 				match right {
 					DexShare::Erc20(address) => {
@@ -823,9 +823,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|_| ())?;
 					}
 					DexShare::Token(_)
+					| DexShare::StableAssetPoolToken(_)
 					| DexShare::LiquidCrowdloan(_)
-					| DexShare::ForeignAsset(_)
-					| DexShare::StableAssetPoolToken(_) => {}
+					| DexShare::ForeignAsset(_) => {}
 				};
 			}
 			CurrencyId::Token(_)
@@ -859,6 +859,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						let id = u32::from_be_bytes(address[H160_POSITION_DEXSHARE_LEFT_FIELD].try_into().ok()?);
 						Erc20IdToAddress::<T>::get(id).map(DexShare::Erc20)
 					}
+					DexShareType::StableAssetPoolToken => {
+						let id = StableAssetPoolId::from_be_bytes(
+							address[H160_POSITION_DEXSHARE_LEFT_FIELD][..].try_into().ok()?,
+						);
+						Some(DexShare::StableAssetPoolToken(id))
+					}
 					DexShareType::LiquidCrowdloan => {
 						let id = Lease::from_be_bytes(address[H160_POSITION_DEXSHARE_LEFT_FIELD].try_into().ok()?);
 						Some(DexShare::LiquidCrowdloan(id))
@@ -868,12 +874,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 							address[H160_POSITION_DEXSHARE_LEFT_FIELD][2..].try_into().ok()?,
 						);
 						Some(DexShare::ForeignAsset(id))
-					}
-					DexShareType::StableAssetPoolToken => {
-						let id = StableAssetPoolId::from_be_bytes(
-							address[H160_POSITION_DEXSHARE_LEFT_FIELD][2..].try_into().ok()?,
-						);
-						Some(DexShare::StableAssetPoolToken(id))
 					}
 				}?;
 				let right = match DexShareType::try_from(address[H160_POSITION_DEXSHARE_RIGHT_TYPE]).ok()? {
@@ -885,6 +885,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						let id = u32::from_be_bytes(address[H160_POSITION_DEXSHARE_RIGHT_FIELD].try_into().ok()?);
 						Erc20IdToAddress::<T>::get(id).map(DexShare::Erc20)
 					}
+					DexShareType::StableAssetPoolToken => {
+						let id = StableAssetPoolId::from_be_bytes(
+							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][..].try_into().ok()?,
+						);
+						Some(DexShare::StableAssetPoolToken(id))
+					}
 					DexShareType::LiquidCrowdloan => {
 						let id = Lease::from_be_bytes(address[H160_POSITION_DEXSHARE_RIGHT_FIELD].try_into().ok()?);
 						Some(DexShare::LiquidCrowdloan(id))
@@ -894,12 +900,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][2..].try_into().ok()?,
 						);
 						Some(DexShare::ForeignAsset(id))
-					}
-					DexShareType::StableAssetPoolToken => {
-						let id = StableAssetPoolId::from_be_bytes(
-							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][2..].try_into().ok()?,
-						);
-						Some(DexShare::StableAssetPoolToken(id))
 					}
 				}?;
 

--- a/modules/asset-registry/src/lib.rs
+++ b/modules/asset-registry/src/lib.rs
@@ -621,9 +621,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				let name_0 = match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).name().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.name),
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
-					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LiquidCrowdloan-{}-{}",
@@ -634,14 +631,14 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.name)
+					}
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
 					}
 				}?;
 				let name_1 = match symbol_1 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).name().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.name),
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
-					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LiquidCrowdloan-{}-{}",
@@ -652,6 +649,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.name)
+					}
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.name)
 					}
 				}?;
 
@@ -697,9 +697,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				let token_symbol_0 = match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).symbol().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.symbol),
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
-					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LC{}-{}",
@@ -712,14 +709,14 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.symbol)
+					}
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
 					}
 				}?;
 				let token_symbol_1 = match symbol_1 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).symbol().map(|v| v.as_bytes().to_vec()),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.symbol),
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
-					}
 					DexShare::LiquidCrowdloan(lease) => Some(
 						format!(
 							"LC{}-{}",
@@ -732,6 +729,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 					),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.symbol)
+					}
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.symbol)
 					}
 				}?;
 
@@ -781,12 +781,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 				match symbol_0 {
 					DexShare::Token(symbol) => CurrencyId::Token(symbol).decimals(),
 					DexShare::Erc20(address) => AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|v| v.decimals),
-					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.decimals)
-					}
 					DexShare::LiquidCrowdloan(_) => T::StakingCurrencyId::get().decimals(),
 					DexShare::ForeignAsset(foreign_asset_id) => {
 						AssetMetadatas::<T>::get(AssetIds::ForeignAssetId(foreign_asset_id)).map(|v| v.decimals)
+					}
+					DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+						AssetMetadatas::<T>::get(AssetIds::StableAssetId(stable_asset_pool_id)).map(|v| v.decimals)
 					}
 				}
 			}
@@ -813,9 +813,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|_| ())?;
 					}
 					DexShare::Token(_)
-					| DexShare::StableAssetPoolToken(_)
 					| DexShare::LiquidCrowdloan(_)
-					| DexShare::ForeignAsset(_) => {}
+					| DexShare::ForeignAsset(_)
+					| DexShare::StableAssetPoolToken(_) => {}
 				};
 				match right {
 					DexShare::Erc20(address) => {
@@ -823,9 +823,9 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						AssetMetadatas::<T>::get(AssetIds::Erc20(address)).map(|_| ())?;
 					}
 					DexShare::Token(_)
-					| DexShare::StableAssetPoolToken(_)
 					| DexShare::LiquidCrowdloan(_)
-					| DexShare::ForeignAsset(_) => {}
+					| DexShare::ForeignAsset(_)
+					| DexShare::StableAssetPoolToken(_) => {}
 				};
 			}
 			CurrencyId::Token(_)
@@ -859,12 +859,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						let id = u32::from_be_bytes(address[H160_POSITION_DEXSHARE_LEFT_FIELD].try_into().ok()?);
 						Erc20IdToAddress::<T>::get(id).map(DexShare::Erc20)
 					}
-					DexShareType::StableAssetPoolToken => {
-						let id = StableAssetPoolId::from_be_bytes(
-							address[H160_POSITION_DEXSHARE_LEFT_FIELD][..].try_into().ok()?,
-						);
-						Some(DexShare::StableAssetPoolToken(id))
-					}
 					DexShareType::LiquidCrowdloan => {
 						let id = Lease::from_be_bytes(address[H160_POSITION_DEXSHARE_LEFT_FIELD].try_into().ok()?);
 						Some(DexShare::LiquidCrowdloan(id))
@@ -874,6 +868,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 							address[H160_POSITION_DEXSHARE_LEFT_FIELD][2..].try_into().ok()?,
 						);
 						Some(DexShare::ForeignAsset(id))
+					}
+					DexShareType::StableAssetPoolToken => {
+						let id = StableAssetPoolId::from_be_bytes(
+							address[H160_POSITION_DEXSHARE_LEFT_FIELD][..].try_into().ok()?,
+						);
+						Some(DexShare::StableAssetPoolToken(id))
 					}
 				}?;
 				let right = match DexShareType::try_from(address[H160_POSITION_DEXSHARE_RIGHT_TYPE]).ok()? {
@@ -885,12 +885,6 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 						let id = u32::from_be_bytes(address[H160_POSITION_DEXSHARE_RIGHT_FIELD].try_into().ok()?);
 						Erc20IdToAddress::<T>::get(id).map(DexShare::Erc20)
 					}
-					DexShareType::StableAssetPoolToken => {
-						let id = StableAssetPoolId::from_be_bytes(
-							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][..].try_into().ok()?,
-						);
-						Some(DexShare::StableAssetPoolToken(id))
-					}
 					DexShareType::LiquidCrowdloan => {
 						let id = Lease::from_be_bytes(address[H160_POSITION_DEXSHARE_RIGHT_FIELD].try_into().ok()?);
 						Some(DexShare::LiquidCrowdloan(id))
@@ -900,6 +894,12 @@ impl<T: Config> Erc20InfoMapping for EvmErc20InfoMapping<T> {
 							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][2..].try_into().ok()?,
 						);
 						Some(DexShare::ForeignAsset(id))
+					}
+					DexShareType::StableAssetPoolToken => {
+						let id = StableAssetPoolId::from_be_bytes(
+							address[H160_POSITION_DEXSHARE_RIGHT_FIELD][..].try_into().ok()?,
+						);
+						Some(DexShare::StableAssetPoolToken(id))
 					}
 				}?;
 

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -518,13 +518,12 @@ pub mod module {
 			);
 
 			let check_asset_registry = |currency_id: CurrencyId| match currency_id {
-				CurrencyId::Erc20(_)
-				| CurrencyId::LiquidCrowdloan(_)
-				| CurrencyId::ForeignAsset(_)
-				| CurrencyId::StableAssetPoolToken(_) => T::Erc20InfoMapping::name(currency_id)
-					.map(|_| ())
-					.ok_or(Error::<T>::AssetUnregistered),
-				CurrencyId::Token(_) | CurrencyId::DexShare(_, _) => Ok(()), /* No registration required */
+				CurrencyId::Erc20(_) | CurrencyId::ForeignAsset(_) | CurrencyId::StableAssetPoolToken(_) => {
+					T::Erc20InfoMapping::name(currency_id)
+						.map(|_| ())
+						.ok_or(Error::<T>::AssetUnregistered)
+				}
+				CurrencyId::Token(_) | CurrencyId::DexShare(_, _) | CurrencyId::LiquidCrowdloan(_) => Ok(()), /* No registration required */
 			};
 			check_asset_registry(currency_id_a)?;
 			check_asset_registry(currency_id_b)?;

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -518,13 +518,13 @@ pub mod module {
 			);
 
 			let check_asset_registry = |currency_id: CurrencyId| match currency_id {
-				CurrencyId::Erc20(_) | CurrencyId::ForeignAsset(_) => T::Erc20InfoMapping::name(currency_id)
+				CurrencyId::Erc20(_)
+				| CurrencyId::StableAssetPoolToken(_)
+				| CurrencyId::LiquidCrowdloan(_)
+				| CurrencyId::ForeignAsset(_) => T::Erc20InfoMapping::name(currency_id)
 					.map(|_| ())
 					.ok_or(Error::<T>::AssetUnregistered),
-				CurrencyId::Token(_)
-				| CurrencyId::DexShare(_, _)
-				| CurrencyId::StableAssetPoolToken(_)
-				| CurrencyId::LiquidCrowdloan(_) => Ok(()), /* No registration required */
+				CurrencyId::Token(_) | CurrencyId::DexShare(_, _) => Ok(()), /* No registration required */
 			};
 			check_asset_registry(currency_id_a)?;
 			check_asset_registry(currency_id_b)?;

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -519,9 +519,9 @@ pub mod module {
 
 			let check_asset_registry = |currency_id: CurrencyId| match currency_id {
 				CurrencyId::Erc20(_)
-				| CurrencyId::StableAssetPoolToken(_)
 				| CurrencyId::LiquidCrowdloan(_)
-				| CurrencyId::ForeignAsset(_) => T::Erc20InfoMapping::name(currency_id)
+				| CurrencyId::ForeignAsset(_)
+				| CurrencyId::StableAssetPoolToken(_) => T::Erc20InfoMapping::name(currency_id)
 					.map(|_| ())
 					.ok_or(Error::<T>::AssetUnregistered),
 				CurrencyId::Token(_) | CurrencyId::DexShare(_, _) => Ok(()), /* No registration required */

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -225,9 +225,9 @@ pub type Lease = BlockNumber;
 pub enum DexShare {
 	Token(TokenSymbol),
 	Erc20(EvmAddress),
-	StableAssetPoolToken(StableAssetPoolId),
 	LiquidCrowdloan(Lease),
 	ForeignAsset(ForeignAssetId),
+	StableAssetPoolToken(StableAssetPoolId),
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
@@ -268,9 +268,9 @@ impl CurrencyId {
 			self,
 			CurrencyId::Token(_)
 				| CurrencyId::Erc20(_)
-				| CurrencyId::StableAssetPoolToken(_)
 				| CurrencyId::LiquidCrowdloan(_)
 				| CurrencyId::ForeignAsset(_)
+				| CurrencyId::StableAssetPoolToken(_)
 		)
 	}
 
@@ -289,22 +289,22 @@ impl CurrencyId {
 		let dex_share_0 = match currency_id_0 {
 			CurrencyId::Token(symbol) => DexShare::Token(symbol),
 			CurrencyId::Erc20(address) => DexShare::Erc20(address),
+			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
+			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			CurrencyId::StableAssetPoolToken(stable_asset_pool_id) => {
 				DexShare::StableAssetPoolToken(stable_asset_pool_id)
 			}
-			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
-			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			// Unsupported
 			CurrencyId::DexShare(..) => return None,
 		};
 		let dex_share_1 = match currency_id_1 {
 			CurrencyId::Token(symbol) => DexShare::Token(symbol),
 			CurrencyId::Erc20(address) => DexShare::Erc20(address),
+			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
+			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			CurrencyId::StableAssetPoolToken(stable_asset_pool_id) => {
 				DexShare::StableAssetPoolToken(stable_asset_pool_id)
 			}
-			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
-			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			// Unsupported
 			CurrencyId::DexShare(..) => return None,
 		};
@@ -327,14 +327,14 @@ impl From<DexShare> for u32 {
 				let index = if leading_zeros > 16 { 16 } else { leading_zeros };
 				bytes[..].copy_from_slice(&address[index..index + 4][..]);
 			}
-			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-				bytes[..].copy_from_slice(&stable_asset_pool_id.to_be_bytes());
-			}
 			DexShare::LiquidCrowdloan(lease) => {
 				bytes[..].copy_from_slice(&lease.to_be_bytes());
 			}
 			DexShare::ForeignAsset(foreign_asset_id) => {
 				bytes[2..].copy_from_slice(&foreign_asset_id.to_be_bytes());
+			}
+			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+				bytes[..].copy_from_slice(&stable_asset_pool_id.to_be_bytes());
 			}
 		}
 		u32::from_be_bytes(bytes)
@@ -346,11 +346,11 @@ impl Into<CurrencyId> for DexShare {
 		match self {
 			DexShare::Token(token) => CurrencyId::Token(token),
 			DexShare::Erc20(address) => CurrencyId::Erc20(address),
+			DexShare::LiquidCrowdloan(lease) => CurrencyId::LiquidCrowdloan(lease),
+			DexShare::ForeignAsset(foreign_asset_id) => CurrencyId::ForeignAsset(foreign_asset_id),
 			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
 				CurrencyId::StableAssetPoolToken(stable_asset_pool_id)
 			}
-			DexShare::LiquidCrowdloan(lease) => CurrencyId::LiquidCrowdloan(lease),
-			DexShare::ForeignAsset(foreign_asset_id) => CurrencyId::ForeignAsset(foreign_asset_id),
 		}
 	}
 }
@@ -375,9 +375,9 @@ pub enum CurrencyIdType {
 pub enum DexShareType {
 	Token,
 	Erc20,
-	StableAssetPoolToken,
 	LiquidCrowdloan,
 	ForeignAsset,
+	StableAssetPoolToken,
 }
 
 impl Into<DexShareType> for DexShare {
@@ -385,9 +385,9 @@ impl Into<DexShareType> for DexShare {
 		match self {
 			DexShare::Token(_) => DexShareType::Token,
 			DexShare::Erc20(_) => DexShareType::Erc20,
-			DexShare::StableAssetPoolToken(_) => DexShareType::StableAssetPoolToken,
 			DexShare::LiquidCrowdloan(_) => DexShareType::LiquidCrowdloan,
 			DexShare::ForeignAsset(_) => DexShareType::ForeignAsset,
+			DexShare::StableAssetPoolToken(_) => DexShareType::StableAssetPoolToken,
 		}
 	}
 }

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -225,9 +225,9 @@ pub type Lease = BlockNumber;
 pub enum DexShare {
 	Token(TokenSymbol),
 	Erc20(EvmAddress),
+	StableAssetPoolToken(StableAssetPoolId),
 	LiquidCrowdloan(Lease),
 	ForeignAsset(ForeignAssetId),
-	StableAssetPoolToken(StableAssetPoolId),
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
@@ -268,9 +268,9 @@ impl CurrencyId {
 			self,
 			CurrencyId::Token(_)
 				| CurrencyId::Erc20(_)
+				| CurrencyId::StableAssetPoolToken(_)
 				| CurrencyId::LiquidCrowdloan(_)
 				| CurrencyId::ForeignAsset(_)
-				| CurrencyId::StableAssetPoolToken(_)
 		)
 	}
 
@@ -289,22 +289,22 @@ impl CurrencyId {
 		let dex_share_0 = match currency_id_0 {
 			CurrencyId::Token(symbol) => DexShare::Token(symbol),
 			CurrencyId::Erc20(address) => DexShare::Erc20(address),
-			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
-			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			CurrencyId::StableAssetPoolToken(stable_asset_pool_id) => {
 				DexShare::StableAssetPoolToken(stable_asset_pool_id)
 			}
+			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
+			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			// Unsupported
 			CurrencyId::DexShare(..) => return None,
 		};
 		let dex_share_1 = match currency_id_1 {
 			CurrencyId::Token(symbol) => DexShare::Token(symbol),
 			CurrencyId::Erc20(address) => DexShare::Erc20(address),
-			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
-			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			CurrencyId::StableAssetPoolToken(stable_asset_pool_id) => {
 				DexShare::StableAssetPoolToken(stable_asset_pool_id)
 			}
+			CurrencyId::LiquidCrowdloan(lease) => DexShare::LiquidCrowdloan(lease),
+			CurrencyId::ForeignAsset(foreign_asset_id) => DexShare::ForeignAsset(foreign_asset_id),
 			// Unsupported
 			CurrencyId::DexShare(..) => return None,
 		};
@@ -327,14 +327,14 @@ impl From<DexShare> for u32 {
 				let index = if leading_zeros > 16 { 16 } else { leading_zeros };
 				bytes[..].copy_from_slice(&address[index..index + 4][..]);
 			}
+			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
+				bytes[..].copy_from_slice(&stable_asset_pool_id.to_be_bytes());
+			}
 			DexShare::LiquidCrowdloan(lease) => {
 				bytes[..].copy_from_slice(&lease.to_be_bytes());
 			}
 			DexShare::ForeignAsset(foreign_asset_id) => {
 				bytes[2..].copy_from_slice(&foreign_asset_id.to_be_bytes());
-			}
-			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
-				bytes[2..].copy_from_slice(&stable_asset_pool_id.to_be_bytes());
 			}
 		}
 		u32::from_be_bytes(bytes)
@@ -346,11 +346,11 @@ impl Into<CurrencyId> for DexShare {
 		match self {
 			DexShare::Token(token) => CurrencyId::Token(token),
 			DexShare::Erc20(address) => CurrencyId::Erc20(address),
-			DexShare::LiquidCrowdloan(lease) => CurrencyId::LiquidCrowdloan(lease),
-			DexShare::ForeignAsset(foreign_asset_id) => CurrencyId::ForeignAsset(foreign_asset_id),
 			DexShare::StableAssetPoolToken(stable_asset_pool_id) => {
 				CurrencyId::StableAssetPoolToken(stable_asset_pool_id)
 			}
+			DexShare::LiquidCrowdloan(lease) => CurrencyId::LiquidCrowdloan(lease),
+			DexShare::ForeignAsset(foreign_asset_id) => CurrencyId::ForeignAsset(foreign_asset_id),
 		}
 	}
 }
@@ -375,9 +375,9 @@ pub enum CurrencyIdType {
 pub enum DexShareType {
 	Token,
 	Erc20,
+	StableAssetPoolToken,
 	LiquidCrowdloan,
 	ForeignAsset,
-	StableAssetPoolToken,
 }
 
 impl Into<DexShareType> for DexShare {
@@ -385,9 +385,9 @@ impl Into<DexShareType> for DexShare {
 		match self {
 			DexShare::Token(_) => DexShareType::Token,
 			DexShare::Erc20(_) => DexShareType::Erc20,
+			DexShare::StableAssetPoolToken(_) => DexShareType::StableAssetPoolToken,
 			DexShare::LiquidCrowdloan(_) => DexShareType::LiquidCrowdloan,
 			DexShare::ForeignAsset(_) => DexShareType::ForeignAsset,
-			DexShare::StableAssetPoolToken(_) => DexShareType::StableAssetPoolToken,
 		}
 	}
 }

--- a/primitives/src/evm.rs
+++ b/primitives/src/evm.rs
@@ -130,7 +130,7 @@ pub const SYSTEM_CONTRACT_ADDRESS_PREFIX: [u8; 9] = [0u8; 9];
 ///                                         ^^ CurrencyId Type is 1-Token, Token
 ///                                   ^^^^^^^^ CurrencyId Type is 1-Token, NFT
 ///                       ^^                   CurrencyId Type is 2-DexShare, DexShare Left Type:
-///                                                             0-Token 1-Erc20 2-LiquidCrowdloan 3-ForeignAsset
+///                                                             0-Token 1-Erc20 2-StableAsset 3-LiquidCrowdloan 4-ForeignAsset
 ///                         ^^^^^^^^           CurrencyId Type is 2-DexShare, DexShare left field
 ///                                 ^^         CurrencyId Type is 2-DexShare, DexShare Right Type:
 ///                                                             the same as DexShare Left Type

--- a/primitives/src/evm.rs
+++ b/primitives/src/evm.rs
@@ -130,7 +130,7 @@ pub const SYSTEM_CONTRACT_ADDRESS_PREFIX: [u8; 9] = [0u8; 9];
 ///                                         ^^ CurrencyId Type is 1-Token, Token
 ///                                   ^^^^^^^^ CurrencyId Type is 1-Token, NFT
 ///                       ^^                   CurrencyId Type is 2-DexShare, DexShare Left Type:
-///                                                             0-Token 1-Erc20 2-StableAsset 3-LiquidCrowdloan 4-ForeignAsset
+///                                                             0-Token 1-Erc20 2-LiquidCrowdloan 3-ForeignAsset 4-StableAsset
 ///                         ^^^^^^^^           CurrencyId Type is 2-DexShare, DexShare left field
 ///                                 ^^         CurrencyId Type is 2-DexShare, DexShare Right Type:
 ///                                                             the same as DexShare Left Type

--- a/primitives/src/tests.rs
+++ b/primitives/src/tests.rs
@@ -119,24 +119,24 @@ fn currency_id_try_into_evm_address_works() {
 
 	assert_eq!(
 		EvmAddress::try_from(CurrencyId::DexShare(
-			DexShare::StableAssetPoolToken(Default::default()),
-			DexShare::StableAssetPoolToken(Default::default())
+			DexShare::LiquidCrowdloan(Default::default()),
+			DexShare::LiquidCrowdloan(Default::default())
 		)),
 		Ok(EvmAddress::from_str("0x0000000000000000000202000000000200000000").unwrap())
 	);
 
 	assert_eq!(
 		EvmAddress::try_from(CurrencyId::DexShare(
-			DexShare::LiquidCrowdloan(Default::default()),
-			DexShare::LiquidCrowdloan(Default::default())
+			DexShare::ForeignAsset(Default::default()),
+			DexShare::ForeignAsset(Default::default())
 		)),
 		Ok(EvmAddress::from_str("0x0000000000000000000203000000000300000000").unwrap())
 	);
 
 	assert_eq!(
 		EvmAddress::try_from(CurrencyId::DexShare(
-			DexShare::ForeignAsset(Default::default()),
-			DexShare::ForeignAsset(Default::default())
+			DexShare::StableAssetPoolToken(Default::default()),
+			DexShare::StableAssetPoolToken(Default::default())
 		)),
 		Ok(EvmAddress::from_str("0x0000000000000000000204000000000400000000").unwrap())
 	);

--- a/primitives/src/tests.rs
+++ b/primitives/src/tests.rs
@@ -116,6 +116,30 @@ fn currency_id_try_into_evm_address_works() {
 
 	let erc20 = EvmAddress::from_str("0x1111111111111111111111111111111111111111").unwrap();
 	assert_eq!(EvmAddress::try_from(CurrencyId::Erc20(erc20)), Ok(erc20));
+
+	assert_eq!(
+		EvmAddress::try_from(CurrencyId::DexShare(
+			DexShare::StableAssetPoolToken(Default::default()),
+			DexShare::StableAssetPoolToken(Default::default())
+		)),
+		Ok(EvmAddress::from_str("0x0000000000000000000202000000000200000000").unwrap())
+	);
+
+	assert_eq!(
+		EvmAddress::try_from(CurrencyId::DexShare(
+			DexShare::LiquidCrowdloan(Default::default()),
+			DexShare::LiquidCrowdloan(Default::default())
+		)),
+		Ok(EvmAddress::from_str("0x0000000000000000000203000000000300000000").unwrap())
+	);
+
+	assert_eq!(
+		EvmAddress::try_from(CurrencyId::DexShare(
+			DexShare::ForeignAsset(Default::default()),
+			DexShare::ForeignAsset(Default::default())
+		)),
+		Ok(EvmAddress::from_str("0x0000000000000000000204000000000400000000").unwrap())
+	);
 }
 
 #[test]


### PR DESCRIPTION
1. Update comment
https://github.com/AcalaNetwork/Acala/blob/2e454f3891e486f55456368f89d96b2511da1df0/primitives/src/evm.rs#L132-L133
2. Update the check in the dex module
https://github.com/AcalaNetwork/Acala/blob/2e454f3891e486f55456368f89d96b2511da1df0/modules/dex/src/lib.rs#L520-L528
3. StableAssetPoolId is `u32`, so needs 4 bytes.
https://github.com/AcalaNetwork/Acala/blob/2e454f3891e486f55456368f89d96b2511da1df0/primitives/src/currency.rs#L336-L338