### PR TITLE
Improve transaction payment and DEX swap

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TARPAULIN_VERSION: 0.31.2
+  TARPAULIN_VERSION: 0.31.4
   CARGO_INCREMENTAL: 0
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Install deps
-        run: cargo install staging-chain-spec-builder
+        run: cargo install staging-chain-spec-builder --force
       - name: Run ts tests
         run: |
           npm install -g yarn

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,6 @@ bench-evm:
 
 .PHONY: tools
 tools:
-	cargo install staging-chain-spec-builder --force
-	cargo install frame-omni-bencher --force
-	cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.7.0 --force
+	cargo install staging-chain-spec-builder
+	cargo install frame-omni-bencher
+	cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.7.0

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,6 @@ bench-evm:
 
 .PHONY: tools
 tools:
-	cargo install staging-chain-spec-builder
-	cargo install frame-omni-bencher
-	cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.7.0
+	cargo install staging-chain-spec-builder --force
+	cargo install frame-omni-bencher --force
+	cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.7.0 --force

--- a/modules/aggregated-dex/src/mock.rs
+++ b/modules/aggregated-dex/src/mock.rs
@@ -41,6 +41,7 @@ mod aggregated_dex {
 
 pub const ALICE: AccountId = AccountId32::new([1u8; 32]);
 pub const BOB: AccountId = AccountId32::new([2u8; 32]);
+pub const ACA: CurrencyId = CurrencyId::Token(TokenSymbol::ACA);
 pub const AUSD: CurrencyId = CurrencyId::Token(TokenSymbol::AUSD);
 pub const DOT: CurrencyId = CurrencyId::Token(TokenSymbol::DOT);
 pub const LDOT: CurrencyId = CurrencyId::Token(TokenSymbol::LDOT);
@@ -81,6 +82,7 @@ ord_parameter_types! {
 parameter_types! {
 	pub const DEXPalletId: PalletId = PalletId(*b"aca/dexm");
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
+	pub const GetNativeCurrencyId: CurrencyId = ACA;
 	pub EnabledTradingPairs: Vec<TradingPair> = vec![];
 }
 
@@ -90,6 +92,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = ConstU32<4>;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = ();
 	type DEXIncentives = ();
 	type WeightInfo = ();

--- a/modules/auction-manager/src/lib.rs
+++ b/modules/auction-manager/src/lib.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::unnecessary_unwrap)]
 
-use frame_support::{pallet_prelude::*, transactional};
+use frame_support::{pallet_prelude::*, traits::ExistenceRequirement, transactional};
 use frame_system::{
 	offchain::{SendTransactionTypes, SubmitTransaction},
 	pallet_prelude::*,
@@ -554,7 +554,13 @@ impl<T: Config> Pallet<T> {
 				// if there's bid before, return stablecoin from new bidder to last bidder
 				if let Some(last_bidder) = last_bidder {
 					let refund = collateral_auction.payment_amount(last_bid_price);
-					T::Currency::transfer(T::GetStableCurrencyId::get(), &new_bidder, last_bidder, refund)?;
+					T::Currency::transfer(
+						T::GetStableCurrencyId::get(),
+						&new_bidder,
+						last_bidder,
+						refund,
+						ExistenceRequirement::AllowDeath,
+					)?;
 
 					payment = payment
 						.checked_sub(refund)

--- a/modules/auction-manager/src/mock.rs
+++ b/modules/auction-manager/src/mock.rs
@@ -45,6 +45,7 @@ pub type Amount = i64;
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 pub const CAROL: AccountId = 3;
+pub const ACA: CurrencyId = CurrencyId::Token(TokenSymbol::ACA);
 pub const AUSD: CurrencyId = CurrencyId::Token(TokenSymbol::AUSD);
 pub const BTC: CurrencyId = CurrencyId::ForeignAsset(255);
 pub const DOT: CurrencyId = CurrencyId::Token(TokenSymbol::DOT);
@@ -141,6 +142,7 @@ impl PriceProvider<CurrencyId> for MockPriceSource {
 parameter_types! {
 	pub const DEXPalletId: PalletId = PalletId(*b"aca/dexm");
 	pub const GetExchangeFee: (u32, u32) = (0, 100);
+	pub const GetNativeCurrencyId: CurrencyId = ACA;
 	pub EnabledTradingPairs: Vec<TradingPair> = vec![
 		TradingPair::from_currency_ids(AUSD, BTC).unwrap(),
 		TradingPair::from_currency_ids(DOT, BTC).unwrap(),
@@ -154,6 +156,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = ConstU32<4>;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = ();
 	type DEXIncentives = ();
 	type WeightInfo = ();

--- a/modules/cdp-engine/src/lib.rs
+++ b/modules/cdp-engine/src/lib.rs
@@ -28,7 +28,9 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::upper_case_acronyms)]
 
-use frame_support::{pallet_prelude::*, traits::UnixTime, transactional, BoundedVec, PalletId};
+use frame_support::{
+	pallet_prelude::*, traits::ExistenceRequirement, traits::UnixTime, transactional, BoundedVec, PalletId,
+};
 use frame_system::{
 	offchain::{SendTransactionTypes, SubmitTransaction},
 	pallet_prelude::*,
@@ -1014,10 +1016,22 @@ impl<T: Config> Pallet<T> {
 
 				// refund unused lp component tokens
 				if let Some(remainer) = available_0.checked_sub(consumption_0) {
-					<T as Config>::Currency::transfer(token_0, &loans_module_account, who, remainer)?;
+					<T as Config>::Currency::transfer(
+						token_0,
+						&loans_module_account,
+						who,
+						remainer,
+						ExistenceRequirement::AllowDeath,
+					)?;
 				}
 				if let Some(remainer) = available_1.checked_sub(consumption_1) {
-					<T as Config>::Currency::transfer(token_1, &loans_module_account, who, remainer)?;
+					<T as Config>::Currency::transfer(
+						token_1,
+						&loans_module_account,
+						who,
+						remainer,
+						ExistenceRequirement::AllowDeath,
+					)?;
 				}
 
 				actual_increase_lp
@@ -1119,6 +1133,7 @@ impl<T: Config> Pallet<T> {
 				&loans_module_account,
 				who,
 				actual_stable_amount.saturating_sub(previous_debit_value),
+				ExistenceRequirement::AllowDeath,
 			)?;
 
 			(previous_debit_value, debit)
@@ -1484,7 +1499,13 @@ impl<T: Config> LiquidateCollateral<T::AccountId> for LiquidateViaContracts<T> {
 					return Ok(());
 				} else if repayment > 0 {
 					// insufficient repayment, refund
-					CurrencyOf::<T>::transfer(stable_coin, &repay_dest_account_id, &contract_account_id, repayment)?;
+					CurrencyOf::<T>::transfer(
+						stable_coin,
+						&repay_dest_account_id,
+						&contract_account_id,
+						repayment,
+						ExistenceRequirement::AllowDeath,
+					)?;
 					// notify liquidation failed
 					T::LiquidationEvmBridge::on_repayment_refund(
 						InvokeContext {

--- a/modules/cdp-engine/src/mock.rs
+++ b/modules/cdp-engine/src/mock.rs
@@ -242,6 +242,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = ConstU32<4>;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = ();
 	type DEXIncentives = ();
 	type WeightInfo = ();

--- a/modules/cdp-treasury/src/lib.rs
+++ b/modules/cdp-treasury/src/lib.rs
@@ -29,7 +29,7 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::needless_range_loop)]
 
-use frame_support::{pallet_prelude::*, transactional, PalletId};
+use frame_support::{pallet_prelude::*, traits::ExistenceRequirement, transactional, PalletId};
 use frame_system::pallet_prelude::*;
 use module_support::{AuctionManager, CDPTreasury, CDPTreasuryExtended, DEXManager, Ratio, Swap, SwapLimit};
 use nutsfinance_stable_asset::traits::StableAsset;
@@ -194,6 +194,7 @@ pub mod module {
 				&Self::account_id(),
 				&T::TreasuryAccount::get(),
 				amount,
+				ExistenceRequirement::AllowDeath,
 			)?;
 			Ok(())
 		}
@@ -391,23 +392,52 @@ impl<T: Config> CDPTreasury<T::AccountId> for Pallet<T> {
 
 	/// This should be the only function in the system that burns stable coin
 	fn burn_debit(who: &T::AccountId, debit: Self::Balance) -> DispatchResult {
-		T::Currency::withdraw(T::GetStableCurrencyId::get(), who, debit)
+		T::Currency::withdraw(
+			T::GetStableCurrencyId::get(),
+			who,
+			debit,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn deposit_surplus(from: &T::AccountId, surplus: Self::Balance) -> DispatchResult {
-		T::Currency::transfer(T::GetStableCurrencyId::get(), from, &Self::account_id(), surplus)
+		T::Currency::transfer(
+			T::GetStableCurrencyId::get(),
+			from,
+			&Self::account_id(),
+			surplus,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn withdraw_surplus(to: &T::AccountId, surplus: Self::Balance) -> DispatchResult {
-		T::Currency::transfer(T::GetStableCurrencyId::get(), &Self::account_id(), to, surplus)
+		T::Currency::transfer(
+			T::GetStableCurrencyId::get(),
+			&Self::account_id(),
+			to,
+			surplus,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn deposit_collateral(from: &T::AccountId, currency_id: Self::CurrencyId, amount: Self::Balance) -> DispatchResult {
-		T::Currency::transfer(currency_id, from, &Self::account_id(), amount)
+		T::Currency::transfer(
+			currency_id,
+			from,
+			&Self::account_id(),
+			amount,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn withdraw_collateral(to: &T::AccountId, currency_id: Self::CurrencyId, amount: Self::Balance) -> DispatchResult {
-		T::Currency::transfer(currency_id, &Self::account_id(), to, amount)
+		T::Currency::transfer(
+			currency_id,
+			&Self::account_id(),
+			to,
+			amount,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 }
 

--- a/modules/cdp-treasury/src/mock.rs
+++ b/modules/cdp-treasury/src/mock.rs
@@ -128,6 +128,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = ConstU32<4>;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = ();
 	type DEXIncentives = ();
 	type WeightInfo = ();

--- a/modules/currencies/src/tests.rs
+++ b/modules/currencies/src/tests.rs
@@ -471,7 +471,12 @@ fn native_currency_should_work() {
 			assert_eq!(NativeCurrency::free_balance(&alice()), 50);
 			assert_eq!(NativeCurrency::free_balance(&bob()), 150);
 
-			assert_ok!(NativeCurrency::transfer(&alice(), &bob(), 10));
+			assert_ok!(NativeCurrency::transfer(
+				&alice(),
+				&bob(),
+				10,
+				ExistenceRequirement::AllowDeath
+			));
 			assert_eq!(NativeCurrency::free_balance(&alice()), 40);
 			assert_eq!(NativeCurrency::free_balance(&bob()), 160);
 
@@ -505,12 +510,22 @@ fn basic_currency_adapting_pallet_balances_transfer() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(AdaptedBasicCurrency::transfer(&alice(), &bob(), 50));
+			assert_ok!(AdaptedBasicCurrency::transfer(
+				&alice(),
+				&bob(),
+				50,
+				ExistenceRequirement::AllowDeath
+			));
 			assert_eq!(PalletBalances::total_balance(&alice()), 50);
 			assert_eq!(PalletBalances::total_balance(&bob()), 150);
 
 			// creation fee
-			assert_ok!(AdaptedBasicCurrency::transfer(&alice(), &eva(), 10));
+			assert_ok!(AdaptedBasicCurrency::transfer(
+				&alice(),
+				&eva(),
+				10,
+				ExistenceRequirement::AllowDeath
+			));
 			assert_eq!(PalletBalances::total_balance(&alice()), 40);
 			assert_eq!(PalletBalances::total_balance(&eva()), 10);
 		});
@@ -554,7 +569,11 @@ fn basic_currency_adapting_pallet_balances_withdraw() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(AdaptedBasicCurrency::withdraw(&alice(), 100));
+			assert_ok!(AdaptedBasicCurrency::withdraw(
+				&alice(),
+				100,
+				ExistenceRequirement::AllowDeath
+			));
 			assert_eq!(PalletBalances::total_balance(&alice()), 0);
 			assert_eq!(PalletBalances::total_issuance(), 100);
 		});
@@ -645,7 +664,8 @@ fn call_event_should_work() {
 				X_TOKEN_ID,
 				&alice(),
 				&bob(),
-				10
+				10,
+				ExistenceRequirement::AllowDeath
 			));
 			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &alice()), 40);
 			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &bob()), 160);
@@ -677,7 +697,8 @@ fn call_event_should_work() {
 			assert_ok!(<Currencies as MultiCurrency<AccountId>>::withdraw(
 				X_TOKEN_ID,
 				&alice(),
-				20
+				20,
+				ExistenceRequirement::AllowDeath
 			));
 			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &alice()), 120);
 			System::assert_last_event(RuntimeEvent::Tokens(orml_tokens::Event::Withdrawn {
@@ -1231,7 +1252,12 @@ fn erc20_withdraw_deposit_works() {
 			);
 
 			// withdraw: sender to erc20 holding account
-			assert_ok!(Currencies::withdraw(CurrencyId::Erc20(erc20_address()), &alice(), 100));
+			assert_ok!(Currencies::withdraw(
+				CurrencyId::Erc20(erc20_address()),
+				&alice(),
+				100,
+				ExistenceRequirement::AllowDeath
+			));
 			assert_eq!(
 				200,
 				Currencies::free_balance(CurrencyId::Erc20(erc20_address()), &erc20_holding_account)

--- a/modules/dex/src/lib.rs
+++ b/modules/dex/src/lib.rs
@@ -114,6 +114,10 @@ pub mod module {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
+		/// The native currency id
+		#[pallet::constant]
+		type GetNativeCurrencyId: Get<CurrencyId>;
+
 		/// Mapping between CurrencyId and ERC20 address so user can use Erc20
 		/// address as LP token.
 		type Erc20InfoMapping: Erc20InfoMapping;
@@ -1434,12 +1438,18 @@ impl<T: Config> Pallet<T> {
 		let module_account_id = Self::account_id();
 		let actual_target_amount = amounts[amounts.len() - 1];
 
+		let path_0_existence_requirement = if path[0] == T::GetNativeCurrencyId::get() {
+			ExistenceRequirement::KeepAlive
+		} else {
+			ExistenceRequirement::AllowDeath
+		};
+
 		T::Currency::transfer(
 			path[0],
 			who,
 			&module_account_id,
 			supply_amount,
-			ExistenceRequirement::AllowDeath,
+			path_0_existence_requirement,
 		)?;
 		Self::_swap_by_path(path, &amounts)?;
 		T::Currency::transfer(
@@ -1470,12 +1480,18 @@ impl<T: Config> Pallet<T> {
 		let module_account_id = Self::account_id();
 		let actual_supply_amount = amounts[0];
 
+		let path_0_existence_requirement = if path[0] == T::GetNativeCurrencyId::get() {
+			ExistenceRequirement::KeepAlive
+		} else {
+			ExistenceRequirement::AllowDeath
+		};
+
 		T::Currency::transfer(
 			path[0],
 			who,
 			&module_account_id,
 			actual_supply_amount,
-			ExistenceRequirement::AllowDeath,
+			path_0_existence_requirement,
 		)?;
 		Self::_swap_by_path(path, &amounts)?;
 		T::Currency::transfer(

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -37,10 +37,10 @@ pub type AccountId = u128;
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 pub const CAROL: AccountId = 3;
+pub const ACA: CurrencyId = CurrencyId::Token(TokenSymbol::ACA);
 pub const AUSD: CurrencyId = CurrencyId::Token(TokenSymbol::AUSD);
 pub const BTC: CurrencyId = CurrencyId::Token(TokenSymbol::TAP);
 pub const DOT: CurrencyId = CurrencyId::Token(TokenSymbol::DOT);
-pub const ACA: CurrencyId = CurrencyId::Token(TokenSymbol::ACA);
 
 parameter_types! {
 	pub static AUSDBTCPair: TradingPair = TradingPair::from_currency_ids(AUSD, BTC).unwrap();
@@ -99,6 +99,7 @@ ord_parameter_types! {
 parameter_types! {
 	pub const GetExchangeFee: (u32, u32) = (1, 100);
 	pub const DEXPalletId: PalletId = PalletId(*b"aca/dexm");
+	pub const GetNativeCurrencyId: CurrencyId = ACA;
 	pub AlternativeSwapPathJointList: Vec<Vec<CurrencyId>> = vec![
 		vec![DOT],
 	];
@@ -124,6 +125,7 @@ impl Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = ConstU32<3>;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = MockErc20InfoMapping;
 	type WeightInfo = ();
 	type DEXIncentives = MockDEXIncentives;

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 	pub static AUSDBTCPair: TradingPair = TradingPair::from_currency_ids(AUSD, BTC).unwrap();
 	pub static AUSDDOTPair: TradingPair = TradingPair::from_currency_ids(AUSD, DOT).unwrap();
 	pub static DOTBTCPair: TradingPair = TradingPair::from_currency_ids(DOT, BTC).unwrap();
-	pub static ACAAUSDPair: TradingPair = TradingPair::from_currency_ids(ACA, AUSD).unwrap();
+	pub static ACABTCPair: TradingPair = TradingPair::from_currency_ids(ACA, BTC).unwrap();
 }
 
 mod dex {
@@ -189,7 +189,7 @@ impl ExtBuilder {
 			AUSDDOTPair::get(),
 			AUSDBTCPair::get(),
 			DOTBTCPair::get(),
-			ACAAUSDPair::get(),
+			ACABTCPair::get(),
 		];
 		self
 	}
@@ -201,7 +201,7 @@ impl ExtBuilder {
 				(AUSDDOTPair::get(), (1_000_000u128, 2_000_000u128)),
 				(AUSDBTCPair::get(), (1_000_000u128, 2_000_000u128)),
 				(DOTBTCPair::get(), (1_000_000u128, 2_000_000u128)),
-				(ACAAUSDPair::get(), (1_000_000u128, 2_000_000u128)),
+				(ACABTCPair::get(), (1_000_000u128, 2_000_000u128)),
 			],
 		)];
 		self

--- a/modules/dex/src/mock.rs
+++ b/modules/dex/src/mock.rs
@@ -46,6 +46,7 @@ parameter_types! {
 	pub static AUSDBTCPair: TradingPair = TradingPair::from_currency_ids(AUSD, BTC).unwrap();
 	pub static AUSDDOTPair: TradingPair = TradingPair::from_currency_ids(AUSD, DOT).unwrap();
 	pub static DOTBTCPair: TradingPair = TradingPair::from_currency_ids(DOT, BTC).unwrap();
+	pub static ACAAUSDPair: TradingPair = TradingPair::from_currency_ids(ACA, AUSD).unwrap();
 }
 
 mod dex {
@@ -61,8 +62,11 @@ impl frame_system::Config for Runtime {
 }
 
 parameter_type_with_key! {
-	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
-		Default::default()
+	pub ExistentialDeposits: |currency_id: CurrencyId| -> Balance {
+		match *currency_id {
+			ACA => 1,
+			_ => Default::default(),
+		}
 	};
 }
 
@@ -181,7 +185,12 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
 	pub fn initialize_enabled_trading_pairs(mut self) -> Self {
-		self.initial_enabled_trading_pairs = vec![AUSDDOTPair::get(), AUSDBTCPair::get(), DOTBTCPair::get()];
+		self.initial_enabled_trading_pairs = vec![
+			AUSDDOTPair::get(),
+			AUSDBTCPair::get(),
+			DOTBTCPair::get(),
+			ACAAUSDPair::get(),
+		];
 		self
 	}
 
@@ -192,6 +201,7 @@ impl ExtBuilder {
 				(AUSDDOTPair::get(), (1_000_000u128, 2_000_000u128)),
 				(AUSDBTCPair::get(), (1_000_000u128, 2_000_000u128)),
 				(DOTBTCPair::get(), (1_000_000u128, 2_000_000u128)),
+				(ACAAUSDPair::get(), (1_000_000u128, 2_000_000u128)),
 			],
 		)];
 		self

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -2005,7 +2005,7 @@ fn do_swap_should_keep_alive_work() {
 			assert_ok!(DexModule::add_liquidity(
 				RuntimeOrigin::signed(ALICE),
 				ACA,
-				AUSD,
+				BTC,
 				1_000_000_000_000_000,
 				2_000_000_000_000_000,
 				0,
@@ -2022,20 +2022,20 @@ fn do_swap_should_keep_alive_work() {
 			assert_eq!(Tokens::free_balance(ACA, &CAROL), 100_000_000_000_000);
 
 			assert_noop!(
-				DexModule::do_swap_with_exact_supply(&CAROL, &[ACA, AUSD], 100_000_000_000_000, 1,),
+				DexModule::do_swap_with_exact_supply(&CAROL, &[ACA, BTC], 100_000_000_000_000, 1,),
 				orml_tokens::Error::<Runtime>::KeepAlive
 			);
 
 			assert_ok!(DexModule::do_swap_with_exact_supply(
 				&CAROL,
-				&[ACA, AUSD],
+				&[ACA, BTC],
 				10_000_000_000_000,
 				1
 			));
 
 			assert_ok!(DexModule::do_swap_with_exact_target(
 				&CAROL,
-				&[ACA, AUSD],
+				&[ACA, BTC],
 				10_000_000_000_000,
 				20_000_000_000_000
 			));

--- a/modules/dex/src/tests.rs
+++ b/modules/dex/src/tests.rs
@@ -1993,3 +1993,51 @@ fn specific_joint_swap_work() {
 			);
 		});
 }
+
+#[test]
+fn do_swap_should_keep_alive_work() {
+	ExtBuilder::default()
+		.initialize_enabled_trading_pairs()
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			assert_ok!(DexModule::add_liquidity(
+				RuntimeOrigin::signed(ALICE),
+				ACA,
+				AUSD,
+				1_000_000_000_000_000,
+				2_000_000_000_000_000,
+				0,
+				false,
+			));
+
+			assert_ok!(Tokens::transfer(
+				RuntimeOrigin::signed(ALICE),
+				CAROL,
+				ACA,
+				100_000_000_000_000
+			));
+
+			assert_eq!(Tokens::free_balance(ACA, &CAROL), 100_000_000_000_000);
+
+			assert_noop!(
+				DexModule::do_swap_with_exact_supply(&CAROL, &[ACA, AUSD], 100_000_000_000_000, 1,),
+				orml_tokens::Error::<Runtime>::KeepAlive
+			);
+
+			assert_ok!(DexModule::do_swap_with_exact_supply(
+				&CAROL,
+				&[ACA, AUSD],
+				10_000_000_000_000,
+				1
+			));
+
+			assert_ok!(DexModule::do_swap_with_exact_target(
+				&CAROL,
+				&[ACA, AUSD],
+				10_000_000_000_000,
+				20_000_000_000_000
+			));
+		});
+}

--- a/modules/evm/src/bench/mock.rs
+++ b/modules/evm/src/bench/mock.rs
@@ -279,6 +279,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = MockErc20InfoMapping;
 	type WeightInfo = ();
 	type DEXIncentives = MockDEXIncentives;

--- a/modules/evm/src/tests.rs
+++ b/modules/evm/src/tests.rs
@@ -2484,6 +2484,7 @@ fn reserve_deposit_makes_user_developer() {
 			&<Runtime as Config>::AddressMapping::get_account_id(&alice()),
 			&who,
 			DEVELOPER_DEPOSIT,
+			ExistenceRequirement::AllowDeath
 		));
 
 		assert_ok!(<Runtime as Config>::Currency::ensure_reserved_named(

--- a/modules/homa/src/mock.rs
+++ b/modules/homa/src/mock.rs
@@ -59,7 +59,12 @@ impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 	type RelayChainAccountId = AccountId;
 
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
-		Currencies::withdraw(StakingCurrencyId::get(), sender, amount)
+		Currencies::withdraw(
+			StakingCurrencyId::get(),
+			sender,
+			amount,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn withdraw_unbonded_from_sub_account(_: u16, _: Balance) -> DispatchResult {

--- a/modules/honzon-bridge/src/lib.rs
+++ b/modules/honzon-bridge/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
-use frame_support::pallet_prelude::*;
+use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
 use frame_system::pallet_prelude::*;
 
 use primitives::{currency::KUSD, evm::EvmAddress, Balance, CurrencyId};
@@ -133,10 +133,22 @@ pub mod module {
 				Self::bridged_stable_coin_currency_id().ok_or(Error::<T>::BridgedStableCoinCurrencyIdNotSet)?;
 
 			// transfer amount of StableCoinCurrencyId to PalletId account
-			T::Currency::transfer(T::StableCoinCurrencyId::get(), &who, &pallet_account, amount)?;
+			T::Currency::transfer(
+				T::StableCoinCurrencyId::get(),
+				&who,
+				&pallet_account,
+				amount,
+				ExistenceRequirement::AllowDeath,
+			)?;
 
 			// transfer amount of BridgedStableCoinCurrencyId from PalletId account to origin
-			T::Currency::transfer(bridged_stable_coin_currency_id, &pallet_account, &who, amount)?;
+			T::Currency::transfer(
+				bridged_stable_coin_currency_id,
+				&pallet_account,
+				&who,
+				amount,
+				ExistenceRequirement::AllowDeath,
+			)?;
 
 			Self::deposit_event(Event::<T>::ToBridged { who, amount });
 			Ok(())
@@ -156,10 +168,22 @@ pub mod module {
 				Self::bridged_stable_coin_currency_id().ok_or(Error::<T>::BridgedStableCoinCurrencyIdNotSet)?;
 
 			// transfer amount of BridgedStableCoinCurrencyId to PalletId account
-			T::Currency::transfer(bridged_stable_coin_currency_id, &who, &pallet_account, amount)?;
+			T::Currency::transfer(
+				bridged_stable_coin_currency_id,
+				&who,
+				&pallet_account,
+				amount,
+				ExistenceRequirement::AllowDeath,
+			)?;
 
 			// transfer amount of StableCoinCurrencyId from PalletId account to origin
-			T::Currency::transfer(T::StableCoinCurrencyId::get(), &pallet_account, &who, amount)?;
+			T::Currency::transfer(
+				T::StableCoinCurrencyId::get(),
+				&pallet_account,
+				&who,
+				amount,
+				ExistenceRequirement::AllowDeath,
+			)?;
 
 			Self::deposit_event(Event::<T>::FromBridged { who, amount });
 			Ok(())

--- a/modules/incentives/src/tests.rs
+++ b/modules/incentives/src/tests.rs
@@ -585,7 +585,12 @@ fn transfer_failed_when_claim_rewards() {
 		);
 
 		// mock the Vault is enough for some reasons
-		assert_ok!(TokensModule::withdraw(AUSD, &VAULT::get(), 3));
+		assert_ok!(TokensModule::withdraw(
+			AUSD,
+			&VAULT::get(),
+			3,
+			ExistenceRequirement::AllowDeath
+		));
 		assert_eq!(TokensModule::free_balance(AUSD, &VAULT::get()), 1);
 
 		assert_eq!(TokensModule::free_balance(AUSD, &BOB::get()), 18);

--- a/modules/liquid-crowdloan/src/lib.rs
+++ b/modules/liquid-crowdloan/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
-use frame_support::{pallet_prelude::*, traits::EnsureOrigin, PalletId};
+use frame_support::{pallet_prelude::*, traits::EnsureOrigin, traits::ExistenceRequirement, PalletId};
 use frame_system::pallet_prelude::*;
 use orml_traits::MultiCurrency;
 use primitives::{Balance, CurrencyId};
@@ -141,8 +141,19 @@ impl<T: Config> Pallet<T> {
 			(currency_id, amount)
 		};
 
-		T::Currency::withdraw(T::LiquidCrowdloanCurrencyId::get(), who, amount)?;
-		T::Currency::transfer(currency_id, &Self::account_id(), who, redeem_amount)?;
+		T::Currency::withdraw(
+			T::LiquidCrowdloanCurrencyId::get(),
+			who,
+			amount,
+			ExistenceRequirement::AllowDeath,
+		)?;
+		T::Currency::transfer(
+			currency_id,
+			&Self::account_id(),
+			who,
+			redeem_amount,
+			ExistenceRequirement::AllowDeath,
+		)?;
 
 		Self::deposit_event(Event::Redeemed {
 			currency_id,

--- a/modules/loans/src/lib.rs
+++ b/modules/loans/src/lib.rs
@@ -27,7 +27,7 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::collapsible_if)]
 
-use frame_support::{pallet_prelude::*, transactional, PalletId};
+use frame_support::{pallet_prelude::*, traits::ExistenceRequirement, transactional, PalletId};
 use module_support::{CDPTreasury, RiskManager};
 use orml_traits::{Handler, MultiCurrency, MultiCurrencyExtended};
 use primitives::{Amount, Balance, CurrencyId, Position};
@@ -189,9 +189,21 @@ impl<T: Config> Pallet<T> {
 		let module_account = Self::account_id();
 
 		if collateral_adjustment.is_positive() {
-			T::Currency::transfer(currency_id, who, &module_account, collateral_balance_adjustment)?;
+			T::Currency::transfer(
+				currency_id,
+				who,
+				&module_account,
+				collateral_balance_adjustment,
+				ExistenceRequirement::AllowDeath,
+			)?;
 		} else if collateral_adjustment.is_negative() {
-			T::Currency::transfer(currency_id, &module_account, who, collateral_balance_adjustment)?;
+			T::Currency::transfer(
+				currency_id,
+				&module_account,
+				who,
+				collateral_balance_adjustment,
+				ExistenceRequirement::AllowDeath,
+			)?;
 		}
 
 		if debit_adjustment.is_positive() {

--- a/modules/loans/src/tests.rs
+++ b/modules/loans/src/tests.rs
@@ -27,10 +27,12 @@ use mock::{RuntimeEvent, *};
 #[test]
 fn debits_key() {
 	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 1000);
 		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 0);
 		assert_eq!(LoansModule::positions(BTC, &ALICE).debit, 0);
 		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, 200, 200));
 		assert_eq!(LoansModule::positions(BTC, &ALICE).debit, 200);
+		assert_eq!(Currencies::free_balance(BTC, &ALICE), 800);
 		assert_eq!(Currencies::free_balance(BTC, &LoansModule::account_id()), 200);
 		assert_ok!(LoansModule::adjust_position(&ALICE, BTC, -100, -100));
 		assert_eq!(LoansModule::positions(BTC, &ALICE).debit, 100);

--- a/modules/transaction-payment/src/mock.rs
+++ b/modules/transaction-payment/src/mock.rs
@@ -164,6 +164,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = ();
 	type DEXIncentives = ();
 	type WeightInfo = ();

--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -894,7 +894,13 @@ fn charges_fee_when_validate_and_native_is_not_enough() {
 
 		// transfer token to Bob, and use Bob as tx sender to test
 		// Bob do not have enough native asset(ACA), but he has AUSD
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(AUSD, &ALICE, &BOB, 4000));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			AUSD,
+			&ALICE,
+			&BOB,
+			4000,
+			ExistenceRequirement::AllowDeath
+		));
 		assert_eq!(DEXModule::get_liquidity_pool(ACA, AUSD), (10000, 1000));
 		assert_eq!(Currencies::total_balance(ACA, &BOB), 0);
 		assert_eq!(<Currencies as MultiCurrency<_>>::free_balance(ACA, &BOB), 0);
@@ -986,7 +992,13 @@ fn payment_reserve_fee() {
 		assert_eq!(reserve_data, *reserves.get(0).unwrap());
 
 		// Bob has not enough native token, but have enough none native token
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(AUSD, &ALICE, &BOB, 4000));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			AUSD,
+			&ALICE,
+			&BOB,
+			4000,
+			ExistenceRequirement::AllowDeath
+		));
 		let fee = <ChargeTransactionPayment<Runtime> as TransactionPaymentT<AccountId, Balance, _>>::reserve_fee(
 			&BOB, 100, None,
 		);
@@ -997,7 +1009,13 @@ fn payment_reserve_fee() {
 
 		// reserve fee not consider multiplier
 		NextFeeMultiplier::<Runtime>::put(Multiplier::saturating_from_rational(3, 2));
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(AUSD, &ALICE, &DAVE, 4000));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			AUSD,
+			&ALICE,
+			&DAVE,
+			4000,
+			ExistenceRequirement::AllowDeath
+		));
 		let fee = <ChargeTransactionPayment<Runtime> as TransactionPaymentT<AccountId, Balance, _>>::reserve_fee(
 			&DAVE, 100, None,
 		);
@@ -1020,7 +1038,13 @@ fn payment_reserve_fee() {
 #[test]
 fn charges_fee_failed_by_slippage_limit() {
 	builder_with_dex_and_fee_pool(true).execute_with(|| {
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(AUSD, &ALICE, &BOB, 1000));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			AUSD,
+			&ALICE,
+			&BOB,
+			1000,
+			ExistenceRequirement::AllowDeath
+		));
 
 		assert_eq!(DEXModule::get_liquidity_pool(ACA, AUSD), (10000, 1000));
 		assert_eq!(Currencies::total_balance(ACA, &BOB), 0);
@@ -1129,7 +1153,13 @@ fn charge_fee_by_alternative_swap_first_priority() {
 		);
 
 		// charge fee token use `DefaultFeeTokens` as `AlternativeFeeSwapPath` condition is failed.
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(DOT, &ALICE, &BOB, 300));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			DOT,
+			&ALICE,
+			&BOB,
+			300,
+			ExistenceRequirement::AllowDeath
+		));
 		assert_eq!(
 			<Currencies as MultiCurrency<_>>::free_balance(ACA, &BOB),
 			PalletBalances::minimum_balance()
@@ -1199,7 +1229,13 @@ fn charge_fee_by_default_fee_tokens_second_priority() {
 		);
 
 		// charge fee token use `AlternativeFeeSwapPath`, although the swap path is invalid.
-		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(DOT, &ALICE, &BOB, 300));
+		assert_ok!(<Currencies as MultiCurrency<_>>::transfer(
+			DOT,
+			&ALICE,
+			&BOB,
+			300,
+			ExistenceRequirement::AllowDeath
+		));
 		assert_eq!(
 			<Currencies as MultiCurrency<_>>::free_balance(ACA, &BOB),
 			PalletBalances::minimum_balance()
@@ -2045,7 +2081,7 @@ fn charge_fee_pool_operation_works() {
 			RuntimeOrigin::root(),
 			ALICE,
 			ACA,
-			10000.unique_saturated_into(),
+			20000.unique_saturated_into(),
 		));
 
 		assert_ok!(DEXModule::add_liquidity(

--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -2081,7 +2081,7 @@ fn charge_fee_pool_operation_works() {
 			RuntimeOrigin::root(),
 			ALICE,
 			ACA,
-			20000.unique_saturated_into(),
+			10000.unique_saturated_into(),
 		));
 
 		assert_ok!(DEXModule::add_liquidity(

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -1172,6 +1172,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = EvmErc20InfoMapping<Runtime>;
 	type DEXIncentives = Incentives;
 	type WeightInfo = weights::module_dex::WeightInfo<Runtime>;

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -22,8 +22,8 @@ use crate::{AllPrecompiles, Ratio, RuntimeBlockWeights, Weight};
 use frame_support::{
 	derive_impl, ord_parameter_types, parameter_types,
 	traits::{
-		ConstU128, ConstU32, ConstU64, EqualPrivilegeOnly, Everything, InstanceFilter, LockIdentifier, Nothing,
-		OnFinalize, OnInitialize, SortedMembers,
+		ConstU128, ConstU32, ConstU64, EqualPrivilegeOnly, Everything, ExistenceRequirement, InstanceFilter,
+		LockIdentifier, Nothing, OnFinalize, OnInitialize, SortedMembers,
 	},
 	weights::{ConstantMultiplier, IdentityFee},
 	PalletId,
@@ -72,7 +72,7 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-	pub const ExistenceRequirement: u128 = 1;
+	pub const ExistentialDeposit: u128 = 1;
 	pub const MinimumCount: u32 = 1;
 	pub const ExpiresIn: u32 = 600;
 	pub const RootOperatorAccountId: AccountId = ALICE;
@@ -147,7 +147,7 @@ impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ExistenceRequirement;
+	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = module_support::SystemAccountStore<Test>;
 	type WeightInfo = ();
 	type MaxLocks = ();
@@ -274,7 +274,7 @@ impl module_transaction_payment::Config for Test {
 	type OperationalFeeMultiplier = ConstU64<5>;
 	type TipPerWeightStep = ConstU128<1>;
 	type MaxTipsOfPriority = ConstU128<1000>;
-	type AlternativeFeeSwapDeposit = ExistenceRequirement;
+	type AlternativeFeeSwapDeposit = ExistentialDeposit;
 	type WeightToFee = IdentityFee<Balance>;
 	type LengthToFee = ConstantMultiplier<Balance, ConstU128<10>>;
 	type FeeMultiplierUpdate = ();
@@ -682,7 +682,12 @@ pub struct MockHomaSubAccountXcm;
 impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 	type RelayChainAccountId = AccountId;
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
-		Currencies::withdraw(StakingCurrencyId::get(), sender, amount)
+		Currencies::withdraw(
+			StakingCurrencyId::get(),
+			sender,
+			amount,
+			ExistenceRequirement::AllowDeath,
+		)
 	}
 
 	fn withdraw_unbonded_from_sub_account(_: u16, _: Balance) -> DispatchResult {
@@ -1107,7 +1112,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.assimilate_storage(&mut storage)
 	.unwrap();
 	module_asset_registry::GenesisConfig::<Test> {
-		assets: vec![(ACA, ExistenceRequirement::get()), (DOT, 0)],
+		assets: vec![(ACA, ExistentialDeposit::get()), (DOT, 0)],
 	}
 	.assimilate_storage(&mut storage)
 	.unwrap();

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -385,6 +385,7 @@ impl module_dex::Config for Test {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = EvmErc20InfoMapping;
 	type WeightInfo = ();
 	type DEXIncentives = MockDEXIncentives;

--- a/runtime/common/src/precompile/multicurrency.rs
+++ b/runtime/common/src/precompile/multicurrency.rs
@@ -20,7 +20,7 @@ use super::input::{Input, InputPricer, InputT, Output};
 use crate::WeightToGas;
 use frame_support::{
 	pallet_prelude::IsType,
-	traits::{Currency, Get},
+	traits::{Currency, ExistenceRequirement, Get},
 };
 use module_currencies::WeightInfo;
 use module_evm::{
@@ -162,6 +162,7 @@ where
 					&from,
 					&to,
 					amount,
+					ExistenceRequirement::AllowDeath,
 				)
 				.map_err(|e| PrecompileFailure::Revert {
 					exit_status: ExitRevert::Reverted,
@@ -188,6 +189,7 @@ where
 					&from,
 					&to,
 					amount,
+					ExistenceRequirement::AllowDeath,
 				)
 				.map_err(|e| PrecompileFailure::Revert {
 					exit_status: ExitRevert::Reverted,

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1179,6 +1179,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = EvmErc20InfoMapping<Runtime>;
 	type DEXIncentives = Incentives;
 	type WeightInfo = weights::module_dex::WeightInfo<Runtime>;

--- a/runtime/mandala/src/benchmarking/homa.rs
+++ b/runtime/mandala/src/benchmarking/homa.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::utils::{set_balance, LIQUID, STAKING};
 use frame_benchmarking::{account, whitelisted_caller};
-use frame_support::traits::OnInitialize;
+use frame_support::traits::{ExistenceRequirement, OnInitialize};
 use frame_system::RawOrigin;
 use module_homa::UnlockChunk;
 use orml_benchmarking::runtime_benchmarks;
@@ -126,7 +126,7 @@ runtime_benchmarks! {
 		let redeem_amount = 10_000_000_000_000;
 		for i in 0 .. n {
 			let redeemer = account("redeemer", i, SEED);
-			<Currencies as MultiCurrency<_>>::transfer(LIQUID, &minter, &redeemer, redeem_amount * 2)?;
+			<Currencies as MultiCurrency<_>>::transfer(LIQUID, &minter, &redeemer, redeem_amount * 2, ExistenceRequirement::AllowDeath)?;
 			Homa::request_redeem(RawOrigin::Signed(redeemer.clone()).into(), redeem_amount, true)?;
 			redeem_request_list.push(redeemer);
 		}

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1218,6 +1218,7 @@ impl module_dex::Config for Runtime {
 	type GetExchangeFee = GetExchangeFee;
 	type TradingPathLimit = TradingPathLimit;
 	type PalletId = DEXPalletId;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type Erc20InfoMapping = EvmErc20InfoMapping<Runtime>;
 	type DEXIncentives = Incentives;
 	type WeightInfo = weights::module_dex::WeightInfo<Runtime>;


### PR DESCRIPTION
Closes: #2834 

1. Modified transfer order in `swap_from_pool_or_dex` of transaction_payment, transfer native token from the pool to the user, then the user transfers other tokens to the pool.
- to ensure the account remains alive (keep-alive check)
- to ensure sufficient native balance for storage fees when transferring ERC20 tokens


2. Enhanced DEX swap logic:
- added check for ACA as a swap-in token(prevents the account from being killed when the user only holds the native balance and tries to swap all of the native balance)