### PR TITLE
Update oracle.rs

### DIFF
--- a/runtime/common/src/precompile/oracle.rs
+++ b/runtime/common/src/precompile/oracle.rs
@@ -76,7 +76,7 @@ where
 					}
 				};
 
-				let maybe_adjustment_multiplier = 10u128.checked_pow((18 - decimals).into());
+				let maybe_adjustment_multiplier = 10u128.checked_pow((18u8.saturating_sub(decimals)).into());
 				let adjustment_multiplier = match maybe_adjustment_multiplier {
 					Some(adjustment_multiplier) => adjustment_multiplier,
 					None => {


### PR DESCRIPTION
In the ERC20 interface, the maximum number of decimals is 18, but it is better to use `saturating_sub`