### PR TITLE
Remove deprecated asset_hub_polkadot

### DIFF
--- a/modules/collator-selection/src/lib.rs
+++ b/modules/collator-selection/src/lib.rs
@@ -54,7 +54,7 @@
 //!   fees are deposited into the Pot.
 //!
 //! Note: Eventually the Pot distribution may be modified as discussed in
-//! [this issue](https://github.com/paritytech/asset_hub_polkadot/issues/21#issuecomment-810481073).
+//! [this issue]().
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]


### PR DESCRIPTION
If there's an updated or alternative option for asset_hub_polkadot, let me know — happy to update it accordingly