### PR TITLE
feat: align derivation accross ecosystem 

### DIFF
--- a/runtime/common/src/xcm_config.rs
+++ b/runtime/common/src/xcm_config.rs
@@ -27,9 +27,9 @@ use polkadot_parachain_primitives::primitives::Sibling;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
-	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit, TrailingSetTopicAsId,
-	WithComputedOrigin,
+	DescribeAllTerminal, DescribeFamily, HashedDescription, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative, SovereignSignedViaLocation,
+	TakeRevenue, TakeWeightCredit, TrailingSetTopicAsId, WithComputedOrigin,
 };
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -44,6 +44,8 @@ pub type LocationToAccountId<RelayNetwork, EvmAddressMapping> = (
 	AccountId32Aliases<RelayNetwork, AccountId>,
 	// Convert `AccountKey20` to `AccountId`
 	AccountKey20Aliases<RelayNetwork, AccountId, EvmAddressMapping>,
+	// Generate remote accounts according to polkadot standards
+	HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
 );
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `RuntimeOrigin`


### PR DESCRIPTION
## Description
Currently, there is no common ecosystem wide approach to derive accounts from xcm-origins. This PR adds a converter both used by 
* [Kusama Asset-Hub](https://github.com/polkadot-fellows/runtimes/blob/b8df4b06c78fb2fb2d0f081c76e30569f12363c6/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs#L91)
* [Centrifuge](https://github.com/centrifuge/centrifuge-chain/blob/93ace412bc269522916cc191caede54733921fa0/runtime/centrifuge/src/xcm.rs#L322)
* [Moonbeam](https://github.com/moonbeam-foundation/moonbeam/blob/3d6eb4e1de334c3259631ac15373e130c48c00af/runtime/moonbeam/src/xcm_config.rs#L111)

The converter was introduced by [Gavin Wood](https://github.com/paritytech/polkadot/pull/7329) in order to create a general purpose conversion. The idea behind this converter is that a user `User1` from `ChainA` has the ability to have a unique account on any other chain in the ecosystem. This so called remote account can only be controlled from `User1` from `ChainA`.

## Motivation and Context
Allows to have remote accounts on Acala for all purposes a native account could be used. Especially useful for when we do not want to deteriorate UX by switching networks in the UI.
 
## How Has This Been Tested?
In production at Centrifuge and Moonbeam for quite some time.

