### PR TITLE
fix: typos in documentation files

### DIFF
--- a/runtime/integration-tests/src/honzon.rs
+++ b/runtime/integration-tests/src/honzon.rs
@@ -544,7 +544,7 @@ fn test_cdp_engine_module() {
 		});
 }
 
-// Honzon's surplus can be transfered and DebitExchangeRate updates accordingly
+// Honzon's surplus can be transferred and DebitExchangeRate updates accordingly
 #[test]
 fn cdp_treasury_handles_honzon_surplus_correctly() {
 	ExtBuilder::default()
@@ -615,7 +615,7 @@ fn cdp_treasury_handles_honzon_surplus_correctly() {
 			// Empty treasury recieves stablecoins into surplus pool from loan
 			assert_eq!(CdpTreasury::get_surplus_pool(), 270716741782);
 			assert_eq!(CdpTreasury::get_debit_pool(), 0);
-			// Honzon generated cdp treasury surplus can be transfered
+			// Honzon generated cdp treasury surplus can be transferred
 			assert_eq!(Currencies::free_balance(USD_CURRENCY, &AccountId::from(BOB)), 0);
 			assert_eq!(
 				CdpEngine::debit_exchange_rate(RELAY_CHAIN_CURRENCY),

--- a/runtime/mandala/src/benchmarking/authority.rs
+++ b/runtime/mandala/src/benchmarking/authority.rs
@@ -46,7 +46,7 @@ runtime_benchmarks! {
 	dispatch_as {
 	}: _(RawOrigin::Root, AuthoritysOriginId::Root, runtime_call())
 
-	// schdule a dispatchable to be dispatched at later block.
+	// schedule a dispatchable to be dispatched at later block.
 	schedule_dispatch_without_delay {
 		let call = RuntimeCall::Authority(orml_authority::Call::dispatch_as {
 			as_origin: AuthoritysOriginId::Root,
@@ -54,7 +54,7 @@ runtime_benchmarks! {
 		});
 	}: schedule_dispatch(RawOrigin::Root, DispatchTime::At(2), 0, false, bounded_call(call))
 
-	// schdule a dispatchable to be dispatched at later block.
+	// schedule a dispatchable to be dispatched at later block.
 	// ensure that the delay is reached when scheduling
 	schedule_dispatch_with_delay {
 		let call = RuntimeCall::Authority(orml_authority::Call::dispatch_as {


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `transfered` to `transferred` x2
Corrected `schdule` to `schedule`

Please review the changes and let me know if any additional changes are needed.