### PR TITLE
add new call to adjust position by debit value

### DIFF
--- a/modules/honzon/src/lib.rs
+++ b/modules/honzon/src/lib.rs
@@ -312,6 +312,37 @@ pub mod module {
 			)?;
 			Ok(())
 		}
+
+		/// Adjust the loans of `currency_id` by specific
+		/// `collateral_adjustment` and `debit_value_adjustment`
+		///
+		/// - `currency_id`: collateral currency id.
+		/// - `collateral_adjustment`: signed amount, positive means to deposit collateral currency
+		///   into CDP, negative means withdraw collateral currency from CDP.
+		/// - `debit_value_adjustment`: signed amount, positive means to issue some amount of
+		///   stablecoin, negative means caller will payback some amount of stablecoin to CDP.
+		#[pallet::weight(<T as Config>::WeightInfo::adjust_loan())]
+		#[transactional]
+		pub fn adjust_loan_by_debit_value(
+			origin: OriginFor<T>,
+			currency_id: CurrencyId,
+			collateral_adjustment: Amount,
+			debit_value_adjustment: Amount,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			// not allowed to adjust the debit after system shutdown
+			if !debit_value_adjustment.is_zero() {
+				ensure!(!T::EmergencyShutdown::is_shutdown(), Error::<T>::AlreadyShutdown);
+			}
+			<cdp_engine::Pallet<T>>::adjust_position_by_debit_value(
+				&who,
+				currency_id,
+				collateral_adjustment,
+				debit_value_adjustment,
+			)?;
+			Ok(())
+		}
 	}
 }
 

--- a/modules/honzon/src/mock.rs
+++ b/modules/honzon/src/mock.rs
@@ -237,7 +237,7 @@ parameter_type_with_key! {
 
 parameter_types! {
 	pub DefaultLiquidationRatio: Ratio = Ratio::saturating_from_rational(3, 2);
-	pub DefaultDebitExchangeRate: ExchangeRate = ExchangeRate::one();
+	pub DefaultDebitExchangeRate: ExchangeRate = ExchangeRate::saturating_from_rational(1, 10);
 	pub DefaultLiquidationPenalty: Rate = Rate::saturating_from_rational(10, 100);
 	pub MaxSwapSlippageCompareToOracle: Ratio = Ratio::saturating_from_rational(50, 100);
 }

--- a/modules/honzon/src/tests.rs
+++ b/modules/honzon/src/tests.rs
@@ -152,6 +152,39 @@ fn adjust_loan_should_work() {
 }
 
 #[test]
+fn adjust_loan_by_debit_value_should_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CDPEngineModule::set_collateral_params(
+			Origin::signed(1),
+			BTC,
+			Change::NewValue(Some(Rate::saturating_from_rational(1, 100000))),
+			Change::NewValue(Some(Ratio::saturating_from_rational(3, 2))),
+			Change::NewValue(Some(Rate::saturating_from_rational(2, 10))),
+			Change::NewValue(Some(Ratio::saturating_from_rational(9, 5))),
+			Change::NewValue(10000),
+		));
+
+		assert_ok!(HonzonModule::adjust_loan_by_debit_value(
+			Origin::signed(ALICE),
+			BTC,
+			100,
+			50
+		));
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 100);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 500);
+
+		assert_ok!(HonzonModule::adjust_loan_by_debit_value(
+			Origin::signed(ALICE),
+			BTC,
+			-10,
+			-5
+		));
+		assert_eq!(LoansModule::positions(BTC, ALICE).collateral, 90);
+		assert_eq!(LoansModule::positions(BTC, ALICE).debit, 450);
+	});
+}
+
+#[test]
 fn on_emergency_shutdown_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		mock_shutdown();


### PR DESCRIPTION
front end can use `honzon.adjustLoanByDebitValue` to manipulate loan by debit value(stable coin amount), complex input processing can be avoided. @qwer951123 @StrawberryFlavor 