### PR TITLE
Add archive params

### DIFF
--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -37,6 +37,8 @@ export async function startAcalaNode(): Promise<{ provider: TestProvider; binary
 		`--ws-external`,
 		`--rpc-cors=all`,
 		`--rpc-methods=unsafe`,
+		`--pruning=archive`,
+		`--keep-blocks=archive`,
 		`--tmp`,
 	];
 	const binary = spawn(cmd, args);


### PR DESCRIPTION
https://github.com/paritytech/substrate/commit/a0ec652e341f694f182a3c5fcc80d4c3fb280003?diff=unified#diff-0e523389a21c9bd9fc1da47816eb73a5ad21637337bb938abecedfe7f936d824R1720

The logic of `prune_blocks` has changed, and the `archive` needs to be specified