### PR TITLE
fix locked balance as fee

### DIFF
--- a/modules/transaction-payment/src/lib.rs
+++ b/modules/transaction-payment/src/lib.rs
@@ -759,16 +759,18 @@ where
 	}
 
 	/// If native asset is enough, return `None`, else return the fee amount should be swapped.
-	fn check_native_is_not_enough(who: &T::AccountId, fee: PalletBalanceOf<T>) -> Option<Balance> {
+	fn check_native_is_not_enough(
+		who: &T::AccountId,
+		fee: PalletBalanceOf<T>,
+		reason: WithdrawReasons,
+	) -> Option<Balance> {
 		let native_existential_deposit = <T as Config>::Currency::minimum_balance();
 		let total_native = <T as Config>::Currency::free_balance(who);
 
 		if fee.saturating_add(native_existential_deposit) <= total_native {
 			// User's locked balance can't be transferable, which means can't be used for fee payment.
 			if let Some(new_free_balance) = total_native.checked_sub(fee) {
-				if T::Currency::ensure_can_withdraw(who, fee, WithdrawReasons::TRANSACTION_PAYMENT, new_free_balance)
-					.is_ok()
-				{
+				if T::Currency::ensure_can_withdraw(who, fee, reason, new_free_balance).is_ok() {
 					return None;
 				}
 			}
@@ -786,6 +788,7 @@ where
 		who: &T::AccountId,
 		fee: PalletBalanceOf<T>,
 		call: &CallOf<T>,
+		reason: WithdrawReasons,
 	) -> Result<Balance, DispatchError> {
 		let custom_fee_surplus = T::CustomFeeSurplus::get().mul_ceil(fee);
 		let custom_fee_amount = fee.saturating_add(custom_fee_surplus);
@@ -811,7 +814,7 @@ where
 				);
 				Self::swap_from_pool_or_dex(who, custom_fee_amount, *currency_id).map(|_| custom_fee_surplus)
 			}
-			_ => Self::native_then_alternative_or_default(who, fee),
+			_ => Self::native_then_alternative_or_default(who, fee, reason),
 		}
 	}
 
@@ -823,8 +826,9 @@ where
 	fn native_then_alternative_or_default(
 		who: &T::AccountId,
 		fee: PalletBalanceOf<T>,
+		reason: WithdrawReasons,
 	) -> Result<Balance, DispatchError> {
-		if let Some(amount) = Self::check_native_is_not_enough(who, fee) {
+		if let Some(amount) = Self::check_native_is_not_enough(who, fee, reason) {
 			// native asset is not enough
 			let fee_surplus = T::AlternativeFeeSurplus::get().mul_ceil(fee);
 			let fee_amount = fee_surplus.saturating_add(amount);
@@ -1209,8 +1213,8 @@ where
 			WithdrawReasons::TRANSACTION_PAYMENT | WithdrawReasons::TIP
 		};
 
-		let fee_surplus =
-			Pallet::<T>::ensure_can_charge_fee_with_call(who, fee, call).map_err(|_| InvalidTransaction::Payment)?;
+		let fee_surplus = Pallet::<T>::ensure_can_charge_fee_with_call(who, fee, call, reason)
+			.map_err(|_| InvalidTransaction::Payment)?;
 
 		// withdraw native currency as fee, also consider surplus when swap from dex or pool.
 		match <T as Config>::Currency::withdraw(who, fee + fee_surplus, reason, ExistenceRequirement::KeepAlive) {

--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -30,7 +30,7 @@ use mock::{
 	AccountId, BlockWeights, Call, Currencies, DEXModule, ExtBuilder, FeePoolSize, MockPriceSource, Origin, Runtime,
 	System, TransactionPayment, ACA, ALICE, AUSD, BOB, CHARLIE, DOT, FEE_UNBALANCED_AMOUNT, TIP_UNBALANCED_AMOUNT,
 };
-use orml_traits::MultiCurrency;
+use orml_traits::{MultiCurrency, MultiLockableCurrency};
 use primitives::currency::*;
 use sp_io::TestExternalities;
 use sp_runtime::{
@@ -240,6 +240,30 @@ fn charges_fee_when_validate_native_is_enough() {
 			1
 		);
 		assert_eq!(Currencies::free_balance(ACA, &ALICE), 100000 - fee - fee2);
+	});
+}
+
+#[test]
+fn charges_fee_when_locked_transfer_not_enough() {
+	builder_with_dex_and_fee_pool(false).execute_with(|| {
+		let fee = 12 * 2 + 1000; // len * byte + weight
+		assert_ok!(Currencies::update_balance(Origin::root(), BOB, ACA, 2048,));
+
+		// transferable=2048-1025 < fee=1024, native asset is not enough
+		assert_ok!(<Currencies as MultiLockableCurrency<AccountId>>::set_lock(
+			[0u8; 8], ACA, &BOB, 1025
+		));
+		assert_noop!(
+			ChargeTransactionPayment::<Runtime>::from(0).validate(&BOB, &CALL, &INFO, 12),
+			TransactionValidityError::Invalid(InvalidTransaction::Payment)
+		);
+
+		// after remove lock, transferable=2048 > fee
+		assert_ok!(<Currencies as MultiLockableCurrency<AccountId>>::remove_lock(
+			[0u8; 8], ACA, &BOB
+		));
+		assert_ok!(ChargeTransactionPayment::<Runtime>::from(0).validate(&BOB, &CALL, &INFO, 12));
+		assert_eq!(Currencies::free_balance(ACA, &BOB), 2048 - fee);
 	});
 }
 


### PR DESCRIPTION
Current, we use `free` balance which containts `locked` part to decide whether the user have enough native asset. If user locked most of native asset, and left transferable native asset less than ED. then withdraw those native asset will failed. Also, this would't use other token as fee payment. because current we either choose native asset if native asset is enough(in this case it's true) or other token if native asset is not enough.
https://github.com/AcalaNetwork/Acala/blob/11d95414d7d3490e9bb8a477995f46e51fd23bb8/modules/transaction-payment/src/lib.rs#L765-L766