### PR TITLE
Added no-metadata-docs and full-metadata-docs to runtimes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
         id: srtool_build
         uses: chevdor/srtool-actions@master
         env:
-          BUILD_OPTS: "--features on-chain-release-build"
+          BUILD_OPTS: "--features on-chain-release-build,no-metadata-docs"
         with:
           chain: ${{ github.event.inputs.chain }}
           tag: ${{ github.event.inputs.srtool_image }}

--- a/Makefile
+++ b/Makefile
@@ -206,15 +206,15 @@ build-wasm-acala:
 
 .PHONY: srtool-build-wasm-mandala
 srtool-build-wasm-mandala:
-	PACKAGE=mandala-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build" ./scripts/srtool-build.sh
+	PACKAGE=mandala-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build,no-metadata-docs" ./scripts/srtool-build.sh
 
 .PHONY: srtool-build-wasm-karura
 srtool-build-wasm-karura:
-	PACKAGE=karura-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build" ./scripts/srtool-build.sh
+	PACKAGE=karura-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build,no-metadata-docs" ./scripts/srtool-build.sh
 
 .PHONY: srtool-build-wasm-acala
 srtool-build-wasm-acala:
-	PACKAGE=acala-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build" ./scripts/srtool-build.sh
+	PACKAGE=acala-runtime PROFILE=production BUILD_OPTS="--features on-chain-release-build,no-metadata-docs" ./scripts/srtool-build.sh
 
 .PHONY: generate-tokens
 generate-tokens:

--- a/Makefile
+++ b/Makefile
@@ -32,23 +32,19 @@ build-all:
 
 .PHONY: build-release
 build-release:
-	cargo build --locked --features with-all-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
-
-.PHONY: build-release-full-metadata
-build-release-full-metadata:
-	cargo build --locked --features with-all-runtime,full-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-all-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-mandala-release
 build-mandala-release:
-	cargo build --locked --features with-mandala-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-mandala-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-karura-release
 build-karura-release:
-	cargo build --locked --features with-karura-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-karura-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-acala-release
 build-acala-release:
-	cargo build --locked --features with-acala-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-acala-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-mandala-internal-release
 build-mandala-internal-release:

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,23 @@ build-all:
 
 .PHONY: build-release
 build-release:
-	cargo build --locked --features with-all-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-all-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+
+.PHONY: build-release-full-metadata
+build-release-full-metadata:
+	cargo build --locked --features with-all-runtime,full-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-mandala-release
 build-mandala-release:
-	cargo build --locked --features with-mandala-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-mandala-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-karura-release
 build-karura-release:
-	cargo build --locked --features with-karura-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-karura-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-acala-release
 build-acala-release:
-	cargo build --locked --features with-acala-runtime --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
+	cargo build --locked --features with-acala-runtime,no-metadata-docs --profile production --workspace --exclude runtime-integration-tests --exclude e2e-tests --exclude test-service
 
 .PHONY: build-mandala-internal-release
 build-mandala-internal-release:

--- a/runtime/acala/Cargo.toml
+++ b/runtime/acala/Cargo.toml
@@ -339,3 +339,9 @@ try-runtime = [
 	"module-xcm-interface/try-runtime",
 	"module-session-manager/try-runtime",
 ]
+# By default some types have documentation, `no-metadata-docs` allows to reduce the documentation
+# in the metadata.
+no-metadata-docs = ["frame-support/no-metadata-docs"]
+# By default some types have documentation, `full-metadata-docs` allows to add documentation to
+# more types in the metadata.
+full-metadata-docs = ["frame-support/full-metadata-docs"]

--- a/runtime/karura/Cargo.toml
+++ b/runtime/karura/Cargo.toml
@@ -344,3 +344,9 @@ try-runtime = [
 ]
 
 integration-tests = []
+# By default some types have documentation, `no-metadata-docs` allows to reduce the documentation
+# in the metadata.
+no-metadata-docs = ["frame-support/no-metadata-docs"]
+# By default some types have documentation, `full-metadata-docs` allows to add documentation to
+# more types in the metadata.
+full-metadata-docs = ["frame-support/full-metadata-docs"]

--- a/runtime/mandala/Cargo.toml
+++ b/runtime/mandala/Cargo.toml
@@ -371,3 +371,9 @@ try-runtime = [
 	"ecosystem-starport/try-runtime",
 	"ecosystem-compound-cash/try-runtime",
 ]
+# By default some types have documentation, `no-metadata-docs` allows to reduce the documentation
+# in the metadata.
+no-metadata-docs = ["frame-support/no-metadata-docs"]
+# By default some types have documentation, `full-metadata-docs` allows to add documentation to
+# more types in the metadata.
+full-metadata-docs = ["frame-support/full-metadata-docs"]


### PR DESCRIPTION
Added the new features no-metadata-docs and full-metadata-docs to the runtimes

Updated build script so publish-release uses no-metadata-docs feature

Closes #1794 