### PR TITLE
fix: Remove Unnecessary Semicolons in Variable Assignments

### DIFF
--- a/scripts/srtool-build.sh
+++ b/scripts/srtool-build.sh
@@ -3,8 +3,8 @@
 set -xe
 
 RUSTC_VERSION=`curl -s https://raw.githubusercontent.com/paritytech/srtool/master/RUSTC_VERSION`
-PACKAGE=$PACKAGE;
-BUILD_OPTS=$BUILD_OPTS;
+PACKAGE=$PACKAGE
+BUILD_OPTS=$BUILD_OPTS
 PROFILE=$PROFILE
 
 docker run --rm -it -e WASM_BUILD_STD=0 -e PROFILE=$PROFILE -e PACKAGE=$PACKAGE -e BUILD_OPTS="$BUILD_OPTS" -v $PWD:/build -v $TMPDIR/cargo:/cargo-home paritytech/srtool:$RUSTC_VERSION $*


### PR DESCRIPTION
While reviewing the code, I noticed that semicolons (`;`) were being used in simple variable assignments like:  

```bash
PACKAGE=$PACKAGE;  
BUILD_OPTS=$BUILD_OPTS;  
```  

These semicolons are unnecessary because they don't signify the end of a command in this context.
Their presence could lead to confusion or errors for other developers maintaining the script.  
