### PR TITLE
[XNFT PoC] xnft module - XCM asset transactor for module nft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5369,6 +5369,7 @@ dependencies = [
  "module-transaction-pause",
  "module-transaction-payment",
  "module-xcm-interface",
+ "module-xnft",
  "nutsfinance-stable-asset",
  "orml-auction",
  "orml-authority",
@@ -7351,6 +7352,25 @@ dependencies = [
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
+ "staging-xcm-executor",
+]
+
+[[package]]
+name = "module-xnft"
+version = "0.1.0-dev"
+dependencies = [
+ "acala-primitives",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "log",
+ "module-nft",
+ "orml-nft",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
  "staging-xcm-executor",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,7 @@ module-incentives = { path = "modules/incentives", default-features = false }
 module-liquid-crowdloan = { path = "modules/liquid-crowdloan", default-features = false }
 module-loans = { path = "modules/loans", default-features = false }
 module-nft = { path = "modules/nft", default-features = false }
+module-xnft = { path = "modules/xnft", default-features = false }
 module-nominees-election = { path = "modules/nominees-election", default-features = false }
 module-prices = { path = "modules/prices", default-features = false }
 module-relaychain = { path = "modules/relaychain", default-features = false }

--- a/modules/nft/src/lib.rs
+++ b/modules/nft/src/lib.rs
@@ -65,7 +65,7 @@ pub struct ClassData<Balance> {
 	pub attributes: Attributes,
 }
 
-#[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo, Serialize, Deserialize)]
+#[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo, Serialize, Deserialize, Default)]
 pub struct TokenData<Balance> {
 	/// Deposit reserved to create token
 	pub deposit: Balance,
@@ -388,7 +388,7 @@ pub mod module {
 
 impl<T: Config> Pallet<T> {
 	#[require_transactional]
-	fn do_transfer(from: &T::AccountId, to: &T::AccountId, token: (ClassIdOf<T>, TokenIdOf<T>)) -> DispatchResult {
+	pub fn do_transfer(from: &T::AccountId, to: &T::AccountId, token: (ClassIdOf<T>, TokenIdOf<T>)) -> DispatchResult {
 		let class_info = orml_nft::Pallet::<T>::classes(token.0).ok_or(Error::<T>::ClassIdNotFound)?;
 		let data = class_info.data;
 		ensure!(

--- a/modules/xnft/Cargo.toml
+++ b/modules/xnft/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "module-xnft"
+description = "XCM NFT PoC"
+version = "0.1.0-dev"
+authors = ["Unique Network Developers"]
+edition = "2021"
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+
+xcm = { package = "staging-xcm", workspace = true }
+xcm-executor = { package = "staging-xcm-executor", workspace = true }
+
+primitives = { workspace = true }
+
+module-nft = { workspace = true }
+orml-nft = { workspace = true }
+
+log = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"parity-scale-codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-runtime/std",
+	"scale-info/std",
+	"sp-std/std",
+	"xcm-executor/std",
+	"xcm/std",
+	"module-nft/std",
+	"orml-nft/std",
+	"cumulus-primitives-core/std",
+]
+try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime"]

--- a/modules/xnft/src/impl_transactor.rs
+++ b/modules/xnft/src/impl_transactor.rs
@@ -1,0 +1,138 @@
+// This file is part of Acala.
+
+// Copyright (C) 2023 Unique Network.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::*;
+
+const LOG_TARGET: &str = "xcm::module_xnft::transactor";
+
+impl<T: Config> TransactAsset for Pallet<T>
+where
+	TokenIdOf<T>: TryFrom<u128>,
+	ClassIdOf<T>: TryFrom<u128>,
+{
+	fn can_check_in(
+		_origin: &xcm::v3::MultiLocation,
+		_what: &MultiAsset,
+		_context: &xcm::v3::XcmContext,
+	) -> xcm::v3::Result {
+		Err(xcm::v3::Error::Unimplemented)
+	}
+
+	fn check_in(_origin: &xcm::v3::MultiLocation, _what: &MultiAsset, _context: &xcm::v3::XcmContext) {}
+
+	fn can_check_out(
+		_dest: &xcm::v3::MultiLocation,
+		_what: &MultiAsset,
+		_context: &xcm::v3::XcmContext,
+	) -> xcm::v3::Result {
+		Err(xcm::v3::Error::Unimplemented)
+	}
+
+	fn check_out(_dest: &xcm::v3::MultiLocation, _what: &MultiAsset, _context: &xcm::v3::XcmContext) {}
+
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &xcm::v3::MultiLocation,
+		context: Option<&xcm::v3::XcmContext>,
+	) -> XcmResult {
+		log::trace!(
+			target: LOG_TARGET,
+			"deposit_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			context,
+		);
+
+		let Fungibility::NonFungible(asset_instance) = what.fun else {
+			return Err(XcmExecutorError::AssetNotHandled.into());
+		};
+
+		let (class_id, is_foreign_asset) = Self::asset_to_collection(&what.id)?;
+
+		let to = <ConverterOf<T>>::convert_location(who).ok_or(XcmExecutorError::AccountIdConversionFailed)?;
+
+		let deposit_handler = if is_foreign_asset {
+			Self::deposit_foreign_asset
+		} else {
+			Self::deposit_local_asset
+		};
+
+		deposit_handler(&to, class_id, &asset_instance)
+	}
+
+	fn withdraw_asset(
+		what: &MultiAsset,
+		who: &xcm::v3::MultiLocation,
+		maybe_context: Option<&xcm::v3::XcmContext>,
+	) -> Result<xcm_executor::Assets, xcm::v3::Error> {
+		log::trace!(
+			target: LOG_TARGET,
+			"withdraw_asset what: {:?}, who: {:?}, maybe_context: {:?}",
+			what,
+			who,
+			maybe_context,
+		);
+
+		let Fungibility::NonFungible(asset_instance) = what.fun else {
+			return Err(XcmExecutorError::AssetNotHandled.into());
+		};
+
+		let (class_id, is_foreign_asset) = Self::asset_to_collection(&what.id)?;
+
+		let from = <ConverterOf<T>>::convert_location(who).ok_or(XcmExecutorError::AccountIdConversionFailed)?;
+
+		let token_id = Self::asset_instance_to_token_id(class_id, is_foreign_asset, &asset_instance)
+			.ok_or(XcmExecutorError::InstanceConversionFailed)?;
+
+		<ModuleNftPallet<T>>::do_transfer(&from, &Self::account_id(), (class_id, token_id))
+			.map(|_| what.clone().into())
+			.map_err(|_| XcmError::FailedToTransactAsset("non-fungible item withdraw failed"))
+	}
+
+	fn internal_transfer_asset(
+		asset: &MultiAsset,
+		from: &xcm::v3::MultiLocation,
+		to: &xcm::v3::MultiLocation,
+		context: &xcm::v3::XcmContext,
+	) -> Result<xcm_executor::Assets, xcm::v3::Error> {
+		log::trace!(
+			target: LOG_TARGET,
+			"internal_transfer_asset: {:?}, from: {:?}, to: {:?}, context: {:?}",
+			asset,
+			from,
+			to,
+			context
+		);
+
+		let Fungibility::NonFungible(asset_instance) = asset.fun else {
+			return Err(XcmExecutorError::AssetNotHandled.into());
+		};
+
+		let (class_id, is_foreign_asset) = Self::asset_to_collection(&asset.id)?;
+
+		let from = <ConverterOf<T>>::convert_location(from).ok_or(XcmExecutorError::AccountIdConversionFailed)?;
+		let to = <ConverterOf<T>>::convert_location(to).ok_or(XcmExecutorError::AccountIdConversionFailed)?;
+
+		let token_id = Self::asset_instance_to_token_id(class_id, is_foreign_asset, &asset_instance)
+			.ok_or(XcmExecutorError::InstanceConversionFailed)?;
+
+		<ModuleNftPallet<T>>::do_transfer(&from, &to, (class_id, token_id))
+			.map(|_| asset.clone().into())
+			.map_err(|_| XcmError::FailedToTransactAsset("non-fungible item internal transfer failed"))
+	}
+}

--- a/modules/xnft/src/lib.rs
+++ b/modules/xnft/src/lib.rs
@@ -1,0 +1,154 @@
+// This file is part of Acala.
+
+// Copyright (C) 2023 Unique Network.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::unused_unit)]
+
+use cumulus_primitives_core::ParaId;
+use frame_support::{ensure, pallet_prelude::*};
+use frame_system::pallet_prelude::*;
+use module_nft::{ClassIdOf, TokenIdOf};
+use sp_runtime::{traits::AccountIdConversion, DispatchResult};
+use sp_std::boxed::Box;
+use xcm::v3::{
+	AssetId, AssetInstance, Error as XcmError, Fungibility, InteriorMultiLocation, Junction::*, MultiAsset,
+	Result as XcmResult,
+};
+use xcm_executor::traits::{ConvertLocation, Error as XcmExecutorError, TransactAsset};
+
+pub mod impl_transactor;
+pub mod xcm_helpers;
+
+pub use pallet::*;
+
+pub type ConverterOf<T> = <T as Config>::LocationToAccountId;
+pub type ModuleNftPallet<T> = module_nft::Pallet<T>;
+pub type OrmlNftPallet<T> = orml_nft::Pallet<T>;
+
+#[frame_support::pallet]
+pub mod pallet {
+
+	use super::*;
+	use module_nft::WeightInfo as _;
+	use primitives::nft::{ClassProperty, Properties};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + module_nft::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type LocationToAccountId: ConvertLocation<Self::AccountId>;
+
+		type SelfParaId: Get<ParaId>;
+
+		type NtfPalletLocation: Get<InteriorMultiLocation>;
+
+		type RegisterOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+	}
+
+	/// Error for non-fungible-token module.
+	#[pallet::error]
+	pub enum Error<T> {
+		AssetAlreadyRegistered,
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
+	pub enum Event<T: Config> {
+		AssetRegistered {
+			asset_id: Box<AssetId>,
+			collection_id: ClassIdOf<T>,
+		},
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn foreign_asset_to_class)]
+	pub type ForeignAssetToClass<T: Config> = StorageMap<_, Twox64Concat, xcm::v3::AssetId, ClassIdOf<T>, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn class_to_foreign_asset)]
+	pub type ClassToForeignAsset<T: Config> = StorageMap<_, Twox64Concat, ClassIdOf<T>, xcm::v3::AssetId, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn asset_instance_to_item)]
+	pub type AssetInstanceToItem<T: Config> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		ClassIdOf<T>,
+		Twox64Concat,
+		xcm::v3::AssetInstance,
+		TokenIdOf<T>,
+		OptionQuery,
+	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn item_to_asset_instance)]
+	pub type ItemToAssetInstance<T: Config> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		ClassIdOf<T>,
+		Twox64Concat,
+		TokenIdOf<T>,
+		xcm::v3::AssetInstance,
+		OptionQuery,
+	>;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::from_parts(1_000_000, 0)
+			.saturating_add(<module_nft::weights::AcalaWeight<T>>::create_class())
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(2)))]
+		pub fn register_asset(origin: OriginFor<T>, foreign_asset: Box<AssetId>) -> DispatchResult {
+			T::RegisterOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				!<ForeignAssetToClass<T>>::contains_key(foreign_asset.as_ref()),
+				<Error<T>>::AssetAlreadyRegistered,
+			);
+
+			let properties =
+				Properties(ClassProperty::Mintable | ClassProperty::Burnable | ClassProperty::Transferable);
+			let data = module_nft::ClassData {
+				deposit: Default::default(),
+				properties,
+				attributes: Default::default(),
+			};
+			let collection_id = orml_nft::Pallet::<T>::create_class(&Self::account_id(), Default::default(), data)?;
+
+			<ForeignAssetToClass<T>>::insert(foreign_asset.as_ref(), collection_id);
+			<ClassToForeignAsset<T>>::insert(collection_id, foreign_asset.as_ref());
+
+			Self::deposit_event(Event::AssetRegistered {
+				asset_id: foreign_asset,
+				collection_id,
+			});
+
+			Ok(())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	pub fn account_id() -> T::AccountId {
+		frame_support::PalletId(*b"poc_xnft").into_account_truncating()
+	}
+}

--- a/modules/xnft/src/lib.rs
+++ b/modules/xnft/src/lib.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::unused_unit)]
 
 use cumulus_primitives_core::ParaId;
-use frame_support::{ensure, pallet_prelude::*};
+use frame_support::{ensure, pallet_prelude::*, PalletId};
 use frame_system::pallet_prelude::*;
 use module_nft::{ClassIdOf, TokenIdOf};
 use sp_runtime::{traits::AccountIdConversion, DispatchResult};
@@ -50,6 +50,8 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config + module_nft::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type PalletId: Get<PalletId>;
 
 		type LocationToAccountId: ConvertLocation<Self::AccountId>;
 
@@ -149,6 +151,6 @@ pub mod pallet {
 
 impl<T: Config> Pallet<T> {
 	pub fn account_id() -> T::AccountId {
-		frame_support::PalletId(*b"poc_xnft").into_account_truncating()
+		<T as Config>::PalletId::get().into_account_truncating()
 	}
 }

--- a/modules/xnft/src/xcm_helpers.rs
+++ b/modules/xnft/src/xcm_helpers.rs
@@ -1,0 +1,97 @@
+// This file is part of Acala.
+
+// Copyright (C) 2023 Unique Network.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::*;
+use xcm::v3::AssetId::Concrete;
+use xcm_executor::traits::Error as MatchError;
+
+impl<T: Config> Pallet<T>
+where
+	TokenIdOf<T>: TryFrom<u128>,
+	ClassIdOf<T>: TryFrom<u128>,
+{
+	pub fn asset_to_collection(asset: &AssetId) -> Result<(ClassIdOf<T>, bool), MatchError> {
+		Self::foreign_asset_to_class(asset)
+			.map(|a| (a, true))
+			.or_else(|| Self::local_asset_to_class(asset).map(|a| (a, false)))
+			.ok_or(MatchError::AssetIdConversionFailed)
+	}
+
+	fn local_asset_to_class(asset: &AssetId) -> Option<ClassIdOf<T>> {
+		let Concrete(asset_location) = asset else {
+			return None;
+		};
+
+		let prefix = if asset_location.parents == 0 {
+			T::NtfPalletLocation::get()
+		} else if asset_location.parents == 1 {
+			T::NtfPalletLocation::get()
+				.pushed_front_with(Parachain(T::SelfParaId::get().into()))
+				.ok()?
+		} else {
+			return None;
+		};
+
+		match asset_location.interior.match_and_split(&prefix) {
+			Some(GeneralIndex(index)) => {
+				let class_id = (*index).try_into().ok()?;
+				Self::class_to_foreign_asset(class_id).is_none().then_some(class_id)
+			}
+			_ => None,
+		}
+	}
+
+	pub fn deposit_foreign_asset(to: &T::AccountId, asset: ClassIdOf<T>, asset_instance: &AssetInstance) -> XcmResult {
+		match Self::asset_instance_to_item(asset, asset_instance) {
+			Some(token_id) => <ModuleNftPallet<T>>::do_transfer(&Self::account_id(), to, (asset, token_id))
+				.map_err(|_| XcmError::FailedToTransactAsset("non-fungible foreign item deposit failed")),
+			None => {
+				let token_id = <OrmlNftPallet<T>>::mint(to, asset, Default::default(), Default::default())
+					.map_err(|_| XcmError::FailedToTransactAsset("non-fungible new foreign item deposit failed"))?;
+				<AssetInstanceToItem<T>>::insert(asset, asset_instance, token_id);
+				<ItemToAssetInstance<T>>::insert(asset, token_id, asset_instance);
+				Ok(())
+			}
+		}
+	}
+
+	pub fn deposit_local_asset(to: &T::AccountId, asset: ClassIdOf<T>, asset_instance: &AssetInstance) -> XcmResult {
+		let token_id = Self::convert_asset_instance(asset_instance)?;
+		<ModuleNftPallet<T>>::do_transfer(&Self::account_id(), to, (asset, token_id))
+			.map_err(|_| XcmError::FailedToTransactAsset("non-fungible local item deposit failed"))
+	}
+
+	pub fn asset_instance_to_token_id(
+		class_id: ClassIdOf<T>,
+		is_foreign_asset: bool,
+		asset_instance: &AssetInstance,
+	) -> Option<TokenIdOf<T>> {
+		match is_foreign_asset {
+			true => Self::asset_instance_to_item(class_id, asset_instance),
+			false => Self::convert_asset_instance(asset_instance).ok(),
+		}
+	}
+
+	fn convert_asset_instance(asset: &AssetInstance) -> Result<TokenIdOf<T>, MatchError> {
+		let AssetInstance::Index(index) = asset else {
+			return Err(MatchError::InstanceConversionFailed);
+		};
+
+		(*index).try_into().map_err(|_| MatchError::InstanceConversionFailed)
+	}
+}

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -25,6 +25,7 @@ fn main() {
 			"../../evm-tests",
 			"../../ecosystem-modules/stable-asset",
 			"../../launch",
+			"../../modules/xnft",
 			"../../orml",
 			"../../predeploy-contracts",
 			"../../ts-tests",

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -351,6 +351,9 @@ pub type EnsureRootOrThreeFourthsTechnicalCommittee = EitherOfDiverse<
 	pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 3, 4>,
 >;
 
+pub type EnsureRootOrOneTechnicalCommittee =
+	EitherOfDiverse<EnsureRoot<AccountId>, pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>>;
+
 /// The type used to represent the kinds of proxying allowed.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub enum ProxyType {

--- a/runtime/karura/Cargo.toml
+++ b/runtime/karura/Cargo.toml
@@ -122,6 +122,7 @@ module-support = { workspace = true }
 module-transaction-pause = { workspace = true }
 module-transaction-payment = { workspace = true }
 module-xcm-interface = { workspace = true }
+module-xnft = { workspace = true }
 
 primitives = { workspace = true }
 runtime-common = { workspace = true }
@@ -257,6 +258,7 @@ std = [
 	"module-transaction-pause/std",
 	"module-transaction-payment/std",
 	"module-xcm-interface/std",
+	"module-xnft/std",
 
 	"primitives/std",
 	"runtime-common/std",

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -31,6 +31,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
+use runtime_common::EnsureRootOrOneTechnicalCommittee;
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -1333,6 +1334,14 @@ impl orml_nft::Config for Runtime {
 	type MaxTokenMetadata = ConstU32<1024>;
 }
 
+impl module_xnft::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type LocationToAccountId = xcm_config::LocationToAccountId;
+	type SelfParaId = ParachainInfo;
+	type NtfPalletLocation = xcm_config::NftPalletLocation;
+	type RegisterOrigin = EnsureRootOrOneTechnicalCommittee;
+}
+
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
@@ -1833,6 +1842,7 @@ construct_runtime!(
 		Incentives: module_incentives = 120,
 		NFT: module_nft = 121,
 		AssetRegistry: module_asset_registry = 122,
+		XNFT: module_xnft = 123,
 
 		// Smart contracts
 		EVM: module_evm = 130,

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -175,6 +175,7 @@ parameter_types! {
 	// Treasury reserve
 	pub const TreasuryReservePalletId: PalletId = PalletId(*b"aca/reve");
 	pub const NftPalletId: PalletId = PalletId(*b"aca/aNFT");
+	pub const XnftPalletId: PalletId = PalletId(*b"aca/xNFT");
 	// Vault all unrleased native token.
 	pub UnreleasedNativeVaultAccountId: AccountId = PalletId(*b"aca/urls").into_account_truncating();
 	// This Pallet is only used to payment fee pool, it's not added to whitelist by design.
@@ -1336,6 +1337,7 @@ impl orml_nft::Config for Runtime {
 
 impl module_xnft::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type PalletId = XnftPalletId;
 	type LocationToAccountId = xcm_config::LocationToAccountId;
 	type SelfParaId = ParachainInfo;
 	type NtfPalletLocation = xcm_config::NftPalletLocation;

--- a/runtime/karura/src/xcm_config.rs
+++ b/runtime/karura/src/xcm_config.rs
@@ -21,7 +21,7 @@ use super::{
 	AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert, Currencies, CurrencyId,
 	EvmAddressMapping, ExistentialDeposits, FixedRateOfAsset, GetNativeCurrencyId, KaruraTreasuryAccount,
 	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, KAR, KUSD, LKSM, TAI,
+	RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, KAR, KUSD, LKSM, TAI, XNFT,
 };
 use cumulus_primitives_core::ParaId;
 use frame_support::{
@@ -47,6 +47,7 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainInfo::parachain_id().into()));
+	pub NftPalletLocation: InteriorMultiLocation = X1(PalletInstance(121));
 	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
 
@@ -298,16 +299,19 @@ impl orml_xtokens::Config for Runtime {
 	type ReserveProvider = AbsoluteReserveProvider;
 }
 
-pub type LocalAssetTransactor = MultiCurrencyAdapter<
-	Currencies,
-	UnknownTokens,
-	IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
-	AccountId,
-	LocationToAccountId,
-	CurrencyId,
-	CurrencyIdConvert,
-	DepositToAlternative<KaruraTreasuryAccount, Currencies, CurrencyId, AccountId, Balance>,
->;
+pub type LocalAssetTransactor = (
+	XNFT,
+	MultiCurrencyAdapter<
+		Currencies,
+		UnknownTokens,
+		IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
+		AccountId,
+		LocationToAccountId,
+		CurrencyId,
+		CurrencyIdConvert,
+		DepositToAlternative<KaruraTreasuryAccount, Currencies, CurrencyId, AccountId, Balance>,
+	>,
+);
 
 pub struct CurrencyIdConvert;
 


### PR DESCRIPTION
This PR adds a new `xnft` module.
This module serves as a PoC of the XCM NFT Asset Transactor on Karura. This code will be used as a base to implement a more general Asset Transactor for Substrate chains.

### Foreign Collection Registration
* To keep things simple in the PoC, a foreign NFT collection can be registered manually by a technical committee member invoking the `xnft.registerAsset` extrinsic. In the future, we need to come up with a mechanism that will allow an owner of an original collection on a remote chain to register the corresponding foreign collection themselves without involving a governance body. 

### Notes:
* `xnft` holds the mapping between the XCM identification of an NFT asset and the local identification in the `nft` module.
The mapping is bidirectional, though only one side is used now. The backward mapping can be used in the future for extrinsics like `xtokens.transfer` where we identify assets using parachain-local IDs.
* `xnft` pallet account serves as the location for NFTs when they are located in the Holding Register to avoid burning an NFT and losing the associated data.
* Also, the `xnft` pallet account will hold a derivative of an NFT when the original NFT is transferred elsewhere instead of burning the derivative. This serves two goals:
    * If the original NFT returns, it will correspond to the same derivative NFT with the same Karura-local ID.
    * Suppose the reserve chain erroneously sends the `ReserveAssetDeposited` containing an NFT that was already present on Karura. In that case, it will fail due to the failed transfer from the xnft module account to the beneficiary because the derivative NFT will belong to someone else's account, avoiding creating a duplicate.

### Tests
The common tests are located in the [xnft-tests](https://github.com/uniqueNetwork/xnft-tests) repository.