### PR TITLE
Keep evm nonce alive

### DIFF
--- a/modules/evm-accounts/src/lib.rs
+++ b/modules/evm-accounts/src/lib.rs
@@ -337,11 +337,7 @@ where
 pub struct CallKillAccount<T>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for CallKillAccount<T> {
 	fn on_killed_account(who: &T::AccountId) {
-		// remove the reserve mapping that could be created by
-		// `get_or_create_evm_address`
-		Accounts::<T>::remove(account_to_default_evm_address(who.into_ref()));
-
-		// remove mapping created by `claim_account`
+		// remove mapping created by `claim_account` or `get_or_create_evm_address`
 		if let Some(evm_addr) = Pallet::<T>::evm_addresses(who) {
 			Accounts::<T>::remove(evm_addr);
 			EvmAddresses::<T>::remove(who);

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -1191,6 +1191,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Remove an account if its empty.
+	/// Keep the non-zero nonce exists.
 	pub fn remove_account_if_empty(address: &H160) {
 		if Self::is_account_empty(address) {
 			let res = Self::remove_account(address);
@@ -1241,7 +1242,8 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Removes an account from Accounts and AccountStorages.
-	pub fn remove_account(address: &EvmAddress) -> DispatchResult {
+	/// Only used in `remove_account_if_empty`
+	fn remove_account(address: &EvmAddress) -> DispatchResult {
 		// Deref code, and remove it if ref count is zero.
 		Accounts::<T>::mutate_exists(&address, |maybe_account| {
 			if let Some(account) = maybe_account {

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -996,10 +996,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			T::NetworkContractOrigin::ensure_origin(origin)?;
 
-			ensure!(
-				Pallet::<T>::is_account_empty(&target),
-				Error::<T>::ContractAlreadyExisted
-			);
+			ensure!(Self::accounts(target).is_none(), Error::<T>::ContractAlreadyExisted);
 
 			let source = T::NetworkContractSource::get();
 			let source_account = T::AddressMapping::get_account_id(&source);

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -1194,7 +1194,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Remove an account if its empty.
-	/// Unused now.
 	pub fn remove_account_if_empty(address: &H160) {
 		if Self::is_account_empty(address) {
 			let res = Self::remove_account(address);
@@ -1824,12 +1823,8 @@ pub struct CallKillAccount<T>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for CallKillAccount<T> {
 	fn on_killed_account(who: &T::AccountId) {
 		if let Some(address) = T::AddressMapping::get_evm_address(who) {
-			let res = Pallet::<T>::remove_account(&address);
-			debug_assert!(res.is_ok());
+			Pallet::<T>::remove_account_if_empty(&address);
 		}
-		let address = T::AddressMapping::get_default_evm_address(who);
-		let res = Pallet::<T>::remove_account(&address);
-		debug_assert!(res.is_ok());
 	}
 }
 
@@ -1963,7 +1958,7 @@ impl<T: Config> DispatchableTask for EvmTask<T> {
 						);
 
 						// Remove account after all of the storages are cleared.
-						Accounts::<T>::take(contract);
+						Pallet::<T>::remove_account_if_empty(&contract);
 
 						TaskResult {
 							result: res,

--- a/modules/evm/src/tests.rs
+++ b/modules/evm/src/tests.rs
@@ -1407,7 +1407,7 @@ fn should_selfdestruct() {
 			287 * EVM::get_storage_deposit_per_byte()
 		);
 
-		// can't publish at the same address until everything is wiped out
+		// can't publish at the same address
 		assert_noop!(
 			EVM::create_predeploy_contract(
 				Origin::signed(NetworkContractAccount::get()),
@@ -1436,18 +1436,8 @@ fn should_selfdestruct() {
 
 		assert_eq!(System::providers(&contract_account_id), 0);
 		assert!(!System::account_exists(&contract_account_id));
-		assert!(!Accounts::<Runtime>::contains_key(&contract_address));
+		assert!(Accounts::<Runtime>::contains_key(&contract_address));
 		assert_eq!(AccountStorages::<Runtime>::iter_prefix(&contract_address).count(), 0);
-
-		assert_ok!(EVM::create_predeploy_contract(
-			Origin::signed(NetworkContractAccount::get()),
-			contract_address,
-			vec![0x01],
-			0,
-			1000000,
-			1000000,
-			vec![],
-		));
 	});
 }
 


### PR DESCRIPTION
Closes: #1846 
Closes: #1668
Closes: #1613

https://github.com/AcalaNetwork/Acala/blob/05ae43770cf8cc747a2aad1c2891046789da51c3/modules/evm-accounts/src/lib.rs#L312-L322

In `get_or_create_evm_address`, it will generate the map between the account and the default eth address. So it can't claim_account for another eth address.
If there is a bug in the code and the map isn't inserted, we can kill the account and then `claim_default_account` to recover the map.