### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,15 +38,13 @@ jobs:
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1.13
       # - name: Install additional dependencies
       #   run: |
       #       sudo apt update -y &&

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,7 @@ jobs:
             test-service \
             --exclude-files **/mock.rs **/weights.rs **/weights/*
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Yarn

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Yarn

--- a/.github/workflows/extrinsic-ordering-check-on-release.yml
+++ b/.github/workflows/extrinsic-ordering-check-on-release.yml
@@ -49,9 +49,9 @@ jobs:
         if: ${{ env.CHAIN == '' || env.VERSION == '' || env.PREVIOUS_VERSION == '' }}
         run: python .github/scripts/extrinsic_check_setup_env.py
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Yarn

--- a/.github/workflows/extrinsic-ordering-check-on-release.yml
+++ b/.github/workflows/extrinsic-ordering-check-on-release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,13 @@ jobs:
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Check format
         run: cargo fmt --all -- --check
       - name: Build
@@ -69,15 +67,13 @@ jobs:
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Run benchmarking tests
         run: make test-benchmarking
   checks-and-tests:
@@ -91,15 +87,13 @@ jobs:
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Run runtime tests
         run: make test-runtimes
       - name: Run eth tests
@@ -121,19 +115,17 @@ jobs:
         with:
           submodules: recursive
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Run e2e tests
         run: make test-e2e
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Run ts tests

--- a/.github/workflows/test.yml.src
+++ b/.github/workflows/test.yml.src
@@ -39,13 +39,11 @@ jobs:
           submodules: recursive
       - &toolchain
         name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: Check format
         run: cargo fmt --all -- --check
       - name: Build
@@ -85,7 +83,7 @@ jobs:
       - *checkout
       - *toolchain
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Run ts tests

--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -18,13 +18,11 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: nightly-2022-08-05
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
       - name: update tokens
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
`
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, jwlawson/actions-setup-cmake@v1.12, actions/setup-node@v2
`

Fix the warnings in https://github.com/AcalaNetwork/Acala/actions/runs/3569255093

`actions-rs/toolchain` is no longer maintained, switch to `dtolnay/rust-toolchain`