### PR TITLE
Update Polkadot Token Economics documentation link

### DIFF
--- a/modules/transaction-payment/src/lib.rs
+++ b/modules/transaction-payment/src/lib.rs
@@ -121,7 +121,7 @@ type CallOf<T> = <T as Config>::RuntimeCall;
 /// congestion.
 ///
 /// More info can be found at:
-/// https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html
+/// https://research.web3.foundation/Polkadot/overview/token-economics
 pub struct TargetedFeeAdjustment<T, S, V, M, X>(sp_std::marker::PhantomData<(T, S, V, M, X)>);
 
 /// Something that can convert the current multiplier to the next one.


### PR DESCRIPTION
Replaced the outdated W3F Token Economics documentation URL with the current, direct link to the "Token Economics" section of the Web3 Foundation Research site. This ensures that references in the codebase point to up-to-date and relevant information about Polkadot's token economics and transaction fee adjustment mechanisms.