### PR TITLE
prevent arbitrary message from xcm pallet as in statemine

### DIFF
--- a/runtime/karura/src/xcm_config.rs
+++ b/runtime/karura/src/xcm_config.rs
@@ -230,7 +230,7 @@ pub type XcmRouter = (
 
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>;
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Nothing;


### PR DESCRIPTION
i known karura disabled most of extrinsics in that pallet via filter call, but hope at some point it will consider it secure to open up it