### PR TITLE
Fix evm origin

### DIFF
--- a/modules/currencies/src/lib.rs
+++ b/modules/currencies/src/lib.rs
@@ -285,7 +285,7 @@ pub mod module {
 
 impl<T: Config> Pallet<T> {
 	fn get_evm_origin() -> Result<EvmAddress, DispatchError> {
-		let origin = T::EVMBridge::get_origin().ok_or(Error::<T>::RealOriginNotFound)?;
+		let origin = T::EVMBridge::get_real_or_xcm_origin().ok_or(Error::<T>::RealOriginNotFound)?;
 		Ok(T::AddressMapping::get_or_create_evm_address(&origin))
 	}
 }
@@ -420,8 +420,8 @@ impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
 		match currency_id {
 			CurrencyId::Erc20(contract) => {
 				// deposit from erc20 holding account to receiver(who). in xcm case which receive erc20 from sibling
-				// parachain, we choose receiver to charge storage fee. we must make sure receiver has enough native
-				// token to charge storage fee.
+				// parachain, we choose sibling parachain sovereign account to charge storage fee. we must make sure
+				// sibling parachain sovereign account has enough native token to charge storage fee.
 				let sender = T::Erc20HoldingAccount::get();
 				let from = T::AddressMapping::get_account_id(&sender);
 				ensure!(

--- a/modules/currencies/src/tests.rs
+++ b/modules/currencies/src/tests.rs
@@ -230,7 +230,7 @@ fn multi_currency_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 			assert_ok!(Currencies::transfer(Some(alice()).into(), bob(), X_TOKEN_ID, 50));
 			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &alice()), 50);
 			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &bob()), 150);
@@ -544,7 +544,7 @@ fn erc20_ensure_withdraw_should_work() {
 		.build()
 		.execute_with(|| {
 			deploy_contracts();
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 			assert_ok!(Currencies::ensure_can_withdraw(
 				CurrencyId::Erc20(erc20_address()),
 				&alice(),
@@ -583,7 +583,7 @@ fn erc20_transfer_should_work() {
 		.build()
 		.execute_with(|| {
 			deploy_contracts();
-			<EVM as EVMTrait<AccountId>>::push_origin(eva());
+			<EVM as EVMTrait<AccountId>>::set_origin(eva());
 
 			assert_ok!(Currencies::transfer(
 				RuntimeOrigin::signed(alice()),
@@ -656,8 +656,8 @@ fn erc20_transfer_should_fail() {
 				Error::<Runtime>::RealOriginNotFound
 			);
 
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
-			<EVM as EVMTrait<AccountId>>::push_origin(bob());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(bob());
 
 			// empty address
 			assert!(Currencies::transfer(
@@ -843,7 +843,7 @@ fn erc20_repatriate_reserved_should_work() {
 		.execute_with(|| {
 			deploy_contracts();
 			let bob_balance = 100;
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 			assert_ok!(Currencies::transfer(
 				RuntimeOrigin::signed(alice()),
 				bob(),
@@ -975,7 +975,7 @@ fn erc20_invalid_operation() {
 		.build()
 		.execute_with(|| {
 			deploy_contracts();
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 
 			assert_noop!(
 				Currencies::update_balance(RuntimeOrigin::root(), alice(), CurrencyId::Erc20(erc20_address()), 1),
@@ -994,7 +994,7 @@ fn erc20_withdraw_deposit_works() {
 		.build()
 		.execute_with(|| {
 			deploy_contracts();
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 
 			let erc20_holding_account = MockAddressMapping::get_account_id(&Erc20HoldingAccount::get());
 
@@ -1683,7 +1683,7 @@ fn fungible_transfer_trait_should_work() {
 			assert_eq!(<AdaptedBasicCurrency as fungible::Inspect<_>>::balance(&bob()), 20000);
 
 			deploy_contracts();
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 			assert_eq!(
 				<Currencies as fungibles::Inspect<_>>::balance(CurrencyId::Erc20(erc20_address()), &alice()),
 				ALICE_BALANCE

--- a/modules/evm-bridge/src/lib.rs
+++ b/modules/evm-bridge/src/lib.rs
@@ -255,12 +255,20 @@ impl<T: Config> EVMBridgeTrait<AccountIdOf<T>, BalanceOf<T>> for EVMBridge<T> {
 		T::EVM::set_origin(origin);
 	}
 
+	fn kill_origin() {
+		T::EVM::kill_origin();
+	}
+
 	fn push_xcm_origin(origin: AccountIdOf<T>) {
 		T::EVM::push_xcm_origin(origin);
 	}
 
 	fn pop_xcm_origin() {
 		T::EVM::pop_xcm_origin();
+	}
+
+	fn kill_xcm_origin() {
+		T::EVM::kill_xcm_origin();
 	}
 
 	fn get_real_or_xcm_origin() -> Option<AccountIdOf<T>> {

--- a/modules/evm-bridge/src/lib.rs
+++ b/modules/evm-bridge/src/lib.rs
@@ -251,12 +251,20 @@ impl<T: Config> EVMBridgeTrait<AccountIdOf<T>, BalanceOf<T>> for EVMBridge<T> {
 		T::EVM::get_origin()
 	}
 
-	fn push_origin(origin: AccountIdOf<T>) {
-		T::EVM::push_origin(origin);
+	fn set_origin(origin: AccountIdOf<T>) {
+		T::EVM::set_origin(origin);
 	}
 
-	fn pop_origin() {
-		T::EVM::pop_origin();
+	fn push_xcm_origin(origin: AccountIdOf<T>) {
+		T::EVM::push_xcm_origin(origin);
+	}
+
+	fn pop_xcm_origin() {
+		T::EVM::pop_xcm_origin();
+	}
+
+	fn get_real_or_xcm_origin() -> Option<AccountIdOf<T>> {
+		T::EVM::get_real_or_xcm_origin()
 	}
 }
 

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -1924,6 +1924,11 @@ impl<T: Config> EVMTrait<T::AccountId> for Pallet<T> {
 		ExtrinsicOrigin::<T>::set(Some(origin));
 	}
 
+	// Kill the EVM origin
+	fn kill_origin() {
+		ExtrinsicOrigin::<T>::kill();
+	}
+
 	// Set the EVM origin in xcm
 	fn push_xcm_origin(origin: T::AccountId) {
 		XcmOrigin::<T>::mutate(|o| {
@@ -1945,6 +1950,11 @@ impl<T: Config> EVMTrait<T::AccountId> for Pallet<T> {
 				}
 			}
 		});
+	}
+
+	// Kill the EVM origin in xcm
+	fn kill_xcm_origin() {
+		XcmOrigin::<T>::kill();
 	}
 
 	// Get the real origin account or xcm origin and charge storage rent from the origin.

--- a/modules/evm/src/lib.rs
+++ b/modules/evm/src/lib.rs
@@ -345,7 +345,14 @@ pub mod module {
 	/// ExtrinsicOrigin: Option<AccountId>
 	#[pallet::storage]
 	#[pallet::getter(fn extrinsic_origin)]
-	pub type ExtrinsicOrigin<T: Config> = StorageValue<_, Vec<T::AccountId>, OptionQuery>;
+	pub type ExtrinsicOrigin<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+	/// Xcm origin for the current transaction.
+	///
+	/// XcmOrigin: Option<Vec<AccountId>>
+	#[pallet::storage]
+	#[pallet::getter(fn xcm_origin)]
+	pub type XcmOrigin<T: Config> = StorageValue<_, Vec<T::AccountId>, OptionQuery>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
@@ -1909,12 +1916,17 @@ impl<T: Config> EVMTrait<T::AccountId> for Pallet<T> {
 
 	/// Get the real origin account and charge storage rent from the origin.
 	fn get_origin() -> Option<T::AccountId> {
-		ExtrinsicOrigin::<T>::get().and_then(|o| o.last().cloned())
+		ExtrinsicOrigin::<T>::get()
 	}
 
-	// Set the EVM origin
-	fn push_origin(origin: T::AccountId) {
-		ExtrinsicOrigin::<T>::mutate(|o| {
+	/// Set the EVM origin
+	fn set_origin(origin: T::AccountId) {
+		ExtrinsicOrigin::<T>::set(Some(origin));
+	}
+
+	// Set the EVM origin in xcm
+	fn push_xcm_origin(origin: T::AccountId) {
+		XcmOrigin::<T>::mutate(|o| {
 			if let Some(o) = o {
 				o.push(origin);
 			} else {
@@ -1923,9 +1935,9 @@ impl<T: Config> EVMTrait<T::AccountId> for Pallet<T> {
 		});
 	}
 
-	// Pop the EVM origin
-	fn pop_origin() {
-		ExtrinsicOrigin::<T>::mutate(|o| {
+	// Pop the EVM origin in xcm
+	fn pop_xcm_origin() {
+		XcmOrigin::<T>::mutate(|o| {
 			if let Some(arr) = o {
 				arr.pop();
 				if arr.is_empty() {
@@ -1933,6 +1945,11 @@ impl<T: Config> EVMTrait<T::AccountId> for Pallet<T> {
 				}
 			}
 		});
+	}
+
+	// Get the real origin account or xcm origin and charge storage rent from the origin.
+	fn get_real_or_xcm_origin() -> Option<T::AccountId> {
+		ExtrinsicOrigin::<T>::get().or_else(|| XcmOrigin::<T>::get().and_then(|o| o.last().cloned()))
 	}
 }
 
@@ -2060,7 +2077,7 @@ impl<T: Config + Send + Sync> SignedExtension for SetEvmOrigin<T> {
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> TransactionValidity {
-		ExtrinsicOrigin::<T>::set(Some(vec![who.clone()]));
+		ExtrinsicOrigin::<T>::set(Some(who.clone()));
 		Ok(ValidTransaction::default())
 	}
 
@@ -2071,7 +2088,7 @@ impl<T: Config + Send + Sync> SignedExtension for SetEvmOrigin<T> {
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> Result<(), TransactionValidityError> {
-		ExtrinsicOrigin::<T>::set(Some(vec![who.clone()]));
+		ExtrinsicOrigin::<T>::set(Some(who.clone()));
 		Ok(())
 	}
 
@@ -2083,6 +2100,7 @@ impl<T: Config + Send + Sync> SignedExtension for SetEvmOrigin<T> {
 		_result: &DispatchResult,
 	) -> Result<(), TransactionValidityError> {
 		ExtrinsicOrigin::<T>::kill();
+		XcmOrigin::<T>::kill();
 		Ok(())
 	}
 }

--- a/modules/evm/src/runner/stack.rs
+++ b/modules/evm/src/runner/stack.rs
@@ -24,8 +24,8 @@ use crate::{
 		state::{Accessed, CustomStackState, StackExecutor, StackState as StackStateT, StackSubstateMetadata},
 		Runner as RunnerT, RunnerExtended,
 	},
-	AccountInfo, AccountStorages, Accounts, BalanceOf, CallInfo, Config, CreateInfo, Error, ExecutionInfo,
-	ExtrinsicOrigin, One, Pallet, STORAGE_SIZE,
+	AccountInfo, AccountStorages, Accounts, BalanceOf, CallInfo, Config, CreateInfo, Error, ExecutionInfo, One, Pallet,
+	STORAGE_SIZE,
 };
 use frame_support::{
 	dispatch::DispatchError,
@@ -37,7 +37,7 @@ use module_evm_utility::{
 	ethereum::Log,
 	evm::{self, backend::Backend as BackendT, ExitError, ExitReason, Transfer},
 };
-use module_support::AddressMapping;
+use module_support::{AddressMapping, EVM};
 pub use primitives::{
 	evm::{convert_decimals_from_evm, EvmAddress, Vicinity, MIRRORED_NFT_ADDRESS_START},
 	ReserveIdentifier,
@@ -371,8 +371,8 @@ impl<T: Config> RunnerExtended<T> for Runner<T> {
 		config: &evm::Config,
 	) -> Result<CallInfo, DispatchError> {
 		// Ensure eth_call has evm origin, otherwise xcm charge rent fee will fail.
-		ExtrinsicOrigin::<T>::set(Some(T::AddressMapping::get_account_id(&origin)));
-		defer!(ExtrinsicOrigin::<T>::kill());
+		Pallet::<T>::set_origin(T::AddressMapping::get_account_id(&origin));
+		defer!(Pallet::<T>::kill_origin());
 
 		let precompiles = T::PrecompilesValue::get();
 		let value = U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(value));

--- a/modules/honzon-bridge/src/tests.rs
+++ b/modules/honzon-bridge/src/tests.rs
@@ -61,7 +61,7 @@ fn to_bridged_works() {
 			erc20_address()
 		));
 		// ensure the honzon-bridge pallet account bind the evmaddress
-		<EVM as EVMTrait<AccountId>>::push_origin(EvmAccountsModule::get_account_id(&alice_evm_addr()));
+		<EVM as EVMTrait<AccountId>>::set_origin(EvmAccountsModule::get_account_id(&alice_evm_addr()));
 		assert_ok!(Currencies::transfer(
 			RuntimeOrigin::signed(alice()),
 			HonzonBridgeAccount::get(),
@@ -132,7 +132,7 @@ fn from_bridged_works() {
 			erc20_address()
 		));
 		// ensure the honzon-bridge pallet account bind the evmaddress
-		<EVM as EVMTrait<AccountId>>::push_origin(EvmAccountsModule::get_account_id(&alice_evm_addr()));
+		<EVM as EVMTrait<AccountId>>::set_origin(EvmAccountsModule::get_account_id(&alice_evm_addr()));
 		assert_ok!(Currencies::transfer(
 			RuntimeOrigin::signed(alice()),
 			HonzonBridgeAccount::get(),

--- a/modules/support/src/evm.rs
+++ b/modules/support/src/evm.rs
@@ -57,10 +57,12 @@ pub trait EVM<AccountId> {
 
 	/// Get the real origin account and charge storage rent from the origin.
 	fn get_origin() -> Option<AccountId>;
+	fn set_origin(origin: AccountId);
 	/// Push new EVM origin
-	fn push_origin(origin: AccountId);
+	fn push_xcm_origin(origin: AccountId);
 	/// Pop EVM origin
-	fn pop_origin();
+	fn pop_xcm_origin();
+	fn get_real_or_xcm_origin() -> Option<AccountId>;
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug)]
@@ -98,10 +100,14 @@ pub trait EVMBridge<AccountId, Balance> {
 	fn transfer(context: InvokeContext, to: EvmAddress, value: Balance) -> DispatchResult;
 	/// Get the real origin account and charge storage rent from the origin.
 	fn get_origin() -> Option<AccountId>;
-	/// Push new EVM origin
-	fn push_origin(origin: AccountId);
-	/// Pop EVM origin
-	fn pop_origin();
+	/// Set the EVM origin
+	fn set_origin(origin: AccountId);
+	/// Push new EVM origin in xcm
+	fn push_xcm_origin(origin: AccountId);
+	/// Pop EVM origin in xcmg
+	fn pop_xcm_origin();
+	/// Get the real origin account or xcm origin and charge storage rent from the origin.
+	fn get_real_or_xcm_origin() -> Option<AccountId>;
 }
 
 #[cfg(feature = "std")]
@@ -127,8 +133,12 @@ impl<AccountId, Balance: Default> EVMBridge<AccountId, Balance> for () {
 	fn get_origin() -> Option<AccountId> {
 		None
 	}
-	fn push_origin(_origin: AccountId) {}
-	fn pop_origin() {}
+	fn set_origin(_origin: AccountId) {}
+	fn push_xcm_origin(_origin: AccountId) {}
+	fn pop_xcm_origin() {}
+	fn get_real_or_xcm_origin() -> Option<AccountId> {
+		None
+	}
 }
 
 /// EVM bridge for collateral liquidation.

--- a/modules/support/src/evm.rs
+++ b/modules/support/src/evm.rs
@@ -57,11 +57,17 @@ pub trait EVM<AccountId> {
 
 	/// Get the real origin account and charge storage rent from the origin.
 	fn get_origin() -> Option<AccountId>;
+	/// Set the EVM origin
 	fn set_origin(origin: AccountId);
-	/// Push new EVM origin
+	/// Kill the EVM origin
+	fn kill_origin();
+	/// Push new EVM origin in xcm
 	fn push_xcm_origin(origin: AccountId);
-	/// Pop EVM origin
+	/// Pop EVM origin in xcm
 	fn pop_xcm_origin();
+	/// Kill the EVM origin in xcm
+	fn kill_xcm_origin();
+	/// Get the real origin account or xcm origin and charge storage rent from the origin.
 	fn get_real_or_xcm_origin() -> Option<AccountId>;
 }
 
@@ -102,10 +108,14 @@ pub trait EVMBridge<AccountId, Balance> {
 	fn get_origin() -> Option<AccountId>;
 	/// Set the EVM origin
 	fn set_origin(origin: AccountId);
+	/// Kill the EVM origin
+	fn kill_origin();
 	/// Push new EVM origin in xcm
 	fn push_xcm_origin(origin: AccountId);
-	/// Pop EVM origin in xcmg
+	/// Pop EVM origin in xcm
 	fn pop_xcm_origin();
+	/// Kill the EVM origin in xcm
+	fn kill_xcm_origin();
 	/// Get the real origin account or xcm origin and charge storage rent from the origin.
 	fn get_real_or_xcm_origin() -> Option<AccountId>;
 }
@@ -134,8 +144,10 @@ impl<AccountId, Balance: Default> EVMBridge<AccountId, Balance> for () {
 		None
 	}
 	fn set_origin(_origin: AccountId) {}
+	fn kill_origin() {}
 	fn push_xcm_origin(_origin: AccountId) {}
 	fn pop_xcm_origin() {}
+	fn kill_xcm_origin() {}
 	fn get_real_or_xcm_origin() -> Option<AccountId> {
 		None
 	}

--- a/runtime/common/src/xcm_impl.rs
+++ b/runtime/common/src/xcm_impl.rs
@@ -256,7 +256,7 @@ impl<
 		let origin = origin.into();
 		let account = AccountIdConvert::convert(origin);
 		let clear = if let Ok(account) = account {
-			EVMBridge::push_origin(account);
+			EVMBridge::push_xcm_origin(account);
 			true
 		} else {
 			false
@@ -265,7 +265,7 @@ impl<
 		let res = xcm_executor::XcmExecutor::<Config>::execute(origin, weighed_message, message_hash, weight_credit);
 
 		if clear {
-			EVMBridge::pop_origin();
+			EVMBridge::pop_xcm_origin();
 		}
 		res
 	}

--- a/runtime/integration-tests/src/evm.rs
+++ b/runtime/integration-tests/src/evm.rs
@@ -238,7 +238,7 @@ fn dex_module_works_with_evm_contract() {
 				0,
 			));
 
-			<EVM as EVMTrait<AccountId>>::push_origin(MockAddressMapping::get_account_id(&alice_evm_addr()));
+			<EVM as EVMTrait<AccountId>>::set_origin(MockAddressMapping::get_account_id(&alice_evm_addr()));
 			assert_ok!(Dex::add_provision(
 				RuntimeOrigin::signed(MockAddressMapping::get_account_id(&alice_evm_addr())),
 				CurrencyId::Erc20(erc20_address_0()),
@@ -261,7 +261,7 @@ fn dex_module_works_with_evm_contract() {
 			);
 
 			// CurrencyId::DexShare(Erc20, Erc20)
-			<EVM as EVMTrait<AccountId>>::push_origin(EvmAddressMapping::<Runtime>::get_account_id(&alice_evm_addr()));
+			<EVM as EVMTrait<AccountId>>::set_origin(EvmAddressMapping::<Runtime>::get_account_id(&alice_evm_addr()));
 
 			assert_ok!(Dex::add_provision(
 				RuntimeOrigin::signed(EvmAddressMapping::<Runtime>::get_account_id(&alice_evm_addr())),
@@ -431,7 +431,7 @@ fn test_multicurrency_precompile_module() {
 			));
 
 			// CurrencyId::DexShare(Erc20, Erc20)
-			<EVM as EVMTrait<AccountId>>::push_origin(MockAddressMapping::get_account_id(&alice_evm_addr()));
+			<EVM as EVMTrait<AccountId>>::set_origin(MockAddressMapping::get_account_id(&alice_evm_addr()));
 			assert_ok!(Dex::add_provision(
 				RuntimeOrigin::signed(MockAddressMapping::get_account_id(&alice_evm_addr())),
 				CurrencyId::Erc20(erc20_address_0()),
@@ -765,7 +765,7 @@ fn test_default_evm_address_in_evm_accounts_module() {
 			assert!(EvmAccounts::evm_addresses(AccountId::from(ALICE)).is_some());
 
 			// get_or_create_evm_address
-			<EVM as EVMTrait<AccountId>>::push_origin(alice());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice());
 			assert_ok!(Currencies::transfer(
 				RuntimeOrigin::signed(EvmAddressMapping::<Runtime>::get_account_id(&alice_evm_addr())),
 				sp_runtime::MultiAddress::Id(AccountId::from(BOB)),
@@ -861,7 +861,7 @@ fn transaction_payment_module_works_with_evm_contract() {
 				0,
 			));
 
-			<EVM as EVMTrait<AccountId>>::push_origin(alice_evm_account.clone());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice_evm_account.clone());
 			assert_ok!(Dex::add_provision(
 				RuntimeOrigin::signed(alice_evm_account.clone()),
 				erc20_token,
@@ -875,7 +875,7 @@ fn transaction_payment_module_works_with_evm_contract() {
 			assert_eq!(Currencies::free_balance(dex_share, &alice_evm_account), 0);
 
 			// CurrencyId::DexShare(Erc20, ACA)
-			<EVM as EVMTrait<AccountId>>::push_origin(alice_evm_account.clone());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice_evm_account.clone());
 			assert_ok!(Dex::add_provision(
 				RuntimeOrigin::signed(alice_evm_account.clone()),
 				erc20_token,
@@ -1252,7 +1252,7 @@ fn honzon_works_with_evm_contract() {
 				.map(|n| n.saturating_mul_int(MinimumDebitValue::get()))
 				.unwrap();
 
-			<EVM as EVMTrait<AccountId>>::push_origin(alice_evm_account.clone());
+			<EVM as EVMTrait<AccountId>>::set_origin(alice_evm_account.clone());
 			// 1.Honzon::adjust_loan
 			assert_ok!(Honzon::adjust_loan(
 				RuntimeOrigin::signed(alice_evm_account.clone()),

--- a/runtime/integration-tests/src/relaychain/erc20.rs
+++ b/runtime/integration-tests/src/relaychain/erc20.rs
@@ -30,7 +30,7 @@ use module_support::EVM as EVMTrait;
 use orml_traits::MultiCurrency;
 use primitives::evm::EvmAddress;
 use runtime_common::precompile::XtokensPrecompile;
-use sp_core::{bounded::BoundedVec, H256, U256};
+use sp_core::{bounded::BoundedVec, defer, H256, U256};
 use std::str::FromStr;
 use xcm::VersionedMultiLocation;
 use xcm_emulator::TestExt;
@@ -171,6 +171,7 @@ fn erc20_transfer_between_sibling() {
 		// `set_origin`. In testcase, we're manual invoke `set_origin` here. because in erc20 xtokens
 		// transfer, the `from` or `to` is not erc20 holding account. so we need make sure origin exists.
 		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
+		defer!(<EVM as EVMTrait<AccountId>>::kill_origin());
 
 		assert_eq!(
 			Currencies::free_balance(CurrencyId::Erc20(erc20_address_0()), &alith),
@@ -393,7 +394,6 @@ fn sibling_erc20_to_self_as_foreign_asset() {
 		));
 
 		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
-
 		// use Currencies `transfer` dispatch call to transfer erc20 token to bob.
 		assert_ok!(Currencies::transfer(
 			RuntimeOrigin::signed(alith),
@@ -405,6 +405,7 @@ fn sibling_erc20_to_self_as_foreign_asset() {
 			Currencies::free_balance(CurrencyId::Erc20(erc20_address_0()), &AccountId::from(CHARLIE)),
 			1_000_000_000_000_000
 		);
+		<EVM as EVMTrait<AccountId>>::kill_origin();
 
 		// transfer erc20 token to Karura
 		assert_ok!(XTokens::transfer(
@@ -526,6 +527,7 @@ fn xtokens_precompile_works() {
 		// `set_origin`. In testcase, we're manual invoke `set_origin` here. because in erc20 xtokens
 		// transfer, the `from` or `to` is not erc20 holding account. so we need make sure origin exists.
 		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
+		defer!(<EVM as EVMTrait<AccountId>>::kill_origin());
 
 		assert_eq!(
 			Currencies::free_balance(CurrencyId::Erc20(erc20_address_0()), &alith),

--- a/runtime/integration-tests/src/relaychain/erc20.rs
+++ b/runtime/integration-tests/src/relaychain/erc20.rs
@@ -168,9 +168,9 @@ fn erc20_transfer_between_sibling() {
 
 		// `transfer` invoked by `TransferReserveAsset` xcm instruction need to passing origin check.
 		// In frontend/js, when issue xtokens extrinsic, it have `EvmSetOrigin` SignedExtra to
-		// `push_origin`. In testcase, we're manual invoke `push_origin` here. because in erc20 xtokens
+		// `set_origin`. In testcase, we're manual invoke `set_origin` here. because in erc20 xtokens
 		// transfer, the `from` or `to` is not erc20 holding account. so we need make sure origin exists.
-		<EVM as EVMTrait<AccountId>>::push_origin(alith.clone());
+		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
 
 		assert_eq!(
 			Currencies::free_balance(CurrencyId::Erc20(erc20_address_0()), &alith),
@@ -392,7 +392,7 @@ fn sibling_erc20_to_self_as_foreign_asset() {
 			EvmAccounts::eth_sign(&alice_key(), &AccountId::from(ALICE))
 		));
 
-		<EVM as EVMTrait<AccountId>>::push_origin(alith.clone());
+		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
 
 		// use Currencies `transfer` dispatch call to transfer erc20 token to bob.
 		assert_ok!(Currencies::transfer(
@@ -523,9 +523,9 @@ fn xtokens_precompile_works() {
 
 		// `transfer` invoked by `TransferReserveAsset` xcm instruction need to passing origin check.
 		// In frontend/js, when issue xtokens extrinsic, it have `EvmSetOrigin` SignedExtra to
-		// `push_origin`. In testcase, we're manual invoke `push_origin` here. because in erc20 xtokens
+		// `set_origin`. In testcase, we're manual invoke `set_origin` here. because in erc20 xtokens
 		// transfer, the `from` or `to` is not erc20 holding account. so we need make sure origin exists.
-		<EVM as EVMTrait<AccountId>>::push_origin(alith.clone());
+		<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
 
 		assert_eq!(
 			Currencies::free_balance(CurrencyId::Erc20(erc20_address_0()), &alith),

--- a/runtime/integration-tests/src/stable_asset.rs
+++ b/runtime/integration-tests/src/stable_asset.rs
@@ -214,7 +214,7 @@ fn three_usd_pool_works() {
 				EvmAccounts::eth_sign(&bob_key(), &AccountId::from(BOB))
 			));
 			// transfer USDC erc20 from alith to ALICE/BOB, used for swap
-			<EVM as EVMTrait<AccountId>>::push_origin(alith.clone());
+			<EVM as EVMTrait<AccountId>>::set_origin(alith.clone());
 			assert_ok!(Currencies::transfer(
 				RuntimeOrigin::signed(alith.clone()),
 				sp_runtime::MultiAddress::Id(AccountId::from(BOB)),


### PR DESCRIPTION
https://github.com/AcalaNetwork/Acala/blob/a5ae0685fd0a450b01091ca48fba06bdb6beaf48/runtime/common/src/xcm_impl.rs#L258-L261

https://github.com/AcalaNetwork/Acala/blob/a5ae0685fd0a450b01091ca48fba06bdb6beaf48/modules/currencies/src/lib.rs#L397

In the router example, the relayer calls the router contract and executes `xtokens.transfer`, the relayer is pushed in origin, and needs to pay the rent fee here.

In this case, the caller should always pay the rent. So it is divided into ExtrinsicOrigin and XcmOrigin