### PR TITLE
Correct argument in try-runtime command for Acala snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ try-runtime on acala
 make try-runtime-acala
 
 # Create a state snapshot to run the migration test.
-# Add `-palet module_name` can specify the module.
+# Add `-pallet module_name` can specify the module.
 cargo run --features with-acala-runtime --features try-runtime -- try-runtime --runtime existing create-snapshot --uri wss://acala.api.onfinality.io:443/public-ws acala-latest.snap
 
 # Use a state snapshot to run the migration test.


### PR DESCRIPTION
### Description:
Fixed a typo in the try-runtime command documentation under the "Try testing runtime" section for Acala. Changed --palet to the correct argument --pallet to properly specify the module when creating a state snapshot.
### Impact:
This fix prevents potential errors during command execution and ensures accurate migration testing for the specified module.