### PR TITLE
add MigrateToLatestXcmVersion

### DIFF
--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -1992,7 +1992,10 @@ parameter_types! {
 }
 
 #[allow(unused_parens)]
-type Migrations = (frame_support::migrations::RemovePallet<StateTrieMigrationName, RocksDbWeight>);
+type Migrations = (
+	frame_support::migrations::RemovePallet<StateTrieMigrationName, RocksDbWeight>,
+	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
+);
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1996,7 +1996,7 @@ pub type Executive = frame_executive::Executive<
 >;
 
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>);
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]


### PR DESCRIPTION
the migration will clean the invalid Parachain(2011) from the polkadotXcm.versionNotifyTargets. 

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/769e9d1d-25c0-4a9c-99c8-d5bb830f0db0" />

migration event:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/d826adce-4c16-4962-8075-b21a33bd9a92" />


polkadotXcm.versionNotifyTargets storage:
<img width="646" alt="image" src="https://github.com/user-attachments/assets/a0b3f8f5-40b6-40a6-9330-e5a68d64026a" />
