### PR TITLE
fix signature of relayer

### DIFF
--- a/modules/transaction-payment/src/lib.rs
+++ b/modules/transaction-payment/src/lib.rs
@@ -56,7 +56,7 @@ use sp_runtime::{
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
-	FixedPointNumber, FixedPointOperand, MultiSignature, Percent, Perquintill,
+	FixedPointNumber, FixedPointOperand, Percent, Perquintill,
 };
 use sp_std::prelude::*;
 use support::{DEXManager, PriceProvider, Ratio, SwapLimit, TransactionPayment};
@@ -605,7 +605,7 @@ pub mod module {
 			origin: OriginFor<T>,
 			call: Box<CallOf<T>>,
 			_payer_addr: T::AccountId,
-			_payer_sig: MultiSignature,
+			_payer_encode_call: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			ensure_signed(origin.clone())?;
 			call.dispatch(origin)
@@ -834,7 +834,7 @@ where
 			Some(Call::with_fee_paid_by {
 				call: _,
 				payer_addr,
-				payer_sig: _,
+				payer_encode_call: _,
 			}) => {
 				// validate payer signature in runtime side, because `SignedExtension` between different runtime
 				// may be different.

--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -88,12 +88,12 @@ fn with_fee_currency_call(currency_id: CurrencyId) -> <Runtime as Config>::Call 
 	fee_call
 }
 
-fn with_fee_paid_by_call(payer_addr: AccountId, payer_sig: MultiSignature) -> <Runtime as Config>::Call {
+fn with_fee_paid_by_call(payer_addr: AccountId, payer_encode_call: Vec<u8>) -> <Runtime as Config>::Call {
 	let fee_call: <Runtime as Config>::Call =
 		Call::TransactionPayment(crate::mock::transaction_payment::Call::with_fee_paid_by {
 			call: Box::new(CALL),
 			payer_addr,
-			payer_sig,
+			payer_encode_call,
 		});
 	fee_call
 }
@@ -600,15 +600,15 @@ fn charges_fee_when_validate_with_fee_currency_call() {
 fn charges_fee_when_validate_with_fee_paid_by_native_token() {
 	// Enable dex with Alice, and initialize tx charge fee pool
 	builder_with_dex_and_fee_pool(true).execute_with(|| {
-		// make a fake signature
-		let signature = MultiSignature::Sr25519(sp_core::sr25519::Signature([0u8; 64]));
+		// make a fake encoded call
+		let encode_call = vec![0u8; 10];
 		// payer has enough native asset
 		assert_ok!(Currencies::update_balance(Origin::root(), BOB, ACA, 500,));
 
 		let fee: Balance = 50 * 2 + 100;
 		assert_ok!(ChargeTransactionPayment::<Runtime>::from(0).validate(
 			&ALICE,
-			&with_fee_paid_by_call(BOB, signature),
+			&with_fee_paid_by_call(BOB, encode_call),
 			&INFO2,
 			50
 		));
@@ -624,14 +624,14 @@ fn charges_fee_when_validate_with_fee_paid_by_default_token() {
 		assert_eq!(100, Currencies::free_balance(AUSD, &ausd_acc));
 		assert_eq!(10000, Currencies::free_balance(ACA, &ausd_acc));
 
-		// make a fake signature
-		let signature = MultiSignature::Sr25519(sp_core::sr25519::Signature([0u8; 64]));
+		// make a fake encode_call
+		let encode_call = vec![0u8; 10];
 		// payer has enough native asset
 		assert_ok!(Currencies::update_balance(Origin::root(), BOB, AUSD, 5000,));
 
 		assert_ok!(ChargeTransactionPayment::<Runtime>::from(0).validate(
 			&ALICE,
-			&with_fee_paid_by_call(BOB, signature),
+			&with_fee_paid_by_call(BOB, encode_call),
 			&INFO2,
 			50
 		));

--- a/node/e2e-tests/test-service/src/lib.rs
+++ b/node/e2e-tests/test-service/src/lib.rs
@@ -185,7 +185,7 @@ pub fn construct_extrinsic(
 		frame_system::CheckSpecVersion::<Runtime>::new(),
 		frame_system::CheckTxVersion::<Runtime>::new(),
 		frame_system::CheckGenesis::<Runtime>::new(),
-		frame_system::CheckEra::<Runtime>::from(Era::mortal(period, current_block)),
+		runtime_common::CheckEra::<Runtime>::from(Era::mortal(period, current_block)),
 		runtime_common::CheckNonce::<Runtime>::from(nonce),
 		frame_system::CheckWeight::<Runtime>::new(),
 		module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -2174,8 +2174,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 			)
 			.map_err(|_e| InvalidTransaction::Call)?;
 			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
-				let (_, _, _, _, _, old_check_nonce, _, _, _) = old_extra.clone();
-				let (_, _, _, _, _, check_nonce, _, _, ..) = extra.clone();
+				let (_, _, _, _, _mortality, old_check_nonce, ..) = old_extra.clone();
+				let (_, _, _, _, _, check_nonce, ..) = extra.clone();
 
 				// make sure nonce keep no changed.
 				if old_check_nonce.nonce != check_nonce.nonce {
@@ -2190,6 +2190,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 				if !raw_payload.using_encoded(|payload| payer_sig.verify(payload, &payer_account.into())) {
 					return Err(InvalidTransaction::BadProof);
 				}
+			} else {
+				return Err(InvalidTransaction::Call);
 			}
 		}
 		Ok(())

--- a/runtime/common/src/check_mortality.rs
+++ b/runtime/common/src/check_mortality.rs
@@ -1,19 +1,20 @@
-// This file is part of Substrate.
+// This file is part of Acala.
 
-// Copyright (C) 2017-2022 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
 use frame_system::{BlockHash, Config, Pallet};

--- a/runtime/common/src/check_mortality.rs
+++ b/runtime/common/src/check_mortality.rs
@@ -1,0 +1,96 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Decode, Encode};
+use frame_system::{BlockHash, Config, Pallet};
+use scale_info::TypeInfo;
+use sp_runtime::{
+	generic::Era,
+	traits::{DispatchInfoOf, SaturatedConversion, SignedExtension},
+	transaction_validity::{InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction},
+};
+
+/// Check for transaction mortality.
+///
+/// # Transaction Validity
+///
+/// The extension affects `longevity` of the transaction according to the [`Era`] definition.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct CheckMortality<T: Config + Send + Sync>(pub Era, sp_std::marker::PhantomData<T>);
+
+impl<T: Config + Send + Sync> CheckMortality<T> {
+	/// utility constructor. Used only in client/factory code.
+	pub fn from(era: Era) -> Self {
+		Self(era, sp_std::marker::PhantomData)
+	}
+}
+
+impl<T: Config + Send + Sync> sp_std::fmt::Debug for CheckMortality<T> {
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "CheckMortality({:?})", self.0)
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
+	}
+}
+
+impl<T: Config + Send + Sync> SignedExtension for CheckMortality<T> {
+	type AccountId = T::AccountId;
+	type Call = T::Call;
+	type AdditionalSigned = T::Hash;
+	type Pre = ();
+	const IDENTIFIER: &'static str = "CheckMortality";
+
+	fn validate(
+		&self,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
+		let valid_till = self.0.death(current_u64);
+		Ok(ValidTransaction {
+			longevity: valid_till.saturating_sub(current_u64),
+			..Default::default()
+		})
+	}
+
+	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
+		let n = self.0.birth(current_u64).saturated_into::<T::BlockNumber>();
+		if !<BlockHash<T>>::contains_key(n) {
+			Err(InvalidTransaction::AncientBirthBlock.into())
+		} else {
+			Ok(<Pallet<T>>::block_hash(n))
+		}
+	}
+
+	fn pre_dispatch(
+		self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		info: &DispatchInfoOf<Self::Call>,
+		len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		self.validate(who, call, info, len).map(|_| ())
+	}
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -47,12 +47,14 @@ use sp_core::bytes::from_hex;
 use std::str::FromStr;
 
 pub mod bench;
+pub mod check_mortality;
 pub mod check_nonce;
 pub mod precompile;
 
 #[cfg(test)]
 mod mock;
 
+pub use check_mortality::CheckMortality as CheckEra;
 pub use check_nonce::CheckNonce;
 use module_evm::GenesisAccount;
 use orml_traits::GetByKey;

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -2219,8 +2219,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 			)
 			.map_err(|_e| InvalidTransaction::Call)?;
 			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
-				let (_, _, _, _, _, old_check_nonce, _, _, _) = old_extra.clone();
-				let (_, _, _, _, _, check_nonce, _, _, ..) = extra.clone();
+				let (_, _, _, _, _mortality, old_check_nonce, ..) = old_extra.clone();
+				let (_, _, _, _, _, check_nonce, ..) = extra.clone();
 
 				// make sure nonce keep no changed.
 				if old_check_nonce.nonce != check_nonce.nonce {
@@ -2235,6 +2235,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 				if !raw_payload.using_encoded(|payload| payer_sig.verify(payload, &payer_account.into())) {
 					return Err(InvalidTransaction::BadProof);
 				}
+			} else {
+				return Err(InvalidTransaction::Call);
 			}
 		}
 		Ok(())

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -90,6 +90,7 @@ pub use primitives::{
 	currency::AssetIds,
 	define_combined_task,
 	evm::{AccessListItem, BlockLimits, EstimateResourcesRequest, EthereumTransactionMessage, EvmAddress},
+	signature::AcalaMultiSignature,
 	task::TaskResult,
 	unchecked_extrinsic::AcalaUncheckedExtrinsic,
 	AccountId, AccountIndex, Address, Amount, AuctionId, AuthoritysOriginId, Balance, BlockNumber, CurrencyId,
@@ -2199,7 +2200,7 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 		if let Call::TransactionPayment(module_transaction_payment::Call::with_fee_paid_by {
 			call,
 			payer_addr,
-			payer_sig,
+			payer_encode_call,
 		}) = call
 		{
 			let payer_account: [u8; 32] = payer_addr
@@ -2207,10 +2208,33 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 				.as_slice()
 				.try_into()
 				.map_err(|_| InvalidTransaction::BadSigner)?;
-			// payer signature is aim at inner call of `with_fee_paid_by` call.
-			let raw_payload = SignedPayload::new(*call, extra).map_err(|_| InvalidTransaction::BadSigner)?;
-			if !raw_payload.using_encoded(|payload| payer_sig.verify(payload, &payer_account.into())) {
-				return Err(InvalidTransaction::BadProof);
+
+			let signed_unsubmit_extrinsic: generic::UncheckedExtrinsic<
+				Address,
+				Call,
+				AcalaMultiSignature,
+				SignedExtra,
+			> = <generic::UncheckedExtrinsic<Address, Call, AcalaMultiSignature, SignedExtra>>::decode(
+				&mut payer_encode_call.as_slice(),
+			)
+			.map_err(|_e| InvalidTransaction::Call)?;
+			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
+				let (_, _, _, _, _, old_check_nonce, _, _, _) = old_extra.clone();
+				let (_, _, _, _, _, check_nonce, _, _, ..) = extra.clone();
+
+				// make sure nonce keep no changed.
+				if old_check_nonce.nonce != check_nonce.nonce {
+					return Err(InvalidTransaction::BadProof);
+				}
+				// make sure relayer/payer address is correct.
+				if relayer != sp_runtime::MultiAddress::Id(payer_addr) {
+					return Err(InvalidTransaction::BadProof);
+				}
+
+				let raw_payload = SignedPayload::new(*call, old_extra).map_err(|_| InvalidTransaction::BadSigner)?;
+				if !raw_payload.using_encoded(|payload| payer_sig.verify(payload, &payer_account.into())) {
+					return Err(InvalidTransaction::BadProof);
+				}
 			}
 		}
 		Ok(())

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -39,7 +39,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdConversion, AccountIdLookup, BadOrigin, BlakeTwo256, Block as BlockT, Convert, SaturatedConversion,
-		StaticLookup, Verify,
+		SignedExtension, StaticLookup, Verify,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, Perbill, Percent, Permill, Perquintill,
@@ -1010,7 +1010,7 @@ where
 			frame_system::CheckSpecVersion::<Runtime>::new(),
 			frame_system::CheckTxVersion::<Runtime>::new(),
 			frame_system::CheckGenesis::<Runtime>::new(),
-			frame_system::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
+			runtime_common::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
 			runtime_common::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
@@ -1751,7 +1751,7 @@ pub type SignedExtra = (
 	frame_system::CheckSpecVersion<Runtime>,
 	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
+	runtime_common::CheckEra<Runtime>,
 	runtime_common::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	module_transaction_payment::ChargeTransactionPayment<Runtime>,
@@ -2160,7 +2160,7 @@ impl Convert<(Call, SignedExtra), Result<(EthereumTransactionMessage, SignedExtr
 
 				let (_, _, _, _, mortality, check_nonce, _, charge, ..) = extra.clone();
 
-				if mortality != frame_system::CheckEra::from(sp_runtime::generic::Era::Immortal) {
+				if mortality != runtime_common::CheckEra::from(sp_runtime::generic::Era::Immortal) {
 					// require immortal
 					return Err(InvalidTransaction::BadProof);
 				}
@@ -2219,8 +2219,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 			)
 			.map_err(|_e| InvalidTransaction::Call)?;
 			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
-				let (_, _, _, _, _mortality, old_check_nonce, ..) = old_extra.clone();
-				let (_, _, _, _, _, check_nonce, ..) = extra.clone();
+				let (_, _, _, _, old_mortality, old_check_nonce, ..) = old_extra.clone();
+				let (_, _, _, _, _, check_nonce, ..) = extra;
 
 				// make sure nonce keep no changed.
 				if old_check_nonce.nonce != check_nonce.nonce {
@@ -2228,6 +2228,16 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 				}
 				// make sure relayer/payer address is correct.
 				if relayer != sp_runtime::MultiAddress::Id(payer_addr) {
+					return Err(InvalidTransaction::BadProof);
+				}
+				// verify era lifetime is not expire
+				let old_block_hash = old_mortality
+					.additional_signed()
+					.map_err(|_e| InvalidTransaction::BadSigner)?;
+				let current_block = <frame_system::Pallet<Runtime>>::block_number();
+				let birth_block = old_mortality.0.birth(current_block as u64);
+				let birth_block_hash = <frame_system::Pallet<Runtime>>::block_hash(birth_block as u32);
+				if birth_block_hash != old_block_hash {
 					return Err(InvalidTransaction::BadProof);
 				}
 

--- a/runtime/mandala/src/benchmarking/transaction_payment.rs
+++ b/runtime/mandala/src/benchmarking/transaction_payment.rs
@@ -154,8 +154,8 @@ runtime_benchmarks! {
 		let caller: AccountId = whitelisted_caller();
 		let payer: AccountId = account("payer", 0, SEED);
 		let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
-		let signature = sp_runtime::MultiSignature::Sr25519(sp_core::sr25519::Signature([0u8; 64]));
-	}: _(RawOrigin::Signed(caller.clone()), call, payer, signature)
+		let encode_call = vec![0u8; 10];
+	}: _(RawOrigin::Signed(caller.clone()), call, payer, encode_call)
 
 	on_finalize {
 	}: {

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1045,7 +1045,7 @@ where
 			frame_system::CheckSpecVersion::<Runtime>::new(),
 			frame_system::CheckTxVersion::<Runtime>::new(),
 			frame_system::CheckGenesis::<Runtime>::new(),
-			frame_system::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
+			runtime_common::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
 			runtime_common::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
@@ -1786,7 +1786,7 @@ impl Convert<(Call, SignedExtra), Result<(EthereumTransactionMessage, SignedExtr
 
 				let (_, _, _, _, mortality, check_nonce, _, charge, ..) = extra.clone();
 
-				if mortality != frame_system::CheckEra::from(sp_runtime::generic::Era::Immortal) {
+				if mortality != runtime_common::CheckEra::from(sp_runtime::generic::Era::Immortal) {
 					// require immortal
 					return Err(InvalidTransaction::BadProof);
 				}
@@ -1845,7 +1845,7 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 			)
 			.map_err(|_e| InvalidTransaction::Call)?;
 			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
-				let (_, _, _, _, _mortality, old_check_nonce, ..) = old_extra.clone();
+				let (_, _, _, _, mortality, old_check_nonce, ..) = old_extra.clone();
 				let (_, _, _, _, _, check_nonce, ..) = extra.clone();
 
 				// make sure nonce keep no changed.
@@ -1884,7 +1884,7 @@ pub type SignedExtra = (
 	frame_system::CheckSpecVersion<Runtime>,
 	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
+	runtime_common::CheckEra<Runtime>,
 	runtime_common::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	module_transaction_payment::ChargeTransactionPayment<Runtime>,
@@ -2485,7 +2485,7 @@ mod tests {
 				frame_system::CheckSpecVersion::<Runtime>::new(),
 				frame_system::CheckTxVersion::<Runtime>::new(),
 				frame_system::CheckGenesis::<Runtime>::new(),
-				frame_system::CheckEra::<Runtime>::from(generic::Era::Immortal),
+				runtime_common::CheckEra::<Runtime>::from(generic::Era::Immortal),
 				runtime_common::CheckNonce::<Runtime>::from(3),
 				frame_system::CheckWeight::<Runtime>::new(),
 				module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
@@ -2574,7 +2574,7 @@ mod tests {
 			frame_system::CheckSpecVersion::<Runtime>::new(),
 			frame_system::CheckTxVersion::<Runtime>::new(),
 			frame_system::CheckGenesis::<Runtime>::new(),
-			frame_system::CheckEra::<Runtime>::from(generic::Era::Immortal),
+			runtime_common::CheckEra::<Runtime>::from(generic::Era::Immortal),
 			runtime_common::CheckNonce::<Runtime>::from(0),
 			frame_system::CheckWeight::<Runtime>::new(),
 			module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
@@ -2586,7 +2586,7 @@ mod tests {
 			frame_system::CheckSpecVersion::<Runtime>::new(),
 			frame_system::CheckTxVersion::<Runtime>::new(),
 			frame_system::CheckGenesis::<Runtime>::new(),
-			frame_system::CheckEra::<Runtime>::from(generic::Era::Immortal),
+			runtime_common::CheckEra::<Runtime>::from(generic::Era::Immortal),
 			runtime_common::CheckNonce::<Runtime>::from(1),
 			frame_system::CheckWeight::<Runtime>::new(),
 			module_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1845,8 +1845,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 			)
 			.map_err(|_e| InvalidTransaction::Call)?;
 			if let Some((relayer, payer_sig, old_extra)) = signed_unsubmit_extrinsic.signature {
-				let (_, _, _, _, mortality, old_check_nonce, _, _, _) = old_extra.clone();
-				let (_, _, _, _, _, check_nonce, _, _, ..) = extra.clone();
+				let (_, _, _, _, _mortality, old_check_nonce, ..) = old_extra.clone();
+				let (_, _, _, _, _, check_nonce, ..) = extra.clone();
 
 				// make sure nonce keep no changed.
 				if old_check_nonce.nonce != check_nonce.nonce {
@@ -1862,6 +1862,8 @@ impl Convert<(Call, SignedExtra), Result<(), InvalidTransaction>> for PayerSigna
 				if !raw_payload.using_encoded(|payload| payer_sig.verify(payload, &payer_account.into())) {
 					return Err(InvalidTransaction::BadProof);
 				}
+			} else {
+				return Err(InvalidTransaction::Call);
 			}
 		}
 		Ok(())


### PR DESCRIPTION
closes: https://github.com/AcalaNetwork/Acala/issues/2170

- use encoded call instead of signature as parameter of `with_fee_paid_by` dispatch call.

testcase:
- sender nonce change should failed.
- era expire should failed. i.e. sign unsubmit at block1, then at block33 issue extrinsic should failed.
- relayer address changed should failed.

> use our own check_mortality for now. once https://github.com/paritytech/substrate/pull/11575 merged, we can use substrate version.