### PR TITLE
make mandala len fee consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,10 @@ test-evm: githooks
 
 .PHONY: test-runtimes
 test-runtimes:
-	SKIP_WASM_BUILD= cargo test --all --features with-all-runtime
-	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-mandala-runtime
-	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-karura-runtime
-	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-acala-runtime
+	SKIP_WASM_BUILD= cargo test --all --features with-all-runtime --lib
+	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-mandala-runtime --lib
+	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-karura-runtime --lib
+	SKIP_WASM_BUILD= cargo test -p runtime-integration-tests --features=with-acala-runtime --lib
 
 .PHONY: test-e2e
 test-e2e:

--- a/runtime/integration-tests/src/evm.rs
+++ b/runtime/integration-tests/src/evm.rs
@@ -970,21 +970,11 @@ fn transaction_payment_module_works_with_evm_contract() {
 				pays_fee: Pays::Yes,
 			};
 			let fee = module_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
-			#[cfg(feature = "with-mandala-runtime")]
-			assert_eq!(fee, 16_000_001_002);
-			#[cfg(feature = "with-karura-runtime")]
-			assert_eq!(fee, 2_500_001_002);
-			#[cfg(feature = "with-acala-runtime")]
 			assert_eq!(fee, 2_500_001_002);
 
 			let surplus_perc = Percent::from_percent(50); // CustomFeeSurplus
 			let fee_surplus = surplus_perc.mul_ceil(fee);
 			let fee = fee + fee_surplus;
-			#[cfg(feature = "with-mandala-runtime")]
-			assert_eq!(fee, 24_000_001_503);
-			#[cfg(feature = "with-karura-runtime")]
-			assert_eq!(fee, 3_750_001_503);
-			#[cfg(feature = "with-acala-runtime")]
 			assert_eq!(fee, 3_750_001_503);
 
 			// empty_account use payment non wrapped call to charge fee by erc20 fee pool.
@@ -999,7 +989,7 @@ fn transaction_payment_module_works_with_evm_contract() {
 			);
 			let erc20_fee = Currencies::free_balance(erc20_token, &sub_account);
 			#[cfg(feature = "with-mandala-runtime")]
-			assert_eq!(erc20_fee, 12_413_541_067);
+			assert_eq!(erc20_fee, 10_386_329_747);
 			#[cfg(feature = "with-karura-runtime")]
 			assert_eq!(erc20_fee, 10_407_164_913);
 			#[cfg(feature = "with-acala-runtime")]
@@ -1052,9 +1042,9 @@ fn transaction_payment_module_works_with_evm_contract() {
 			#[cfg(feature = "with-karura-runtime")]
 			let (erc20_with_fee, native_with_fee) = (376162732, 3750001503);
 			#[cfg(feature = "with-acala-runtime")]
-			let (erc20_with_fee, native_with_fee) = (376162732, 3750001503);
+			let (erc20_with_fee, native_with_fee) = (376162732, 376162732);
 			#[cfg(feature = "with-mandala-runtime")]
-			let (erc20_with_fee, native_with_fee) = (2402620973, 24000001503);
+			let (erc20_with_fee, native_with_fee) = (375409653, 3750001503);
 			assert_eq!(
 				Currencies::free_balance(erc20_token, &sub_account),
 				erc20_fee * 2 + erc20_with_fee

--- a/runtime/integration-tests/src/evm.rs
+++ b/runtime/integration-tests/src/evm.rs
@@ -1042,7 +1042,7 @@ fn transaction_payment_module_works_with_evm_contract() {
 			#[cfg(feature = "with-karura-runtime")]
 			let (erc20_with_fee, native_with_fee) = (376162732, 3750001503);
 			#[cfg(feature = "with-acala-runtime")]
-			let (erc20_with_fee, native_with_fee) = (376162732, 376162732);
+			let (erc20_with_fee, native_with_fee) = (376162732, 3750001503);
 			#[cfg(feature = "with-mandala-runtime")]
 			let (erc20_with_fee, native_with_fee) = (375409653, 3750001503);
 			assert_eq!(

--- a/runtime/integration-tests/src/payment.rs
+++ b/runtime/integration-tests/src/payment.rs
@@ -555,7 +555,7 @@ fn with_fee_call_works(
 			#[cfg(feature = "with-acala-runtime")]
 			let amount = 12_726_949_852u128;
 			#[cfg(feature = "with-mandala-runtime")]
-			let amount = 13_264_589_848u128;
+			let amount = 12_701_470_473u128;
 
 			System::assert_has_event(RuntimeEvent::Tokens(orml_tokens::Event::Transfer {
 				currency_id: USD_CURRENCY,

--- a/runtime/integration-tests/src/runtime.rs
+++ b/runtime/integration-tests/src/runtime.rs
@@ -369,11 +369,11 @@ mod mandala_only_tests {
 			} = fee.inclusion_fee.unwrap();
 
 			assert_eq!(base_fee, 1_000_000_000);
-			assert_eq!(len_fee, 500_000_000);
+			assert_eq!(len_fee, 50_000_000);
 			assert_eq!(adjusted_weight_fee, 20_943_510);
 
 			let total_fee = base_fee.saturating_add(len_fee).saturating_add(adjusted_weight_fee);
-			assert_eq!(total_fee, 1_520_943_510);
+			assert_eq!(total_fee, 1_070_943_510);
 		});
 	}
 
@@ -512,7 +512,7 @@ mod mandala_only_tests {
 						bytes.len()
 					),
 					Ok(ValidTransaction {
-						priority: 69_373_368_594_080_000,
+						priority: 62_850_168_594_080_000,
 						requires: vec![],
 						provides: vec![],
 						longevity: 18_446_744_073_709_551_615,

--- a/runtime/integration-tests/src/stable_asset.rs
+++ b/runtime/integration-tests/src/stable_asset.rs
@@ -600,7 +600,7 @@ fn three_usd_pool_works() {
 			#[cfg(any(feature = "with-karura-runtime", feature = "with-acala-runtime"))]
 			let (amount1, amount2) = (227_029_666u128, 2_250_002_477u128);
 			#[cfg(feature = "with-mandala-runtime")]
-			let (amount1, amount2) = (906_308_660u128, 9_000_001_503u128);
+			let (amount1, amount2) = (226_576_506, 2_250_002_467);
 			System::assert_has_event(RuntimeEvent::Dex(module_dex::Event::Swap {
 				trader: AccountId::from(BOB),
 				path: vec![USD_CURRENCY, NATIVE_CURRENCY],

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -344,7 +344,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub TransactionByteFee: Balance = 10 * millicent(ACA);
+	pub TransactionByteFee: Balance = millicent(ACA);
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);

--- a/ts-tests/tests/test-balance.ts
+++ b/ts-tests/tests/test-balance.ts
@@ -12,8 +12,8 @@ describeWithAcala("Acala RPC (Balance)", (context) => {
     });
 
     step("genesis balance is setup correctly", async function () {
-        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999985816987179000000");
-        expect((await context.provider.getBalance(alice.getAddress(), "latest")).toString()).to.equal("8999999985816987179000000");
+        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999995446987179000000");
+        expect((await context.provider.getBalance(alice.getAddress(), "latest")).toString()).to.equal("8999999995446987179000000");
 
         expect((await context.provider.getBalance(alice.getAddress(), "latest")).toString())
             .to.equal((await context.provider.api.query.system.account(alice.substrateAddress)).data.free.toString() + "000000");
@@ -22,13 +22,13 @@ describeWithAcala("Acala RPC (Balance)", (context) => {
     step("balance to be updated after transfer", async function () {
         this.timeout(15000);
 
-        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999985816987179000000");
-        expect((await context.provider.getBalance(alice_stash.getAddress())).toString()).to.equal("10100000985816993362000000");
+        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999995446987179000000");
+        expect((await context.provider.getBalance(alice_stash.getAddress())).toString()).to.equal("10100000995446993362000000");
 
         await transfer(context, alice.substrateAddress, alice_stash.substrateAddress, 1000);
-        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999968983298526000000");
-        expect((await context.provider.getBalance(alice_stash.getAddress())).toString()).to.equal("10100000985816994362000000");
-        expect((await context.provider.getBalance(alice.getAddress(), "latest")).toString()).to.equal("8999999968983298526000000");
+        expect((await context.provider.getBalance(alice.getAddress())).toString()).to.equal("8999999991393298526000000");
+        expect((await context.provider.getBalance(alice_stash.getAddress())).toString()).to.equal("10100000995446994362000000");
+        expect((await context.provider.getBalance(alice.getAddress(), "latest")).toString()).to.equal("8999999991393298526000000");
         expect((await context.provider.getBalance(alice_stash.getAddress(), "earliest")).toString()).to.equal("0");
     });
 });


### PR DESCRIPTION
mandala len fee is 10x than karura and acala (is there any particular reason for this?), I think we should make it consistent to avoid "passing on mandala, but failed on other two networks".

when testing eth_call v2 corner cases, it works with lowest fee tx on mandala, but now it fails on karura since karura's lowest fee tx is even lower :joy: