### PR TITLE
Some improvement for security

### DIFF
--- a/modules/cdp-treasury/src/lib.rs
+++ b/modules/cdp-treasury/src/lib.rs
@@ -293,7 +293,7 @@ impl<T: Config> Pallet<T> {
 
 		// Burn the amount that is equal to offset amount of stable currency.
 		if !offset_amount.is_zero() {
-			let res = T::Currency::withdraw(T::GetStableCurrencyId::get(), &Self::account_id(), offset_amount);
+			let res = Self::burn_debit(&Self::account_id(), offset_amount);
 			match res {
 				Ok(_) => {
 					DebitPool::<T>::mutate(|debit| {
@@ -346,6 +346,7 @@ impl<T: Config> CDPTreasury<T::AccountId> for Pallet<T> {
 		Self::issue_debit(&Self::account_id(), amount, true)
 	}
 
+	/// This should be the only function in the system that issues stable coin
 	fn issue_debit(who: &T::AccountId, debit: Self::Balance, backed: bool) -> DispatchResult {
 		// increase system debit if the debit is unbacked
 		if !backed {
@@ -356,6 +357,7 @@ impl<T: Config> CDPTreasury<T::AccountId> for Pallet<T> {
 		Ok(())
 	}
 
+	/// This should be the only function in the system that burns stable coin
 	fn burn_debit(who: &T::AccountId, debit: Self::Balance) -> DispatchResult {
 		T::Currency::withdraw(T::GetStableCurrencyId::get(), who, debit)
 	}

--- a/modules/homa/src/tests.rs
+++ b/modules/homa/src/tests.rs
@@ -300,6 +300,8 @@ fn update_bump_era_params_works() {
 		assert_eq!(Homa::last_era_bumped_block(), 0);
 		assert_eq!(Homa::bump_era_frequency(), 0);
 
+		MockRelayBlockNumberProvider::set(10);
+
 		assert_ok!(Homa::update_bump_era_params(
 			Origin::signed(HomaAdmin::get()),
 			Some(10),
@@ -1147,6 +1149,7 @@ fn era_amount_should_to_bump_works() {
 		assert_eq!(Homa::era_amount_should_to_bump(11), 1);
 		assert_eq!(Homa::era_amount_should_to_bump(30), 3);
 
+		MockRelayBlockNumberProvider::set(10);
 		assert_ok!(Homa::update_bump_era_params(
 			Origin::signed(HomaAdmin::get()),
 			Some(1),
@@ -1358,4 +1361,54 @@ fn bump_current_era_works() {
 				589_344
 			);
 		});
+}
+
+#[test]
+fn last_era_bumped_block_config_check_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(Homa::last_era_bumped_block(), 0);
+		assert_eq!(Homa::bump_era_frequency(), 0);
+		assert_eq!(MockRelayBlockNumberProvider::current_block_number(), 0);
+
+		MockRelayBlockNumberProvider::set(100);
+
+		// it's ok, nothing happen because bump_era_frequency is zero
+		assert_ok!(Homa::update_bump_era_params(
+			Origin::signed(HomaAdmin::get()),
+			Some(100),
+			None,
+		));
+		assert_eq!(Homa::last_era_bumped_block(), 0);
+		assert_eq!(Homa::bump_era_frequency(), 0);
+
+		// 50 will trigger bump era
+		assert_noop!(
+			Homa::update_bump_era_params(Origin::signed(HomaAdmin::get()), Some(50), Some(50),),
+			Error::<Runtime>::InvalidLastEraBumpedBlock
+		);
+
+		assert_ok!(Homa::update_bump_era_params(
+			Origin::signed(HomaAdmin::get()),
+			Some(51),
+			Some(50),
+		));
+		assert_eq!(Homa::last_era_bumped_block(), 51);
+		assert_eq!(Homa::bump_era_frequency(), 50);
+		assert_eq!(MockRelayBlockNumberProvider::current_block_number(), 100);
+
+		// 101 is great than current relaychain block
+		assert_noop!(
+			Homa::update_bump_era_params(Origin::signed(HomaAdmin::get()), Some(101), None,),
+			Error::<Runtime>::InvalidLastEraBumpedBlock
+		);
+
+		assert_ok!(Homa::update_bump_era_params(
+			Origin::signed(HomaAdmin::get()),
+			Some(100),
+			None,
+		));
+		assert_eq!(Homa::last_era_bumped_block(), 100);
+		assert_eq!(Homa::bump_era_frequency(), 50);
+		assert_eq!(MockRelayBlockNumberProvider::current_block_number(), 100);
+	});
 }

--- a/runtime/mandala/src/benchmarking/homa.rs
+++ b/runtime/mandala/src/benchmarking/homa.rs
@@ -133,7 +133,9 @@ runtime_benchmarks! {
 		Some(Rate::saturating_from_rational(1, 100)),
 		Some(Rate::saturating_from_rational(1, 100)))
 
-	update_bump_era_params {}: _(RawOrigin::Root, Some(3000), Some(7200))
+	update_bump_era_params {
+		RelaychainBlockNumberProvider::<Runtime>::set_block_number(10000);
+	}: _(RawOrigin::Root, Some(3000), Some(7200))
 
 	reset_ledgers {
 		let n in 0 .. 10;


### PR DESCRIPTION
1. use wrapped function to issue/burn for some assets instead of using Tokens.deposit/withdraw directly
2. config homa.LastEraBumpedBlock shouldn't cause immediately bump era