### PR TITLE
[AHM] Relay to Assethub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6554,6 +6554,7 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "parity-scale-codec",
+ "polkadot-parachain-primitives",
  "runtime-common",
  "serde_json",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,8 +4190,6 @@ dependencies = [
  "module-assethub",
  "module-currencies",
  "module-support",
- "orml-tokens",
- "orml-traits",
  "pallet-balances",
  "pallet-xcm",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "log",
  "module-aggregated-dex",
  "module-asset-registry",
+ "module-assethub",
  "module-auction-manager",
  "module-cdp-engine",
  "module-cdp-treasury",
@@ -87,7 +88,6 @@ dependencies = [
  "module-nft",
  "module-nominees-election",
  "module-prices",
- "module-relaychain",
  "module-session-manager",
  "module-support",
  "module-transaction-pause",
@@ -2804,6 +2804,7 @@ dependencies = [
  "log",
  "module-aggregated-dex",
  "module-asset-registry",
+ "module-assethub",
  "module-auction-manager",
  "module-cdp-engine",
  "module-cdp-treasury",
@@ -2828,7 +2829,6 @@ dependencies = [
  "module-nft",
  "module-nominees-election",
  "module-prices",
- "module-relaychain",
  "module-session-manager",
  "module-support",
  "module-transaction-pause",
@@ -3216,6 +3216,7 @@ dependencies = [
  "log",
  "module-aggregated-dex",
  "module-asset-registry",
+ "module-assethub",
  "module-auction-manager",
  "module-cdp-engine",
  "module-cdp-treasury",
@@ -3241,7 +3242,6 @@ dependencies = [
  "module-nft",
  "module-nominees-election",
  "module-prices",
- "module-relaychain",
  "module-session-manager",
  "module-support",
  "module-transaction-pause",
@@ -3481,6 +3481,23 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+]
+
+[[package]]
+name = "module-assethub"
+version = "2.30.0"
+dependencies = [
+ "acala-primitives",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "module-support",
+ "parity-scale-codec",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4074,23 +4091,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "module-relaychain"
-version = "2.30.0"
-dependencies = [
- "acala-primitives",
- "cumulus-primitives-core",
- "frame-support",
- "frame-system",
- "module-support",
- "parity-scale-codec",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "staging-xcm",
-]
-
-[[package]]
 name = "module-session-manager"
 version = "2.30.0"
 dependencies = [
@@ -4187,8 +4187,8 @@ dependencies = [
  "frame-system",
  "insta",
  "log",
+ "module-assethub",
  "module-currencies",
- "module-relaychain",
  "module-support",
  "orml-tokens",
  "orml-traits",
@@ -6496,6 +6496,7 @@ dependencies = [
  "mandala-runtime",
  "module-aggregated-dex",
  "module-asset-registry",
+ "module-assethub",
  "module-auction-manager",
  "module-cdp-engine",
  "module-cdp-treasury",
@@ -6513,7 +6514,6 @@ dependencies = [
  "module-loans",
  "module-nft",
  "module-prices",
- "module-relaychain",
  "module-session-manager",
  "module-support",
  "module-transaction-payment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ module-nft = { path = "modules/nft", default-features = false }
 module-xnft = { path = "modules/xnft", default-features = false }
 module-nominees-election = { path = "modules/nominees-election", default-features = false }
 module-prices = { path = "modules/prices", default-features = false }
-module-relaychain = { path = "modules/relaychain", default-features = false }
+module-assethub = { path = "modules/assethub", default-features = false }
 module-session-manager = { path = "modules/session-manager", default-features = false }
 module-support = { path = "modules/support", default-features = false }
 module-transaction-pause = { path = "modules/transaction-pause", default-features = false }

--- a/modules/assethub/Cargo.toml
+++ b/modules/assethub/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-relaychain"
+name = "module-assethub"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/modules/assethub/src/lib.rs
+++ b/modules/assethub/src/lib.rs
@@ -182,7 +182,7 @@ where
 			SetFeesMode { jit_withdraw: true },
 			InitiateReserveWithdraw {
 				assets: All.into(),
-				reserve: reserve,
+				reserve,
 				xcm: Xcm(vec![
 					BuyExecution {
 						fees: asset,

--- a/modules/assethub/src/lib.rs
+++ b/modules/assethub/src/lib.rs
@@ -185,7 +185,7 @@ where
 			},
 			RefundSurplus,
 			DepositAsset {
-				assets: AllCounted(1).into(), // there is only 1 asset on assethub
+				assets: AllCounted(1).into(),
 				beneficiary: Location {
 					parents: 0,
 					interior: Parachain(ParachainId::get().into()).into(),

--- a/modules/assethub/src/lib.rs
+++ b/modules/assethub/src/lib.rs
@@ -16,9 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! # Module RelayChain
+//! # Module AssetHub
 //!
-//! This module is in charge of handling relaychain related utilities and business logic.
+//! This module is in charge of handling assethub related utilities and business logic.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
@@ -28,17 +28,17 @@ use parity_scale_codec::{Decode, Encode, FullCodec};
 use sp_runtime::{traits::StaticLookup, RuntimeDebug};
 
 use frame_support::traits::Get;
-use module_support::relaychain::*;
+use module_support::assethub::*;
 use primitives::{AccountId, Balance};
 use sp_std::{boxed::Box, marker::PhantomData, prelude::*};
 
 pub use cumulus_primitives_core::ParaId;
 use xcm::v4::{prelude::*, Weight as XcmWeight};
 
-/// The encoded index corresponds to Kusama's Runtime module configuration.
+/// The encoded index corresponds to AssetHub's Runtime module configuration.
 /// https://github.com/paritytech/polkadot/blob/444e96ae34bcec8362f0f947a07bd912b32ca48f/runtime/kusama/src/lib.rs#L1379
 #[derive(Encode, Decode, RuntimeDebug)]
-pub enum KusamaRelayChainCall {
+pub enum KusamaAssetHubCall {
 	#[codec(index = 4)]
 	Balances(BalancesCall),
 	#[codec(index = 6)]
@@ -51,32 +51,32 @@ pub enum KusamaRelayChainCall {
 	XcmPallet(XcmCall),
 }
 
-impl RelayChainCall for KusamaRelayChainCall {
+impl AssetHubCall for KusamaAssetHubCall {
 	fn balances(call: BalancesCall) -> Self {
-		KusamaRelayChainCall::Balances(call)
+		KusamaAssetHubCall::Balances(call)
 	}
 
 	fn staking(call: StakingCall) -> Self {
-		KusamaRelayChainCall::Staking(call)
+		KusamaAssetHubCall::Staking(call)
 	}
 
 	fn utility(call: UtilityCall<Self>) -> Self {
-		KusamaRelayChainCall::Utility(Box::new(call))
+		KusamaAssetHubCall::Utility(Box::new(call))
 	}
 
 	fn proxy(call: ProxyCall<Self>) -> Self {
-		KusamaRelayChainCall::Proxy(Box::new(call))
+		KusamaAssetHubCall::Proxy(Box::new(call))
 	}
 
 	fn xcm_pallet(call: XcmCall) -> Self {
-		KusamaRelayChainCall::XcmPallet(call)
+		KusamaAssetHubCall::XcmPallet(call)
 	}
 }
 
-/// The encoded index corresponds to Polkadot's Runtime module configuration.
+/// The encoded index corresponds to AssetHub's Runtime module configuration.
 /// https://github.com/paritytech/polkadot/blob/84a3962e76151ac5ed3afa4ef1e0af829531ab42/runtime/polkadot/src/lib.rs#L1040
 #[derive(Encode, Decode, RuntimeDebug)]
-pub enum PolkadotRelayChainCall {
+pub enum PolkadotAssetHubCall {
 	#[codec(index = 5)]
 	Balances(BalancesCall),
 	#[codec(index = 7)]
@@ -89,63 +89,63 @@ pub enum PolkadotRelayChainCall {
 	XcmPallet(XcmCall),
 }
 
-impl RelayChainCall for PolkadotRelayChainCall {
+impl AssetHubCall for PolkadotAssetHubCall {
 	fn balances(call: BalancesCall) -> Self {
-		PolkadotRelayChainCall::Balances(call)
+		PolkadotAssetHubCall::Balances(call)
 	}
 
 	fn staking(call: StakingCall) -> Self {
-		PolkadotRelayChainCall::Staking(call)
+		PolkadotAssetHubCall::Staking(call)
 	}
 
 	fn utility(call: UtilityCall<Self>) -> Self {
-		PolkadotRelayChainCall::Utility(Box::new(call))
+		PolkadotAssetHubCall::Utility(Box::new(call))
 	}
 
 	fn proxy(call: ProxyCall<Self>) -> Self {
-		PolkadotRelayChainCall::Proxy(Box::new(call))
+		PolkadotAssetHubCall::Proxy(Box::new(call))
 	}
 
 	fn xcm_pallet(call: XcmCall) -> Self {
-		PolkadotRelayChainCall::XcmPallet(call)
+		PolkadotAssetHubCall::XcmPallet(call)
 	}
 }
 
-pub struct RelayChainCallBuilder<ParachainId, RCC>(PhantomData<(ParachainId, RCC)>);
+pub struct AssetHubCallBuilder<ParachainId, AHC>(PhantomData<(ParachainId, AHC)>);
 
-impl<ParachainId, RCC> CallBuilder for RelayChainCallBuilder<ParachainId, RCC>
+impl<ParachainId, AHC> CallBuilder for AssetHubCallBuilder<ParachainId, AHC>
 where
 	ParachainId: Get<ParaId>,
-	RCC: RelayChainCall + FullCodec,
+	AHC: AssetHubCall + FullCodec,
 {
-	type RelayChainAccountId = AccountId;
+	type AssetHubAccountId = AccountId;
 	type Balance = Balance;
-	type RelayChainCall = RCC;
+	type AssetHubCall = AHC;
 
-	fn utility_as_derivative_call(call: RCC, index: u16) -> RCC {
-		RCC::utility(UtilityCall::AsDerivative(index, call))
+	fn utility_as_derivative_call(call: AHC, index: u16) -> AHC {
+		AHC::utility(UtilityCall::AsDerivative(index, call))
 	}
 
-	fn staking_bond_extra(amount: Self::Balance) -> RCC {
-		RCC::staking(StakingCall::BondExtra(amount))
+	fn staking_bond_extra(amount: Self::Balance) -> AHC {
+		AHC::staking(StakingCall::BondExtra(amount))
 	}
 
-	fn staking_unbond(amount: Self::Balance) -> RCC {
-		RCC::staking(StakingCall::Unbond(amount))
+	fn staking_unbond(amount: Self::Balance) -> AHC {
+		AHC::staking(StakingCall::Unbond(amount))
 	}
 
-	fn staking_withdraw_unbonded(num_slashing_spans: u32) -> RCC {
-		RCC::staking(StakingCall::WithdrawUnbonded(num_slashing_spans))
+	fn staking_withdraw_unbonded(num_slashing_spans: u32) -> AHC {
+		AHC::staking(StakingCall::WithdrawUnbonded(num_slashing_spans))
 	}
 
-	fn staking_nominate(targets: Vec<Self::RelayChainAccountId>) -> RCC {
-		RCC::staking(StakingCall::Nominate(
-			targets.iter().map(|a| RelayChainLookup::unlookup(a.clone())).collect(),
+	fn staking_nominate(targets: Vec<Self::AssetHubAccountId>) -> AHC {
+		AHC::staking(StakingCall::Nominate(
+			targets.iter().map(|a| AssetHubLookup::unlookup(a.clone())).collect(),
 		))
 	}
 
-	fn balances_transfer_keep_alive(to: Self::RelayChainAccountId, amount: Self::Balance) -> RCC {
-		RCC::balances(BalancesCall::TransferKeepAlive(RelayChainLookup::unlookup(to), amount))
+	fn balances_transfer_keep_alive(to: Self::AssetHubAccountId, amount: Self::Balance) -> AHC {
+		AHC::balances(BalancesCall::TransferKeepAlive(AssetHubLookup::unlookup(to), amount))
 	}
 
 	fn xcm_pallet_reserve_transfer_assets(
@@ -153,8 +153,8 @@ where
 		beneficiary: Location,
 		assets: Assets,
 		fee_assets_item: u32,
-	) -> RCC {
-		RCC::xcm_pallet(XcmCall::LimitedReserveTransferAssets(
+	) -> AHC {
+		AHC::xcm_pallet(XcmCall::LimitedReserveTransferAssets(
 			dest.into_versioned(),
 			beneficiary.into_versioned(),
 			assets.into(),
@@ -163,11 +163,11 @@ where
 		))
 	}
 
-	fn proxy_call(real: Self::RelayChainAccountId, call: RCC) -> RCC {
-		RCC::proxy(ProxyCall::Proxy(RelayChainLookup::unlookup(real), None, call))
+	fn proxy_call(real: Self::AssetHubAccountId, call: AHC) -> AHC {
+		AHC::proxy(ProxyCall::Proxy(AssetHubLookup::unlookup(real), None, call))
 	}
 
-	fn finalize_call_into_xcm_message(call: RCC, extra_fee: Self::Balance, weight: XcmWeight) -> Xcm<()> {
+	fn finalize_call_into_xcm_message(call: AHC, extra_fee: Self::Balance, weight: XcmWeight) -> Xcm<()> {
 		let asset = Asset {
 			id: AssetId(Location::here()),
 			fun: Fungibility::Fungible(extra_fee),
@@ -185,7 +185,7 @@ where
 			},
 			RefundSurplus,
 			DepositAsset {
-				assets: AllCounted(1).into(), // there is only 1 asset on relaychain
+				assets: AllCounted(1).into(), // there is only 1 asset on assethub
 				beneficiary: Location {
 					parents: 0,
 					interior: Parachain(ParachainId::get().into()).into(),
@@ -194,7 +194,7 @@ where
 		])
 	}
 
-	fn finalize_multiple_calls_into_xcm_message(calls: Vec<(RCC, XcmWeight)>, extra_fee: Self::Balance) -> Xcm<()> {
+	fn finalize_multiple_calls_into_xcm_message(calls: Vec<(AHC, XcmWeight)>, extra_fee: Self::Balance) -> Xcm<()> {
 		let asset = Asset {
 			id: AssetId(Location::here()),
 			fun: Fungibility::Fungible(extra_fee),
@@ -221,7 +221,7 @@ where
 			vec![
 				RefundSurplus,
 				DepositAsset {
-					assets: AllCounted(1).into(), // there is only 1 asset on relaychain
+					assets: AllCounted(1).into(), // there is only 1 asset on assethub
 					beneficiary: Location {
 						parents: 0,
 						interior: Parachain(ParachainId::get().into()).into(),

--- a/modules/assethub/src/lib.rs
+++ b/modules/assethub/src/lib.rs
@@ -36,18 +36,18 @@ pub use cumulus_primitives_core::ParaId;
 use xcm::v4::{prelude::*, Weight as XcmWeight};
 
 /// The encoded index corresponds to AssetHub's Runtime module configuration.
-/// https://github.com/paritytech/polkadot/blob/444e96ae34bcec8362f0f947a07bd912b32ca48f/runtime/kusama/src/lib.rs#L1379
+/// https://github.com/polkadot-fellows/runtimes/blob/2fb47566718a974c261b68fffaae500be5581820/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs#L1065
 #[derive(Encode, Decode, RuntimeDebug)]
 pub enum KusamaAssetHubCall {
-	#[codec(index = 4)]
+	#[codec(index = 10)]
 	Balances(BalancesCall),
-	#[codec(index = 6)]
+	#[codec(index = 89)] // TODO: update
 	Staking(StakingCall),
-	#[codec(index = 24)]
+	#[codec(index = 40)]
 	Utility(Box<UtilityCall<Self>>),
-	#[codec(index = 30)]
+	#[codec(index = 42)]
 	Proxy(Box<ProxyCall<Self>>),
-	#[codec(index = 99)]
+	#[codec(index = 31)]
 	XcmPallet(XcmCall),
 }
 
@@ -74,18 +74,18 @@ impl AssetHubCall for KusamaAssetHubCall {
 }
 
 /// The encoded index corresponds to AssetHub's Runtime module configuration.
-/// https://github.com/paritytech/polkadot/blob/84a3962e76151ac5ed3afa4ef1e0af829531ab42/runtime/polkadot/src/lib.rs#L1040
+/// https://github.com/polkadot-fellows/runtimes/blob/2fb47566718a974c261b68fffaae500be5581820/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs#L983
 #[derive(Encode, Decode, RuntimeDebug)]
 pub enum PolkadotAssetHubCall {
-	#[codec(index = 5)]
+	#[codec(index = 10)]
 	Balances(BalancesCall),
-	#[codec(index = 7)]
+	#[codec(index = 89)] // TODO: check https://github.com/polkadot-fellows/runtimes/pull/812
 	Staking(StakingCall),
-	#[codec(index = 26)]
+	#[codec(index = 40)]
 	Utility(Box<UtilityCall<Self>>),
-	#[codec(index = 29)]
+	#[codec(index = 42)]
 	Proxy(Box<ProxyCall<Self>>),
-	#[codec(index = 99)]
+	#[codec(index = 31)]
 	XcmPallet(XcmCall),
 }
 
@@ -169,7 +169,7 @@ where
 
 	fn finalize_call_into_xcm_message(call: AHC, extra_fee: Self::Balance, weight: XcmWeight) -> Xcm<()> {
 		let asset = Asset {
-			id: AssetId(Location::here()),
+			id: AssetId(Location::parent()),
 			fun: Fungibility::Fungible(extra_fee),
 		};
 		Xcm(vec![
@@ -196,7 +196,7 @@ where
 
 	fn finalize_multiple_calls_into_xcm_message(calls: Vec<(AHC, XcmWeight)>, extra_fee: Self::Balance) -> Xcm<()> {
 		let asset = Asset {
-			id: AssetId(Location::here()),
+			id: AssetId(Location::parent()),
 			fun: Fungibility::Fungible(extra_fee),
 		};
 

--- a/modules/homa-validator-list/src/lib.rs
+++ b/modules/homa-validator-list/src/lib.rs
@@ -111,14 +111,14 @@ impl<EraIndex: PartialOrd> Guarantee<EraIndex> {
 	}
 }
 
-/// Information on a relay chain validator's slash
+/// Information on a assethub validator's slash
 #[derive(Encode, Decode, Clone, RuntimeDebug, Eq, PartialEq, MaxEncodedLen, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct SlashInfo<Balance, RelayChainAccountId> {
-	/// Address of a validator on the relay chain
-	pub validator: RelayChainAccountId,
-	/// The amount of tokens a validator has in backing on the relay chain
-	pub relaychain_token_amount: Balance,
+pub struct SlashInfo<Balance, ValidatorId> {
+	/// Address of a validator on the assethub
+	pub validator: ValidatorId,
+	/// The amount of tokens a validator has in backing on the assethub
+	pub token_amount: Balance,
 }
 
 /// Validator insurance and frozen status
@@ -138,16 +138,10 @@ pub mod module {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// The AccountId of a relay chain account.
-		type RelayChainAccountId: Parameter
-			+ Member
-			+ MaybeSerializeDeserialize
-			+ Debug
-			+ MaybeDisplay
-			+ Ord
-			+ MaxEncodedLen;
+		/// The AccountId of a assethub account.
+		type ValidatorId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord + MaxEncodedLen;
 
-		/// The liquid representation of the staking token on the relay chain.
+		/// The liquid representation of the staking token on the assethub.
 		type LiquidTokenCurrency: BasicLockableCurrency<Self::AccountId, Balance = Balance>;
 
 		/// The minimum amount of tokens that can be bonded to a validator.
@@ -185,47 +179,47 @@ pub mod module {
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		FreezeValidator {
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 		},
 		ThawValidator {
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 		},
 		BondGuarantee {
 			who: T::AccountId,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			bond: Balance,
 		},
 		UnbondGuarantee {
 			who: T::AccountId,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			bond: Balance,
 		},
 		WithdrawnGuarantee {
 			who: T::AccountId,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			bond: Balance,
 		},
 		SlashGuarantee {
 			who: T::AccountId,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			bond: Balance,
 		},
 		RebondGuarantee {
 			who: T::AccountId,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			bond: Balance,
 		},
 	}
 
-	/// The slash guarantee deposits for relaychain validators.
+	/// The slash guarantee deposits for assethub validators.
 	///
-	/// Guarantees: double_map RelayChainAccountId, AccountId => Option<Guarantee>
+	/// Guarantees: double_map ValidatorId, AccountId => Option<Guarantee>
 	#[pallet::storage]
 	#[pallet::getter(fn guarantees)]
 	pub type Guarantees<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
-		T::RelayChainAccountId,
+		T::ValidatorId,
 		Twox64Concat,
 		T::AccountId,
 		Guarantee<EraIndex>,
@@ -241,11 +235,11 @@ pub mod module {
 
 	/// Total deposit for validators.
 	///
-	/// ValidatorBackings: map RelayChainAccountId => Option<ValidatorBacking>
+	/// ValidatorBackings: map ValidatorId => Option<ValidatorBacking>
 	#[pallet::storage]
 	#[pallet::getter(fn validator_backings)]
 	pub type ValidatorBackings<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::RelayChainAccountId, ValidatorBacking, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::ValidatorId, ValidatorBacking, OptionQuery>;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
@@ -264,7 +258,7 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::bond())]
 		pub fn bond(
 			origin: OriginFor<T>,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			#[pallet::compact] amount: Balance,
 		) -> DispatchResult {
 			let guarantor = ensure_signed(origin)?;
@@ -303,7 +297,7 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::unbond())]
 		pub fn unbond(
 			origin: OriginFor<T>,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			#[pallet::compact] amount: Balance,
 		) -> DispatchResult {
 			let guarantor = ensure_signed(origin)?;
@@ -339,7 +333,7 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::rebond())]
 		pub fn rebond(
 			origin: OriginFor<T>,
-			validator: T::RelayChainAccountId,
+			validator: T::ValidatorId,
 			#[pallet::compact] amount: Balance,
 		) -> DispatchResult {
 			let guarantor = ensure_signed(origin)?;
@@ -368,7 +362,7 @@ pub mod module {
 		/// - `validator`: The AccountId of a validator on the relay chain to withdraw from
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::withdraw_unbonded())]
-		pub fn withdraw_unbonded(origin: OriginFor<T>, validator: T::RelayChainAccountId) -> DispatchResult {
+		pub fn withdraw_unbonded(origin: OriginFor<T>, validator: T::ValidatorId) -> DispatchResult {
 			let guarantor = ensure_signed(origin)?;
 			ensure!(
 				!Self::validator_backings(&validator).unwrap_or_default().is_frozen,
@@ -399,7 +393,7 @@ pub mod module {
 		/// - `validators`: The AccountIds of the validators on the relay chain to freeze
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::freeze(validators.len() as u32))]
-		pub fn freeze(origin: OriginFor<T>, validators: Vec<T::RelayChainAccountId>) -> DispatchResult {
+		pub fn freeze(origin: OriginFor<T>, validators: Vec<T::ValidatorId>) -> DispatchResult {
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			validators.iter().for_each(|validator| {
 				ValidatorBackings::<T>::mutate_exists(validator, |maybe_validator| {
@@ -422,7 +416,7 @@ pub mod module {
 		/// - `validators`: The AccountIds of the validators on the relay chain to unfreeze
 		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::thaw(validators.len() as u32))]
-		pub fn thaw(origin: OriginFor<T>, validators: Vec<T::RelayChainAccountId>) -> DispatchResult {
+		pub fn thaw(origin: OriginFor<T>, validators: Vec<T::ValidatorId>) -> DispatchResult {
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			validators.iter().for_each(|validator| {
 				ValidatorBackings::<T>::mutate_exists(validator, |maybe_validator| {
@@ -445,7 +439,7 @@ pub mod module {
 		/// - `slashes`: The SlashInfos of the validators to be slashed
 		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::slash(slashes.len() as u32))]
-		pub fn slash(origin: OriginFor<T>, slashes: Vec<SlashInfo<Balance, T::RelayChainAccountId>>) -> DispatchResult {
+		pub fn slash(origin: OriginFor<T>, slashes: Vec<SlashInfo<Balance, T::ValidatorId>>) -> DispatchResult {
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			let liquid_staking_exchange_rate = T::LiquidStakingExchangeRateProvider::get_exchange_rate();
 			let staking_liquid_exchange_rate = liquid_staking_exchange_rate.reciprocal().unwrap_or_default();
@@ -453,12 +447,12 @@ pub mod module {
 
 			for SlashInfo {
 				validator,
-				relaychain_token_amount,
+				token_amount,
 			} in slashes
 			{
 				let ValidatorBacking { total_insurance, .. } = Self::validator_backings(&validator).unwrap_or_default();
 				let insurance_loss = staking_liquid_exchange_rate
-					.saturating_mul_int(relaychain_token_amount)
+					.saturating_mul_int(token_amount)
 					.min(total_insurance);
 
 				for (guarantor, _) in Guarantees::<T>::iter_prefix(&validator) {
@@ -490,7 +484,7 @@ pub mod module {
 impl<T: Config> Pallet<T> {
 	fn update_guarantee(
 		guarantor: &T::AccountId,
-		validator: &T::RelayChainAccountId,
+		validator: &T::ValidatorId,
 		f: impl FnOnce(&mut Guarantee<EraIndex>) -> DispatchResult,
 	) -> DispatchResult {
 		Guarantees::<T>::try_mutate_exists(validator, guarantor, |maybe_guarantee| -> DispatchResult {
@@ -549,8 +543,8 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> Contains<T::RelayChainAccountId> for Pallet<T> {
-	fn contains(account: &T::RelayChainAccountId) -> bool {
+impl<T: Config> Contains<T::ValidatorId> for Pallet<T> {
+	fn contains(account: &T::ValidatorId) -> bool {
 		ValidatorBackings::<T>::get(account)
 			.is_some_and(|vb| vb.total_insurance >= T::ValidatorInsuranceThreshold::get() && !vb.is_frozen)
 	}

--- a/modules/homa-validator-list/src/mock.rs
+++ b/modules/homa-validator-list/src/mock.rs
@@ -121,7 +121,7 @@ parameter_types! {
 
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RelayChainAccountId = AccountId;
+	type ValidatorId = AccountId;
 	type LiquidTokenCurrency = LDOTCurrency;
 	type MinBondAmount = ConstU128<100>;
 	type BondingDuration = BondingDuration;

--- a/modules/homa-validator-list/src/tests.rs
+++ b/modules/homa-validator-list/src/tests.rs
@@ -701,11 +701,11 @@ fn slash_work() {
 				vec![
 					SlashInfo {
 						validator: VALIDATOR_1,
-						relaychain_token_amount: 90
+						token_amount: 90
 					},
 					SlashInfo {
 						validator: VALIDATOR_2,
-						relaychain_token_amount: 50
+						token_amount: 50
 					},
 				]
 			),
@@ -717,11 +717,11 @@ fn slash_work() {
 			vec![
 				SlashInfo {
 					validator: VALIDATOR_1,
-					relaychain_token_amount: 90
+					token_amount: 90
 				},
 				SlashInfo {
 					validator: VALIDATOR_2,
-					relaychain_token_amount: 50
+					token_amount: 50
 				},
 			]
 		));

--- a/modules/homa/src/lib.rs
+++ b/modules/homa/src/lib.rs
@@ -663,10 +663,10 @@ pub mod module {
 
 		#[pallet::call_index(8)]
 		#[pallet::weight(< T as Config >::WeightInfo::on_initialize_with_bump_era(T::ProcessRedeemRequestsLimit::get()))]
-		pub fn force_bump_current_era(origin: OriginFor<T>, bump_amount: EraIndex) -> DispatchResultWithPostInfo {
+		pub fn force_bump_current_era(origin: OriginFor<T>, bump_era: EraIndex) -> DispatchResultWithPostInfo {
 			T::GovernanceOrigin::ensure_origin(origin)?;
 
-			let res = Self::bump_current_era(bump_amount);
+			let res = Self::bump_current_era(bump_era);
 			Ok(Some(T::WeightInfo::on_initialize_with_bump_era(res.unwrap_or_default())).into())
 		}
 
@@ -1181,9 +1181,9 @@ pub mod module {
 		/// The rebalance will send XCM messages to assethub. Once the XCM message is sent,
 		/// the execution result cannot be obtained and cannot be rolled back. So the process
 		/// of rebalance is not atomic.
-		pub fn bump_current_era(amount: EraIndex) -> Result<u32, DispatchError> {
+		pub fn bump_current_era(bump_era: EraIndex) -> Result<u32, DispatchError> {
 			let previous_era = Self::relay_chain_current_era();
-			let new_era = previous_era.saturating_add(amount);
+			let new_era = previous_era.saturating_add(bump_era);
 			RelayChainCurrentEra::<T>::put(new_era);
 			LastEraBumpedBlock::<T>::put(T::RelayChainBlockNumber::current_block_number());
 			Self::deposit_event(Event::<T>::CurrentEraBumped { new_era_index: new_era });

--- a/modules/homa/src/lib.rs
+++ b/modules/homa/src/lib.rs
@@ -49,10 +49,8 @@ pub mod weights;
 pub mod module {
 	use super::*;
 
-	pub type AssetHubAccountIdOf<T> = <<T as Config>::XcmInterface as HomaSubAccountXcm<
-		<T as frame_system::Config>::AccountId,
-		Balance,
-	>>::AssetHubAccountId;
+	pub type NomineeIdOf<T> =
+		<<T as Config>::XcmInterface as HomaSubAccountXcm<<T as frame_system::Config>::AccountId, Balance>>::NomineeId;
 
 	/// The subaccount's staking ledger which kept by Homa protocol
 	#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, Default)]
@@ -163,7 +161,7 @@ pub mod module {
 		/// Weight information for the extrinsics in this module.
 		type WeightInfo: WeightInfo;
 
-		type NominationsProvider: NomineesProvider<AssetHubAccountIdOf<Self>>;
+		type NominationsProvider: NomineesProvider<NomineeIdOf<Self>>;
 	}
 
 	#[pallet::error]
@@ -265,7 +263,7 @@ pub mod module {
 		/// Nominate validators on assethub
 		HomaNominate {
 			sub_account_index: u16,
-			nominations: Vec<AssetHubAccountIdOf<T>>,
+			nominations: Vec<NomineeIdOf<T>>,
 		},
 	}
 

--- a/modules/homa/src/mock.rs
+++ b/modules/homa/src/mock.rs
@@ -56,7 +56,7 @@ pub const VALIDATOR_D: AccountId = AccountId32::new([203u8; 32]);
 /// mock XCM transfer.
 pub struct MockHomaSubAccountXcm;
 impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
-	type AssetHubAccountId = AccountId;
+	type NomineeId = AccountId;
 
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
 		Currencies::withdraw(
@@ -79,7 +79,7 @@ impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 		Ok(())
 	}
 
-	fn nominate_on_sub_account(_: u16, _: Vec<Self::AssetHubAccountId>) -> DispatchResult {
+	fn nominate_on_sub_account(_: u16, _: Vec<Self::NomineeId>) -> DispatchResult {
 		Ok(())
 	}
 

--- a/modules/homa/src/mock.rs
+++ b/modules/homa/src/mock.rs
@@ -56,7 +56,7 @@ pub const VALIDATOR_D: AccountId = AccountId32::new([203u8; 32]);
 /// mock XCM transfer.
 pub struct MockHomaSubAccountXcm;
 impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
-	type RelayChainAccountId = AccountId;
+	type AssetHubAccountId = AccountId;
 
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
 		Currencies::withdraw(
@@ -79,7 +79,7 @@ impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 		Ok(())
 	}
 
-	fn nominate_on_sub_account(_: u16, _: Vec<Self::RelayChainAccountId>) -> DispatchResult {
+	fn nominate_on_sub_account(_: u16, _: Vec<Self::AssetHubAccountId>) -> DispatchResult {
 		Ok(())
 	}
 

--- a/modules/support/src/assethub.rs
+++ b/modules/support/src/assethub.rs
@@ -141,6 +141,7 @@ pub trait CallBuilder {
 	///  params:
 	/// - to: The destination account.
 	/// - amount: The amount of staking currency to be transferred.
+	/// - reserve: The reserve location.
 	/// - weight: the weight limit used for XCM.
 	fn finalize_transfer_asset_xcm_message(
 		to: Self::AssetHubAccountId,

--- a/modules/support/src/assethub.rs
+++ b/modules/support/src/assethub.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// * Since XCM V3, relaychain configs 'SafeCallFilter' to filter the call in Transact:
+// * Since XCM V3, xcm executor configs 'SafeCallFilter' to filter the call in Transact:
 // * https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/xcm_config.rs
 
 use parity_scale_codec::{Decode, Encode, FullCodec};
@@ -31,13 +31,13 @@ use xcm::{prelude::*, v3::Weight as XcmWeight};
 #[derive(Encode, Decode, RuntimeDebug)]
 pub enum BalancesCall {
 	#[codec(index = 3)]
-	TransferKeepAlive(<RelayChainLookup as StaticLookup>::Source, #[codec(compact)] Balance),
+	TransferKeepAlive(<AssetHubLookup as StaticLookup>::Source, #[codec(compact)] Balance),
 }
 
 #[derive(Encode, Decode, RuntimeDebug)]
-pub enum UtilityCall<RCC> {
+pub enum UtilityCall<AHC> {
 	#[codec(index = 1)]
-	AsDerivative(u16, RCC),
+	AsDerivative(u16, AHC),
 }
 
 #[derive(Encode, Decode, RuntimeDebug)]
@@ -49,7 +49,7 @@ pub enum StakingCall {
 	#[codec(index = 3)]
 	WithdrawUnbonded(u32),
 	#[codec(index = 5)]
-	Nominate(Vec<<RelayChainLookup as StaticLookup>::Source>),
+	Nominate(Vec<<AssetHubLookup as StaticLookup>::Source>),
 }
 
 /// `pallet-xcm` calls.
@@ -62,18 +62,18 @@ pub enum XcmCall {
 }
 
 // Same to `Polkadot` and `Kusama` runtime `Lookup` config.
-pub type RelayChainLookup = AccountIdLookup<AccountId, ()>;
+pub type AssetHubLookup = AccountIdLookup<AccountId, ()>;
 
 /// `pallet-proxy` calls.
 #[derive(Encode, Decode, RuntimeDebug)]
-pub enum ProxyCall<RCC> {
+pub enum ProxyCall<AHC> {
 	/// `proxy(real, force_proxy_type, call)` call. Force proxy type is not supported and
 	/// is always set to `None`.
 	#[codec(index = 0)]
-	Proxy(<RelayChainLookup as StaticLookup>::Source, Option<()>, RCC),
+	Proxy(<AssetHubLookup as StaticLookup>::Source, Option<()>, AHC),
 }
 
-pub trait RelayChainCall: Sized {
+pub trait AssetHubCall: Sized {
 	fn balances(call: BalancesCall) -> Self;
 	fn staking(call: StakingCall) -> Self;
 	fn utility(call: UtilityCall<Self>) -> Self;
@@ -82,41 +82,41 @@ pub trait RelayChainCall: Sized {
 }
 
 pub trait CallBuilder {
-	type RelayChainAccountId: FullCodec;
+	type AssetHubAccountId: FullCodec;
 	type Balance: FullCodec;
-	type RelayChainCall: FullCodec + RelayChainCall;
+	type AssetHubCall: FullCodec + AssetHubCall;
 
 	/// Execute a call, replacing the `Origin` with a sub-account.
 	///  params:
 	/// - call: The call to be executed.
 	/// - index: The index of sub-account to be used as the new origin.
-	fn utility_as_derivative_call(call: Self::RelayChainCall, index: u16) -> Self::RelayChainCall;
+	fn utility_as_derivative_call(call: Self::AssetHubCall, index: u16) -> Self::AssetHubCall;
 
-	/// Bond extra on relay-chain.
+	/// Bond extra on assethub.
 	///  params:
 	/// - amount: The amount of staking currency to bond.
-	fn staking_bond_extra(amount: Self::Balance) -> Self::RelayChainCall;
+	fn staking_bond_extra(amount: Self::Balance) -> Self::AssetHubCall;
 
-	/// Unbond on relay-chain.
+	/// Unbond on assethub.
 	///  params:
 	/// - amount: The amount of staking currency to unbond.
-	fn staking_unbond(amount: Self::Balance) -> Self::RelayChainCall;
+	fn staking_unbond(amount: Self::Balance) -> Self::AssetHubCall;
 
-	/// Withdraw unbonded staking on the relay-chain.
+	/// Withdraw unbonded staking on the assethub.
 	///  params:
 	/// - num_slashing_spans: The number of slashing spans to withdraw from.
-	fn staking_withdraw_unbonded(num_slashing_spans: u32) -> Self::RelayChainCall;
+	fn staking_withdraw_unbonded(num_slashing_spans: u32) -> Self::AssetHubCall;
 
-	/// Nominate the relay-chain.
+	/// Nominate the assethub.
 	///  params:
 	/// - targets: The target validator list.
-	fn staking_nominate(targets: Vec<Self::RelayChainAccountId>) -> Self::RelayChainCall;
+	fn staking_nominate(targets: Vec<Self::AssetHubAccountId>) -> Self::AssetHubCall;
 
 	/// Transfer Staking currency to another account, disallowing "death".
 	///  params:
 	/// - to: The destination for the transfer
 	/// - amount: The amount of staking currency to be transferred.
-	fn balances_transfer_keep_alive(to: Self::RelayChainAccountId, amount: Self::Balance) -> Self::RelayChainCall;
+	fn balances_transfer_keep_alive(to: Self::AssetHubAccountId, amount: Self::Balance) -> Self::AssetHubCall;
 
 	/// Reserve transfer assets.
 	/// params:
@@ -129,31 +129,28 @@ pub trait CallBuilder {
 		beneficiary: Location,
 		assets: Assets,
 		fee_assets_item: u32,
-	) -> Self::RelayChainCall;
+	) -> Self::AssetHubCall;
 
 	/// Proxy a call with a `real` account without a forced proxy type.
 	/// params:
 	/// - real: The real account.
 	/// - call: The call to be executed.
-	fn proxy_call(real: Self::RelayChainAccountId, call: Self::RelayChainCall) -> Self::RelayChainCall;
+	fn proxy_call(real: Self::AssetHubAccountId, call: Self::AssetHubCall) -> Self::AssetHubCall;
 
 	/// Wrap the final call into the Xcm format.
 	///  params:
 	/// - call: The call to be executed
 	/// - extra_fee: Extra fee (in staking currency) used for buy the `weight`.
 	/// - weight: the weight limit used for XCM.
-	fn finalize_call_into_xcm_message(
-		call: Self::RelayChainCall,
-		extra_fee: Self::Balance,
-		weight: XcmWeight,
-	) -> Xcm<()>;
+	fn finalize_call_into_xcm_message(call: Self::AssetHubCall, extra_fee: Self::Balance, weight: XcmWeight)
+		-> Xcm<()>;
 
 	/// Wrap the final multiple calls into the Xcm format.
 	///  params:
 	/// - calls: the multiple calls and its weight limit to be executed
 	/// - extra_fee: Extra fee (in staking currency) used for buy the `weight`.
 	fn finalize_multiple_calls_into_xcm_message(
-		calls: Vec<(Self::RelayChainCall, XcmWeight)>,
+		calls: Vec<(Self::AssetHubCall, XcmWeight)>,
 		extra_fee: Self::Balance,
 	) -> Xcm<()>;
 }

--- a/modules/support/src/assethub.rs
+++ b/modules/support/src/assethub.rs
@@ -137,6 +137,18 @@ pub trait CallBuilder {
 	/// - call: The call to be executed.
 	fn proxy_call(real: Self::AssetHubAccountId, call: Self::AssetHubCall) -> Self::AssetHubCall;
 
+	/// Wrap the final transfer asset into the Xcm format.
+	///  params:
+	/// - to: The destination account.
+	/// - amount: The amount of staking currency to be transferred.
+	/// - weight: the weight limit used for XCM.
+	fn finalize_transfer_asset_xcm_message(
+		to: Self::AssetHubAccountId,
+		amount: Self::Balance,
+		reserve: Location,
+		weight: XcmWeight,
+	) -> Xcm<()>;
+
 	/// Wrap the final call into the Xcm format.
 	///  params:
 	/// - call: The call to be executed

--- a/modules/support/src/homa.rs
+++ b/modules/support/src/homa.rs
@@ -22,18 +22,18 @@ use sp_std::{fmt::Debug, vec::Vec};
 use xcm::v4::prelude::*;
 
 pub trait HomaSubAccountXcm<AccountId, Balance> {
-	type RelayChainAccountId: Debug + Clone + Ord;
-	/// Cross-chain transfer staking currency to sub account on relaychain.
+	type AssetHubAccountId: Debug + Clone + Ord;
+	/// Cross-chain transfer staking currency to sub account on assethub.
 	fn transfer_staking_to_sub_account(sender: &AccountId, sub_account_index: u16, amount: Balance) -> DispatchResult;
-	/// Send XCM message to the relaychain for sub account to withdraw_unbonded staking currency and
+	/// Send XCM message to the assethub for sub account to withdraw_unbonded staking currency and
 	/// send it back.
 	fn withdraw_unbonded_from_sub_account(sub_account_index: u16, amount: Balance) -> DispatchResult;
-	/// Send XCM message to the relaychain for sub account to bond extra.
+	/// Send XCM message to the assethub for sub account to bond extra.
 	fn bond_extra_on_sub_account(sub_account_index: u16, amount: Balance) -> DispatchResult;
-	/// Send XCM message to the relaychain for sub account to unbond.
+	/// Send XCM message to the assethub for sub account to unbond.
 	fn unbond_on_sub_account(sub_account_index: u16, amount: Balance) -> DispatchResult;
-	/// Send XCM message to the relaychain for sub account to nominate.
-	fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::RelayChainAccountId>) -> DispatchResult;
+	/// Send XCM message to the assethub for sub account to nominate.
+	fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::AssetHubAccountId>) -> DispatchResult;
 	/// The fee of cross-chain transfer is deducted from the recipient.
 	fn get_xcm_transfer_fee() -> Balance;
 	/// The fee of parachain

--- a/modules/support/src/homa.rs
+++ b/modules/support/src/homa.rs
@@ -22,7 +22,7 @@ use sp_std::{fmt::Debug, vec::Vec};
 use xcm::v4::prelude::*;
 
 pub trait HomaSubAccountXcm<AccountId, Balance> {
-	type AssetHubAccountId: Debug + Clone + Ord;
+	type NomineeId: Debug + Clone + Ord;
 	/// Cross-chain transfer staking currency to sub account on assethub.
 	fn transfer_staking_to_sub_account(sender: &AccountId, sub_account_index: u16, amount: Balance) -> DispatchResult;
 	/// Send XCM message to the assethub for sub account to withdraw_unbonded staking currency and
@@ -33,7 +33,7 @@ pub trait HomaSubAccountXcm<AccountId, Balance> {
 	/// Send XCM message to the assethub for sub account to unbond.
 	fn unbond_on_sub_account(sub_account_index: u16, amount: Balance) -> DispatchResult;
 	/// Send XCM message to the assethub for sub account to nominate.
-	fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::AssetHubAccountId>) -> DispatchResult;
+	fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::NomineeId>) -> DispatchResult;
 	/// The fee of cross-chain transfer is deducted from the recipient.
 	fn get_xcm_transfer_fee() -> Balance;
 	/// The fee of parachain

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -29,6 +29,7 @@ use sp_runtime::{
 use sp_std::{prelude::*, result::Result, vec};
 use xcm::prelude::*;
 
+pub mod assethub;
 pub mod bounded;
 pub mod dex;
 pub mod earning;
@@ -37,7 +38,6 @@ pub mod homa;
 pub mod honzon;
 pub mod incentives;
 pub mod mocks;
-pub mod relaychain;
 pub mod stable_asset;
 
 pub use crate::bounded::*;

--- a/modules/xcm-interface/Cargo.toml
+++ b/modules/xcm-interface/Cargo.toml
@@ -16,6 +16,7 @@ sp-core = { workspace = true }
 sp-std = { workspace = true }
 pallet-xcm = { workspace = true }
 xcm = { workspace = true }
+xcm-executor = { workspace = true }
 primitives = { workspace = true }
 orml-traits = { workspace = true }
 module-support = { workspace = true }
@@ -47,6 +48,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"xcm/std",
+	"xcm-executor/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",

--- a/modules/xcm-interface/Cargo.toml
+++ b/modules/xcm-interface/Cargo.toml
@@ -29,7 +29,7 @@ xcm-builder = { workspace = true, features = ["std"] }
 xcm-executor = { workspace = true, features = ["std"] }
 orml-tokens = { workspace = true, features = ["std"] }
 module-currencies = { workspace = true, features = ["std"] }
-module-relaychain = { workspace = true, features = ["std"] }
+module-assethub = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/modules/xcm-interface/Cargo.toml
+++ b/modules/xcm-interface/Cargo.toml
@@ -18,7 +18,6 @@ pallet-xcm = { workspace = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
 primitives = { workspace = true }
-orml-traits = { workspace = true }
 module-support = { workspace = true }
 
 [dev-dependencies]
@@ -28,7 +27,6 @@ pallet-balances = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
 xcm-builder = { workspace = true, features = ["std"] }
 xcm-executor = { workspace = true, features = ["std"] }
-orml-tokens = { workspace = true, features = ["std"] }
 module-currencies = { workspace = true, features = ["std"] }
 module-assethub = { workspace = true, features = ["std"] }
 
@@ -40,7 +38,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"module-support/std",
-	"orml-traits/std",
 	"pallet-xcm/std",
 	"primitives/std",
 	"scale-info/std",

--- a/modules/xcm-interface/src/lib.rs
+++ b/modules/xcm-interface/src/lib.rs
@@ -172,7 +172,7 @@ pub mod module {
 	}
 
 	impl<T: Config> HomaSubAccountXcm<T::AccountId, Balance> for Pallet<T> {
-		type AssetHubAccountId = T::AccountId;
+		type NomineeId = T::AccountId;
 
 		/// Cross-chain transfer staking currency to sub account on assethub.
 		fn transfer_staking_to_sub_account(
@@ -273,7 +273,7 @@ pub mod module {
 		}
 
 		/// Send XCM message to the assethub for sub account to nominate.
-		fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::AssetHubAccountId>) -> DispatchResult {
+		fn nominate_on_sub_account(sub_account_index: u16, targets: Vec<Self::NomineeId>) -> DispatchResult {
 			let (xcm_dest_weight, xcm_fee) = Self::xcm_dest_weight_and_fee(XcmInterfaceOperation::HomaNominate);
 			let xcm_message = T::AssetHubCallBuilder::finalize_call_into_xcm_message(
 				T::AssetHubCallBuilder::utility_as_derivative_call(

--- a/modules/xcm-interface/src/mocks/kusama.rs
+++ b/modules/xcm-interface/src/mocks/kusama.rs
@@ -18,4 +18,4 @@
 
 use super::*;
 
-impl_mock!(module_relaychain::KusamaRelayChainCall);
+impl_mock!(module_assethub::KusamaAssetHubCall);

--- a/modules/xcm-interface/src/mocks/mod.rs
+++ b/modules/xcm-interface/src/mocks/mod.rs
@@ -61,7 +61,8 @@ parameter_types! {
 	pub const GetStakingCurrencyId: CurrencyId = DOT;
 	pub const ParachainAccount: AccountId = AccountId32::new([0u8; 32]);
 	pub const ParachainId: module_assethub::ParaId = module_assethub::ParaId::new(2000);
-	pub SelfLocation: Location = Location::new(1, Parachain(ParachainId::get().into()));
+	pub const AssetHubId: module_assethub::ParaId = module_assethub::ParaId::new(1000);
+	pub AssetHubLocation: Location = Location::new(1, Parachain(AssetHubId::get().into()));
 }
 
 pub struct SubAccountIndexLocationConvertor;
@@ -275,7 +276,7 @@ macro_rules! impl_mock {
 			type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
 			type AssetHubCallBuilder = module_assethub::AssetHubCallBuilder<ParachainId, $assethub>;
 			type XcmTransfer = MockXcmTransfer;
-			type SelfLocation = SelfLocation;
+			type AssetHubLocation = AssetHubLocation;
 			type AccountIdToLocation = AccountIdToLocation;
 		}
 

--- a/modules/xcm-interface/src/mocks/mod.rs
+++ b/modules/xcm-interface/src/mocks/mod.rs
@@ -60,7 +60,7 @@ ord_parameter_types! {
 parameter_types! {
 	pub const GetStakingCurrencyId: CurrencyId = DOT;
 	pub const ParachainAccount: AccountId = AccountId32::new([0u8; 32]);
-	pub const ParachainId: module_relaychain::ParaId = module_relaychain::ParaId::new(2000);
+	pub const ParachainId: module_assethub::ParaId = module_assethub::ParaId::new(2000);
 	pub SelfLocation: Location = Location::new(1, Parachain(ParachainId::get().into()));
 }
 
@@ -212,7 +212,7 @@ impl XcmAssetTransfers for MockExec {
 
 #[macro_export]
 macro_rules! impl_mock {
-	($relaychain:ty) => {
+	($assethub:ty) => {
 		pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
 		pub type Block = frame_system::mocking::MockBlock<Runtime>;
 
@@ -271,9 +271,9 @@ macro_rules! impl_mock {
 			type UpdateOrigin = EnsureSignedBy<One, AccountId>;
 			type StakingCurrencyId = GetStakingCurrencyId;
 			type ParachainAccount = ParachainAccount;
-			type RelayChainUnbondingSlashingSpans = ConstU32<28>;
+			type AssetHubUnbondingSlashingSpans = ConstU32<28>;
 			type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
-			type RelayChainCallBuilder = module_relaychain::RelayChainCallBuilder<ParachainId, $relaychain>;
+			type AssetHubCallBuilder = module_assethub::AssetHubCallBuilder<ParachainId, $assethub>;
 			type XcmTransfer = MockXcmTransfer;
 			type SelfLocation = SelfLocation;
 			type AccountIdToLocation = AccountIdToLocation;

--- a/modules/xcm-interface/src/mocks/mod.rs
+++ b/modules/xcm-interface/src/mocks/mod.rs
@@ -25,8 +25,6 @@ use frame_support::{
 	traits::{ConstU128, ConstU32, Everything, Nothing},
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
-use orml_traits::xcm_transfer::Transferred;
-use primitives::{CurrencyId, TokenSymbol};
 use sp_runtime::{traits::IdentityLookup, AccountId32, BuildStorage};
 use xcm_builder::{EnsureXcmOrigin, FixedWeightBounds, SignedToAccountId32};
 use xcm_executor::traits::XcmAssetTransfers;
@@ -37,8 +35,6 @@ pub mod polkadot;
 pub type AccountId = AccountId32;
 
 pub const ALICE: AccountId = AccountId32::new([1u8; 32]);
-pub const BOB: AccountId = AccountId32::new([2u8; 32]);
-pub const DOT: CurrencyId = CurrencyId::Token(TokenSymbol::DOT);
 
 parameter_types! {
 	pub const UnitWeightCost: XcmWeight = XcmWeight::from_parts(10, 10);
@@ -65,9 +61,9 @@ parameter_types! {
 }
 
 pub struct SubAccountIndexAccountIdConvertor;
-impl Convert<u16, Location> for SubAccountIndexAccountIdConvertor {
+impl Convert<u16, AccountId> for SubAccountIndexAccountIdConvertor {
 	fn convert(_sub_account_index: u16) -> AccountId {
-		AccountId32::new([1u8; 32])
+		AccountId::new([1u8; 32])
 	}
 }
 

--- a/modules/xcm-interface/src/mocks/mod.rs
+++ b/modules/xcm-interface/src/mocks/mod.rs
@@ -58,82 +58,16 @@ ord_parameter_types! {
 }
 
 parameter_types! {
-	pub const GetStakingCurrencyId: CurrencyId = DOT;
 	pub const ParachainAccount: AccountId = AccountId32::new([0u8; 32]);
 	pub const ParachainId: module_assethub::ParaId = module_assethub::ParaId::new(2000);
 	pub const AssetHubId: module_assethub::ParaId = module_assethub::ParaId::new(1000);
 	pub AssetHubLocation: Location = Location::new(1, Parachain(AssetHubId::get().into()));
 }
 
-pub struct SubAccountIndexLocationConvertor;
-impl Convert<u16, Location> for SubAccountIndexLocationConvertor {
-	fn convert(_sub_account_index: u16) -> Location {
-		(Parent, Parachain(2000)).into()
-	}
-}
-
-pub struct MockXcmTransfer;
-impl XcmTransfer<AccountId, Balance, CurrencyId> for MockXcmTransfer {
-	fn transfer(
-		_who: AccountId,
-		_currency_id: CurrencyId,
-		_amount: Balance,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId32>, DispatchError> {
-		unimplemented!()
-	}
-
-	/// Transfer `Asset`
-	fn transfer_multiasset(
-		_who: AccountId,
-		_asset: Asset,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId32>, DispatchError> {
-		unimplemented!()
-	}
-
-	fn transfer_with_fee(
-		_who: AccountId,
-		_currency_id: CurrencyId,
-		_amount: Balance,
-		_fee: Balance,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId>, DispatchError> {
-		unimplemented!()
-	}
-
-	/// Transfer `AssetWithFee`
-	fn transfer_multiasset_with_fee(
-		_who: AccountId,
-		_asset: Asset,
-		_fee: Asset,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId32>, DispatchError> {
-		unimplemented!()
-	}
-
-	fn transfer_multicurrencies(
-		_who: AccountId,
-		_currencies: Vec<(CurrencyId, Balance)>,
-		_fee_item: u32,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId32>, DispatchError> {
-		unimplemented!()
-	}
-
-	fn transfer_multiassets(
-		_who: AccountId,
-		_assets: Assets,
-		_fee: Asset,
-		_dest: Location,
-		_dest_weight_limit: WeightLimit,
-	) -> Result<Transferred<AccountId32>, DispatchError> {
-		unimplemented!()
+pub struct SubAccountIndexAccountIdConvertor;
+impl Convert<u16, Location> for SubAccountIndexAccountIdConvertor {
+	fn convert(_sub_account_index: u16) -> AccountId {
+		AccountId32::new([1u8; 32])
 	}
 }
 
@@ -270,12 +204,10 @@ macro_rules! impl_mock {
 		impl Config for Runtime {
 			type RuntimeEvent = RuntimeEvent;
 			type UpdateOrigin = EnsureSignedBy<One, AccountId>;
-			type StakingCurrencyId = GetStakingCurrencyId;
 			type ParachainAccount = ParachainAccount;
 			type AssetHubUnbondingSlashingSpans = ConstU32<28>;
-			type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
+			type SovereignSubAccountIdConvert = SubAccountIndexAccountIdConvertor;
 			type AssetHubCallBuilder = module_assethub::AssetHubCallBuilder<ParachainId, $assethub>;
-			type XcmTransfer = MockXcmTransfer;
 			type AssetHubLocation = AssetHubLocation;
 			type AccountIdToLocation = AccountIdToLocation;
 		}

--- a/modules/xcm-interface/src/mocks/polkadot.rs
+++ b/modules/xcm-interface/src/mocks/polkadot.rs
@@ -18,4 +18,4 @@
 
 use super::*;
 
-impl_mock!(module_relaychain::PolkadotRelayChainCall);
+impl_mock!(module_assethub::PolkadotAssetHubCall);

--- a/runtime/acala/Cargo.toml
+++ b/runtime/acala/Cargo.toml
@@ -120,7 +120,7 @@ module-liquid-crowdloan = { workspace = true }
 module-loans = { workspace = true }
 module-nft = { workspace = true }
 module-prices = { workspace = true }
-module-relaychain = { workspace = true }
+module-assethub = { workspace = true }
 module-session-manager = { workspace = true }
 module-support = { workspace = true }
 module-transaction-pause = { workspace = true }
@@ -259,7 +259,7 @@ std = [
 	"module-loans/std",
 	"module-nft/std",
 	"module-prices/std",
-	"module-relaychain/std",
+	"module-assethub/std",
 	"module-session-manager/std",
 	"module-support/std",
 	"module-transaction-pause/std",

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -1676,7 +1676,7 @@ impl module_xcm_interface::Config for Runtime {
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
 	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::PolkadotAssetHubCall>;
 	type XcmTransfer = XTokens;
-	type SelfLocation = xcm_config::SelfLocation;
+	type AssetHubLocation = xcm_config::AssetHubLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;
 }
 

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -52,11 +52,11 @@ use sp_version::RuntimeVersion;
 
 use frame_system::{EnsureRoot, EnsureSigned, RawOrigin};
 use module_asset_registry::{AssetIdMaps, EvmErc20InfoMapping};
+use module_assethub::AssetHubCallBuilder;
 use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_relaychain::RelayChainCallBuilder;
 use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, PoolId};
 use module_transaction_payment::TargetedFeeAdjustment;
 
@@ -1606,7 +1606,7 @@ parameter_types! {
 
 impl module_homa_validator_list::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RelayChainAccountId = AccountId;
+	type ValidatorId = AccountId;
 	type LiquidTokenCurrency = module_currencies::Currency<Runtime, GetLiquidCurrencyId>;
 	type MinBondAmount = MinBondAmount;
 	type BondingDuration = BondingDuration;
@@ -1672,9 +1672,9 @@ impl module_xcm_interface::Config for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfGeneralCouncil;
 	type StakingCurrencyId = GetStakingCurrencyId;
 	type ParachainAccount = ParachainAccount;
-	type RelayChainUnbondingSlashingSpans = ConstU32<5>;
+	type AssetHubUnbondingSlashingSpans = ConstU32<5>;
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
-	type RelayChainCallBuilder = RelayChainCallBuilder<ParachainInfo, module_relaychain::PolkadotRelayChainCall>;
+	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::PolkadotAssetHubCall>;
 	type XcmTransfer = XTokens;
 	type SelfLocation = xcm_config::SelfLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -114,7 +114,6 @@ use runtime_common::{
 	Rate, Ratio, RuntimeBlockLength, RuntimeBlockWeights, TechnicalCommitteeInstance,
 	TechnicalCommitteeMembershipInstance, TimeStampedPrice, TipPerWeightStep, ACA, AUSD, DOT, LCDOT, LDOT, TAP,
 };
-use xcm::v4::prelude::*;
 
 mod authority;
 mod benchmarking;
@@ -1639,27 +1638,13 @@ impl module_nominees_election::Config for Runtime {
 	type WeightInfo = weights::module_nominees_election::WeightInfo<Runtime>;
 }
 
-pub fn create_x2_parachain_location(index: u16) -> Location {
-	Location::new(
-		1,
-		[
-			Parachain(parachains::asset_hub_polkadot::ID),
-			AccountId32 {
-				network: None,
-				id: Utility::derivative_account_id(
-					Sibling::from(ParachainInfo::get()).into_account_truncating(),
-					index,
-				)
-				.into(),
-			},
-		],
-	)
-}
-
-pub struct SubAccountIndexLocationConvertor;
-impl Convert<u16, Location> for SubAccountIndexLocationConvertor {
-	fn convert(sub_account_index: u16) -> Location {
-		create_x2_parachain_location(sub_account_index)
+pub struct SubAccountIndexAccountIdConvertor;
+impl Convert<u16, AccountId> for SubAccountIndexAccountIdConvertor {
+	fn convert(sub_account_index: u16) -> AccountId {
+		Utility::derivative_account_id(
+			Sibling::from(ParachainInfo::get()).into_account_truncating(),
+			sub_account_index,
+		)
 	}
 }
 
@@ -1670,12 +1655,10 @@ parameter_types! {
 impl module_xcm_interface::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type UpdateOrigin = EnsureRootOrHalfGeneralCouncil;
-	type StakingCurrencyId = GetStakingCurrencyId;
 	type ParachainAccount = ParachainAccount;
 	type AssetHubUnbondingSlashingSpans = ConstU32<5>;
-	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
+	type SovereignSubAccountIdConvert = SubAccountIndexAccountIdConvertor;
 	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::PolkadotAssetHubCall>;
-	type XcmTransfer = XTokens;
 	type AssetHubLocation = xcm_config::AssetHubLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;
 }

--- a/runtime/acala/src/xcm_config.rs
+++ b/runtime/acala/src/xcm_config.rs
@@ -97,7 +97,7 @@ parameter_types! {
 	pub BaseRate: u128 = aca_per_second();
 
 	/// Location of Asset Hub
-	 pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
+	 pub AssetHubLocation: Location = Location::new(1, [Parachain(parachains::asset_hub_polkadot::ID)]);
 	 pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		 RelayLocationFilter::get(),
 		 AssetHubLocation::get()

--- a/runtime/acala/src/xcm_config.rs
+++ b/runtime/acala/src/xcm_config.rs
@@ -97,11 +97,11 @@ parameter_types! {
 	pub BaseRate: u128 = aca_per_second();
 
 	/// Location of Asset Hub
-	 pub AssetHubLocation: Location = Location::new(1, [Parachain(parachains::asset_hub_polkadot::ID)]);
-	 pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
-		 RelayLocationFilter::get(),
-		 AssetHubLocation::get()
-	 );
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(parachains::asset_hub_polkadot::ID)]);
+	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
+		RelayLocationFilter::get(),
+		AssetHubLocation::get()
+	);
 }
 
 type Reserves = (

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -681,7 +681,7 @@ impl module_prices::Config for Test {
 /// mock XCM transfer.
 pub struct MockHomaSubAccountXcm;
 impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
-	type AssetHubAccountId = AccountId;
+	type NomineeId = AccountId;
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
 		Currencies::withdraw(
 			StakingCurrencyId::get(),
@@ -703,7 +703,7 @@ impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 		Ok(())
 	}
 
-	fn nominate_on_sub_account(_: u16, _: Vec<Self::AssetHubAccountId>) -> DispatchResult {
+	fn nominate_on_sub_account(_: u16, _: Vec<Self::NomineeId>) -> DispatchResult {
 		Ok(())
 	}
 

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -681,7 +681,7 @@ impl module_prices::Config for Test {
 /// mock XCM transfer.
 pub struct MockHomaSubAccountXcm;
 impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
-	type RelayChainAccountId = AccountId;
+	type AssetHubAccountId = AccountId;
 	fn transfer_staking_to_sub_account(sender: &AccountId, _: u16, amount: Balance) -> DispatchResult {
 		Currencies::withdraw(
 			StakingCurrencyId::get(),
@@ -703,7 +703,7 @@ impl HomaSubAccountXcm<AccountId, Balance> for MockHomaSubAccountXcm {
 		Ok(())
 	}
 
-	fn nominate_on_sub_account(_: u16, _: Vec<Self::RelayChainAccountId>) -> DispatchResult {
+	fn nominate_on_sub_account(_: u16, _: Vec<Self::AssetHubAccountId>) -> DispatchResult {
 		Ok(())
 	}
 

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -66,6 +66,7 @@ xcm = { workspace = true, features = ["std"] }
 xcm-executor = { workspace = true, features = ["std"] }
 xcm-builder = { workspace = true, features = ["std"] }
 pallet-xcm = { workspace = true, features = ["std"] }
+polkadot-parachain-primitives = { workspace = true, features = ["std"] }
 
 # orml
 orml-auction = { workspace = true, features = ["std"] }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -107,7 +107,7 @@ module-support = { workspace = true, features = ["std"] }
 module-xcm-interface = { workspace = true, features = ["std"] }
 module-homa = { workspace = true, features = ["std"] }
 module-session-manager = { workspace = true, features = ["std"] }
-module-relaychain = { workspace = true, features = ["std"] }
+module-assethub = { workspace = true, features = ["std"] }
 
 primitives = { workspace = true, features = ["std"] }
 runtime-common = { workspace = true, features = ["std"] }

--- a/runtime/integration-tests/src/runtime.rs
+++ b/runtime/integration-tests/src/runtime.rs
@@ -290,30 +290,45 @@ fn currency_id_convert() {
 #[test]
 fn parachain_subaccounts_are_unique() {
 	ExtBuilder::default().build().execute_with(|| {
-		let parachain: AccountId = ParachainInfo::parachain_id().into_account_truncating();
+		let parachain: AccountId = ParachainInfo::get().into_account_truncating();
 		assert_eq!(
 			parachain,
 			hex_literal::hex!["70617261d0070000000000000000000000000000000000000000000000000000"].into()
+		);
+
+		let sibling: AccountId =
+			polkadot_parachain_primitives::primitives::Sibling::from(ParachainInfo::get()).into_account_truncating();
+		assert_eq!(
+			sibling,
+			hex_literal::hex!["7369626cd0070000000000000000000000000000000000000000000000000000"].into()
 		);
 
 		assert_eq!(
 			create_x2_parachain_location(0),
 			Location::new(
 				1,
-				[Junction::AccountId32 {
-					network: None,
-					id: hex_literal::hex!["d7b8926b326dd349355a9a7cca6606c1e0eb6fd2b506066b518c7155ff0d8297"].into(),
-				}]
+				[
+					Parachain(1000),
+					Junction::AccountId32 {
+						network: None,
+						id: hex_literal::hex!["50ca9b6bf6c83ca2a918b9861788d6facd26e5fd78a07f9848070697683745b3"]
+							.into(),
+					}
+				]
 			),
 		);
 		assert_eq!(
 			create_x2_parachain_location(1),
 			Location::new(
 				1,
-				[Junction::AccountId32 {
-					network: None,
-					id: hex_literal::hex!["74d37d762e06c6841a5dad64463a9afe0684f7e45245f6a7296ca613cca74669"].into(),
-				}]
+				[
+					Parachain(1000),
+					Junction::AccountId32 {
+						network: None,
+						id: hex_literal::hex!["025f1ca0b76b0d646f33b799a040df9fc14e06b7486770656766e8e8381f6c6f"]
+							.into(),
+					}
+				]
 			),
 		);
 	});

--- a/runtime/integration-tests/src/runtime.rs
+++ b/runtime/integration-tests/src/runtime.rs
@@ -304,32 +304,12 @@ fn parachain_subaccounts_are_unique() {
 		);
 
 		assert_eq!(
-			create_x2_parachain_location(0),
-			Location::new(
-				1,
-				[
-					Parachain(1000),
-					Junction::AccountId32 {
-						network: None,
-						id: hex_literal::hex!["50ca9b6bf6c83ca2a918b9861788d6facd26e5fd78a07f9848070697683745b3"]
-							.into(),
-					}
-				]
-			),
+			SubAccountIndexAccountIdConvertor::convert(0),
+			hex_literal::hex!["50ca9b6bf6c83ca2a918b9861788d6facd26e5fd78a07f9848070697683745b3"].into()
 		);
 		assert_eq!(
-			create_x2_parachain_location(1),
-			Location::new(
-				1,
-				[
-					Parachain(1000),
-					Junction::AccountId32 {
-						network: None,
-						id: hex_literal::hex!["025f1ca0b76b0d646f33b799a040df9fc14e06b7486770656766e8e8381f6c6f"]
-							.into(),
-					}
-				]
-			),
+			SubAccountIndexAccountIdConvertor::convert(1),
+			hex_literal::hex!["025f1ca0b76b0d646f33b799a040df9fc14e06b7486770656766e8e8381f6c6f"].into()
 		);
 	});
 }

--- a/runtime/integration-tests/src/setup.rs
+++ b/runtime/integration-tests/src/setup.rs
@@ -60,17 +60,17 @@ mod mandala_imports {
 	pub use mandala_runtime::xcm_config::*;
 	use mandala_runtime::AlternativeFeeSurplus;
 	pub use mandala_runtime::{
-		create_x2_parachain_location, get_all_module_accounts, AcalaOracle, AcalaSwap, AccountId, AggregatedDex,
-		AssetRegistry, AuctionManager, Aura, AuraExt, Authority, AuthoritysOriginId, Authorship, Balance, Balances,
-		BlockNumber, CDPEnginePalletId, CDPTreasuryPalletId, CdpEngine, CdpTreasury, CollatorSelection,
-		CreateClassDeposit, CreateTokenDeposit, Currencies, CurrencyId, DataDepositPerByte, DealWithFees,
-		DefaultDebitExchangeRate, DefaultExchangeRate, Dex, EmergencyShutdown, EvmAccounts, ExistentialDeposits,
-		FinancialCouncil, GetNativeCurrencyId, Homa, Honzon, IdleScheduler, Loans, MinRewardDistributeAmount,
-		MinimumDebitValue, NativeTokenExistentialDeposit, NftPalletId, OneDay, OriginCaller, ParachainInfo,
-		ParachainSystem, Proxy, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Scheduler, Session, SessionKeys,
-		SessionManager, SevenDays, StableAsset, StableAssetPalletId, System, Timestamp, TokenSymbol, Tokens,
-		TransactionPayment, TransactionPaymentPalletId, TreasuryAccount, TreasuryPalletId, UncheckedExtrinsic, Utility,
-		Vesting, XcmInterface, EVM, NFT,
+		get_all_module_accounts, AcalaOracle, AcalaSwap, AccountId, AggregatedDex, AssetRegistry, AuctionManager, Aura,
+		AuraExt, Authority, AuthoritysOriginId, Authorship, Balance, Balances, BlockNumber, CDPEnginePalletId,
+		CDPTreasuryPalletId, CdpEngine, CdpTreasury, CollatorSelection, CreateClassDeposit, CreateTokenDeposit,
+		Currencies, CurrencyId, DataDepositPerByte, DealWithFees, DefaultDebitExchangeRate, DefaultExchangeRate, Dex,
+		EmergencyShutdown, EvmAccounts, ExistentialDeposits, FinancialCouncil, GetNativeCurrencyId, Homa, Honzon,
+		IdleScheduler, Loans, MinRewardDistributeAmount, MinimumDebitValue, NativeTokenExistentialDeposit, NftPalletId,
+		OneDay, OriginCaller, ParachainInfo, ParachainSystem, Proxy, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
+		Scheduler, Session, SessionKeys, SessionManager, SevenDays, StableAsset, StableAssetPalletId,
+		SubAccountIndexAccountIdConvertor, System, Timestamp, TokenSymbol, Tokens, TransactionPayment,
+		TransactionPaymentPalletId, TreasuryAccount, TreasuryPalletId, UncheckedExtrinsic, Utility, Vesting,
+		XcmInterface, EVM, NFT,
 	};
 	use primitives::TradingPair;
 	use runtime_common::{ACA, AUSD, DOT, LDOT};
@@ -106,16 +106,17 @@ mod karura_imports {
 	pub use karura_runtime::xcm_config::*;
 	use karura_runtime::AlternativeFeeSurplus;
 	pub use karura_runtime::{
-		constants::parachains, create_x2_parachain_location, get_all_module_accounts, AcalaOracle, AcalaSwap,
-		AccountId, AggregatedDex, AssetRegistry, AuctionManager, Aura, AuraExt, Authority, AuthoritysOriginId, Balance,
-		Balances, BlockNumber, CDPEnginePalletId, CDPTreasuryPalletId, CdpEngine, CdpTreasury, CreateClassDeposit,
-		CreateTokenDeposit, Currencies, CurrencyId, DataDepositPerByte, DefaultDebitExchangeRate, DefaultExchangeRate,
-		Dex, EmergencyShutdown, EvmAccounts, ExistentialDeposits, FinancialCouncil, GetNativeCurrencyId, Homa, Honzon,
+		constants::parachains, get_all_module_accounts, AcalaOracle, AcalaSwap, AccountId, AggregatedDex,
+		AssetRegistry, AuctionManager, Aura, AuraExt, Authority, AuthoritysOriginId, Balance, Balances, BlockNumber,
+		CDPEnginePalletId, CDPTreasuryPalletId, CdpEngine, CdpTreasury, CreateClassDeposit, CreateTokenDeposit,
+		Currencies, CurrencyId, DataDepositPerByte, DefaultDebitExchangeRate, DefaultExchangeRate, Dex,
+		EmergencyShutdown, EvmAccounts, ExistentialDeposits, FinancialCouncil, GetNativeCurrencyId, Homa, Honzon,
 		IdleScheduler, KaruraFoundationAccounts, Loans, MinimumDebitValue, NativeTokenExistentialDeposit, NftPalletId,
 		OneDay, OriginCaller, ParachainAccount, ParachainInfo, ParachainSystem, PolkadotXcm, Proxy, Runtime,
 		RuntimeCall, RuntimeEvent, RuntimeOrigin, Scheduler, Session, SessionManager, SevenDays, StableAsset,
-		StableAssetPalletId, System, Timestamp, TokenSymbol, Tokens, TransactionPayment, TransactionPaymentPalletId,
-		TreasuryPalletId, Utility, Vesting, XTokens, XcmInterface, EVM, NFT,
+		StableAssetPalletId, SubAccountIndexAccountIdConvertor, System, Timestamp, TokenSymbol, Tokens,
+		TransactionPayment, TransactionPaymentPalletId, TreasuryPalletId, Utility, Vesting, XTokens, XcmInterface, EVM,
+		NFT,
 	};
 	use primitives::TradingPair;
 	use runtime_common::{KAR, KSM, KUSD, LKSM};
@@ -150,17 +151,16 @@ mod acala_imports {
 	pub use acala_runtime::xcm_config::*;
 	use acala_runtime::AlternativeFeeSurplus;
 	pub use acala_runtime::{
-		constants::parachains, create_x2_parachain_location, get_all_module_accounts, AcalaFoundationAccounts,
-		AcalaOracle, AcalaSwap, AccountId, AggregatedDex, AssetRegistry, AuctionManager, Aura, AuraExt, Authority,
-		AuthoritysOriginId, Balance, Balances, BlockNumber, CDPEnginePalletId, CDPTreasuryPalletId, CdpEngine,
-		CdpTreasury, CreateClassDeposit, CreateTokenDeposit, Currencies, CurrencyId, DataDepositPerByte,
-		DefaultDebitExchangeRate, DefaultExchangeRate, Dex, EmergencyShutdown, EvmAccounts, ExistentialDeposits,
-		FinancialCouncil, GetNativeCurrencyId, Homa, Honzon, IdleScheduler, Loans, MinimumDebitValue,
-		NativeTokenExistentialDeposit, NftPalletId, OneDay, OriginCaller, ParachainAccount, ParachainInfo,
-		ParachainSystem, PolkadotXcm, Proxy, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Scheduler, Session,
-		SessionManager, SevenDays, StableAsset, StableAssetPalletId, System, Timestamp, TokenSymbol, Tokens,
-		TransactionPayment, TransactionPaymentPalletId, TreasuryPalletId, Utility, Vesting, XTokens, XcmInterface, EVM,
-		NFT,
+		constants::parachains, get_all_module_accounts, AcalaFoundationAccounts, AcalaOracle, AcalaSwap, AccountId,
+		AggregatedDex, AssetRegistry, AuctionManager, Aura, AuraExt, Authority, AuthoritysOriginId, Balance, Balances,
+		BlockNumber, CDPEnginePalletId, CDPTreasuryPalletId, CdpEngine, CdpTreasury, CreateClassDeposit,
+		CreateTokenDeposit, Currencies, CurrencyId, DataDepositPerByte, DefaultDebitExchangeRate, DefaultExchangeRate,
+		Dex, EmergencyShutdown, EvmAccounts, ExistentialDeposits, FinancialCouncil, GetNativeCurrencyId, Homa, Honzon,
+		IdleScheduler, Loans, MinimumDebitValue, NativeTokenExistentialDeposit, NftPalletId, OneDay, OriginCaller,
+		ParachainAccount, ParachainInfo, ParachainSystem, PolkadotXcm, Proxy, Runtime, RuntimeCall, RuntimeEvent,
+		RuntimeOrigin, Scheduler, Session, SessionManager, SevenDays, StableAsset, StableAssetPalletId,
+		SubAccountIndexAccountIdConvertor, System, Timestamp, TokenSymbol, Tokens, TransactionPayment,
+		TransactionPaymentPalletId, TreasuryPalletId, Utility, Vesting, XTokens, XcmInterface, EVM, NFT,
 	};
 	use frame_support::parameter_types;
 	use primitives::TradingPair;

--- a/runtime/karura/Cargo.toml
+++ b/runtime/karura/Cargo.toml
@@ -120,7 +120,7 @@ module-incentives = { workspace = true }
 module-loans = { workspace = true }
 module-nft = { workspace = true }
 module-prices = { workspace = true }
-module-relaychain = { workspace = true }
+module-assethub = { workspace = true }
 module-session-manager = { workspace = true }
 module-support = { workspace = true }
 module-transaction-pause = { workspace = true }
@@ -261,7 +261,7 @@ std = [
 	"module-loans/std",
 	"module-nft/std",
 	"module-prices/std",
-	"module-relaychain/std",
+	"module-assethub/std",
 	"module-session-manager/std",
 	"module-support/std",
 	"module-transaction-pause/std",

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -53,11 +53,11 @@ use sp_version::RuntimeVersion;
 
 use frame_system::{EnsureRoot, EnsureSigned, RawOrigin};
 use module_asset_registry::{AssetIdMaps, EvmErc20InfoMapping};
+use module_assethub::AssetHubCallBuilder;
 use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_relaychain::RelayChainCallBuilder;
 use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, ExchangeRateProvider, FractionalRate, PoolId};
 use module_transaction_payment::TargetedFeeAdjustment;
 
@@ -1631,7 +1631,7 @@ parameter_types! {
 
 impl module_homa_validator_list::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RelayChainAccountId = AccountId;
+	type ValidatorId = AccountId;
 	type LiquidTokenCurrency = module_currencies::Currency<Runtime, GetLiquidCurrencyId>;
 	type MinBondAmount = MinBondAmount;
 	type BondingDuration = BondingDuration;
@@ -1697,9 +1697,9 @@ impl module_xcm_interface::Config for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfGeneralCouncil;
 	type StakingCurrencyId = GetStakingCurrencyId;
 	type ParachainAccount = ParachainAccount;
-	type RelayChainUnbondingSlashingSpans = ConstU32<5>;
+	type AssetHubUnbondingSlashingSpans = ConstU32<5>;
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
-	type RelayChainCallBuilder = RelayChainCallBuilder<ParachainInfo, module_relaychain::KusamaRelayChainCall>;
+	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::KusamaAssetHubCall>;
 	type XcmTransfer = XTokens;
 	type SelfLocation = xcm_config::SelfLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -115,7 +115,6 @@ use runtime_common::{
 	Rate, Ratio, RuntimeBlockLength, RuntimeBlockWeights, TechnicalCommitteeInstance,
 	TechnicalCommitteeMembershipInstance, TimeStampedPrice, TipPerWeightStep, KAR, KSM, KUSD, LKSM, TAI,
 };
-use xcm::v4::prelude::*;
 
 /// Import the stable_asset pallet.
 pub use nutsfinance_stable_asset;
@@ -1664,27 +1663,13 @@ impl module_nominees_election::Config for Runtime {
 	type WeightInfo = weights::module_nominees_election::WeightInfo<Runtime>;
 }
 
-pub fn create_x2_parachain_location(index: u16) -> Location {
-	Location::new(
-		1,
-		[
-			Parachain(parachains::asset_hub_kusama::ID),
-			AccountId32 {
-				network: None,
-				id: Utility::derivative_account_id(
-					Sibling::from(ParachainInfo::get()).into_account_truncating(),
-					index,
-				)
-				.into(),
-			},
-		],
-	)
-}
-
-pub struct SubAccountIndexLocationConvertor;
-impl Convert<u16, Location> for SubAccountIndexLocationConvertor {
-	fn convert(sub_account_index: u16) -> Location {
-		create_x2_parachain_location(sub_account_index)
+pub struct SubAccountIndexAccountIdConvertor;
+impl Convert<u16, AccountId> for SubAccountIndexAccountIdConvertor {
+	fn convert(sub_account_index: u16) -> AccountId {
+		Utility::derivative_account_id(
+			Sibling::from(ParachainInfo::get()).into_account_truncating(),
+			sub_account_index,
+		)
 	}
 }
 
@@ -1695,12 +1680,10 @@ parameter_types! {
 impl module_xcm_interface::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type UpdateOrigin = EnsureRootOrHalfGeneralCouncil;
-	type StakingCurrencyId = GetStakingCurrencyId;
 	type ParachainAccount = ParachainAccount;
 	type AssetHubUnbondingSlashingSpans = ConstU32<5>;
-	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
+	type SovereignSubAccountIdConvert = SubAccountIndexAccountIdConvertor;
 	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::KusamaAssetHubCall>;
-	type XcmTransfer = XTokens;
 	type AssetHubLocation = xcm_config::AssetHubLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;
 }

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -1701,7 +1701,7 @@ impl module_xcm_interface::Config for Runtime {
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
 	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::KusamaAssetHubCall>;
 	type XcmTransfer = XTokens;
-	type SelfLocation = xcm_config::SelfLocation;
+	type AssetHubLocation = xcm_config::AssetHubLocation;
 	type AccountIdToLocation = runtime_common::xcm_config::AccountIdToLocation;
 }
 

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -31,6 +31,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
+use polkadot_parachain_primitives::primitives::Sibling;
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -1594,9 +1595,9 @@ parameter_types! {
 	pub DefaultExchangeRate: ExchangeRate = ExchangeRate::saturating_from_rational(1, 10);
 	pub HomaTreasuryAccount: AccountId = HomaTreasuryPalletId::get().into_account_truncating();
 	pub ActiveSubAccountsIndexList: Vec<u16> = vec![
-		0,  // HTAeD1dokCVs9MwnC1q9s2a7d2kQ52TAjrxE1y5mj5MFLLA
-		1,  // FDVu3RdH5WsE2yTdXN3QMq6v1XVDK8GKjhq5oFjXe8wZYpL
-		2,  // EMrKvFy7xLgzzdgruXT9oXERt553igEScqgSjoDm3GewPSA
+		0,  // EQFY1VnjdYUSJ9oWoNgunPHeqLFooyPF3r6ZkTbCU5a6Eez
+		1,  // CdRsH6LC4yVvSH4XC2qmtPhuAoQEqedBdmnfaYPSVh5TDZ7
+		2,  // HZyWwhbi8yWGK6HJGjgYWQtszPvggLUrQDX9PR6StbmPwHP
 	];
 	pub MintThreshold: Balance = 10 * cent(KSM);
 	pub RedeemThreshold: Balance = 50 * cent(LKSM);
@@ -1666,10 +1667,17 @@ impl module_nominees_election::Config for Runtime {
 pub fn create_x2_parachain_location(index: u16) -> Location {
 	Location::new(
 		1,
-		AccountId32 {
-			network: None,
-			id: Utility::derivative_account_id(ParachainInfo::get().into_account_truncating(), index).into(),
-		},
+		[
+			Parachain(parachains::asset_hub_kusama::ID),
+			AccountId32 {
+				network: None,
+				id: Utility::derivative_account_id(
+					Sibling::from(ParachainInfo::get()).into_account_truncating(),
+					index,
+				)
+				.into(),
+			},
+		],
 	)
 }
 
@@ -1681,7 +1689,7 @@ impl Convert<u16, Location> for SubAccountIndexLocationConvertor {
 }
 
 parameter_types! {
-	pub ParachainAccount: AccountId = ParachainInfo::get().into_account_truncating();
+	pub ParachainAccount: AccountId = Sibling::from(ParachainInfo::get()).into_account_truncating();
 }
 
 impl module_xcm_interface::Config for Runtime {

--- a/runtime/karura/src/xcm_config.rs
+++ b/runtime/karura/src/xcm_config.rs
@@ -139,7 +139,7 @@ parameter_types! {
 	pub BaseRate: u128 = kar_per_second();
 
 	/// Location of Asset Hub
-	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(parachains::asset_hub_kusama::ID)]);
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()
@@ -149,7 +149,7 @@ parameter_types! {
 type Reserves = (
 	// Assets bridged from different consensus systems held in reserve on Asset Hub.
 	IsBridgedConcreteAssetFrom<AssetHubLocation>,
-	// Relaychain (DOT) from Asset Hub
+	// Relaychain (KSM) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets which the reserve is the same as the origin.
 	MultiNativeAsset<AbsoluteReserveProvider>,

--- a/runtime/mandala/Cargo.toml
+++ b/runtime/mandala/Cargo.toml
@@ -128,7 +128,7 @@ module-homa-validator-list = { workspace = true }
 module-xcm-interface = { workspace = true }
 module-nominees-election = { workspace = true }
 module-session-manager = { workspace = true }
-module-relaychain = { workspace = true }
+module-assethub = { workspace = true }
 module-idle-scheduler = { workspace = true }
 module-aggregated-dex = { workspace = true }
 module-liquid-crowdloan = { workspace = true }
@@ -274,7 +274,7 @@ std = [
 	"module-nft/std",
 	"module-nominees-election/std",
 	"module-prices/std",
-	"module-relaychain/std",
+	"module-assethub/std",
 	"module-session-manager/std",
 	"module-support/std",
 	"module-transaction-pause/std",

--- a/runtime/mandala/src/benchmarking/homa_validator_list.rs
+++ b/runtime/mandala/src/benchmarking/homa_validator_list.rs
@@ -136,7 +136,7 @@ runtime_benchmarks! {
 			)?;
 			slashes.push(SlashInfo{
 				validator,
-				relaychain_token_amount: ValidatorInsuranceThreshold::get() * 9
+				token_amount: ValidatorInsuranceThreshold::get() * 9
 			});
 		}
 	}: _(RawOrigin::Root, slashes)

--- a/runtime/mandala/src/constants.rs
+++ b/runtime/mandala/src/constants.rs
@@ -91,6 +91,12 @@ pub mod fee {
 	}
 }
 
+pub mod parachains {
+	pub mod asset_hub_polkadot {
+		pub const ID: u32 = 1000;
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::{constants::fee::base_tx_in_aca, Balance};

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -1432,7 +1432,7 @@ pub fn create_x2_parachain_location(index: u16) -> Location {
 parameter_types! {
 	pub HomaTreasuryAccount: AccountId = HomaTreasuryPalletId::get().into_account_truncating();
 	pub ActiveSubAccountsIndexList: Vec<u16> = vec![
-		0,  // 15sr8Dvq3AT3Z2Z1y8FnQ4VipekAHhmQnrkgzegUr1tNgbcn
+		0,  // 12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7
 	];
 	pub MintThreshold: Balance = dollar(DOT);
 	pub RedeemThreshold: Balance = 10 * dollar(LDOT);
@@ -1519,7 +1519,7 @@ impl module_xcm_interface::Config for Runtime {
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
 	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::PolkadotAssetHubCall>;
 	type XcmTransfer = XTokens;
-	type SelfLocation = xcm_config::SelfLocation;
+	type AssetHubLocation = xcm_config::AssetHubLocation;
 	type AccountIdToLocation = xcm_config::AccountIdToLocation;
 }
 

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -94,7 +94,7 @@ pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Percent, Permill, Perquintill};
 
 pub use authority::AuthorityConfigImpl;
-pub use constants::{fee::*, time::*};
+pub use constants::{fee::*, parachains, time::*};
 pub use primitives::{
 	currency::AssetIds,
 	evm::{BlockLimits, EstimateResourcesRequest},
@@ -1416,7 +1416,7 @@ pub fn create_x2_parachain_location(index: u16) -> Location {
 	Location::new(
 		1,
 		[
-			Parachain(1000),
+			Parachain(parachains::asset_hub_polkadot::ID),
 			AccountId32 {
 				network: None,
 				id: Utility::derivative_account_id(

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -56,6 +56,7 @@ use module_relaychain::RelayChainCallBuilder;
 use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, ExchangeRateProvider, FractionalRate, PoolId};
 use module_transaction_payment::TargetedFeeAdjustment;
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
+use polkadot_parachain_primitives::primitives::Sibling;
 use scale_info::TypeInfo;
 
 use orml_tokens::CurrencyAdapter;
@@ -1414,10 +1415,17 @@ parameter_types! {
 pub fn create_x2_parachain_location(index: u16) -> Location {
 	Location::new(
 		1,
-		AccountId32 {
-			network: None,
-			id: Utility::derivative_account_id(ParachainInfo::get().into_account_truncating(), index).into(),
-		},
+		[
+			Parachain(1000),
+			AccountId32 {
+				network: None,
+				id: Utility::derivative_account_id(
+					Sibling::from(ParachainInfo::get()).into_account_truncating(),
+					index,
+				)
+				.into(),
+			},
+		],
 	)
 }
 
@@ -1492,7 +1500,7 @@ impl module_nominees_election::Config for Runtime {
 }
 
 parameter_types! {
-	pub ParachainAccount: AccountId = ParachainInfo::get().into_account_truncating();
+	pub ParachainAccount: AccountId = Sibling::from(ParachainInfo::get()).into_account_truncating();
 }
 
 pub struct SubAccountIndexLocationConvertor;

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -48,11 +48,11 @@ use frame_support::{
 };
 use frame_system::{EnsureRoot, EnsureSigned, RawOrigin};
 use module_asset_registry::{AssetIdMaps, EvmErc20InfoMapping};
+use module_assethub::AssetHubCallBuilder;
 use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_relaychain::RelayChainCallBuilder;
 use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, ExchangeRateProvider, FractionalRate, PoolId};
 use module_transaction_payment::TargetedFeeAdjustment;
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
@@ -1466,7 +1466,7 @@ parameter_types! {
 
 impl module_homa_validator_list::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RelayChainAccountId = AccountId;
+	type ValidatorId = AccountId;
 	type LiquidTokenCurrency = module_currencies::Currency<Runtime, GetLiquidCurrencyId>;
 	type MinBondAmount = MinBondAmount;
 	type BondingDuration = BondingDuration;
@@ -1515,9 +1515,9 @@ impl module_xcm_interface::Config for Runtime {
 	type UpdateOrigin = EnsureRootOrHalfGeneralCouncil;
 	type StakingCurrencyId = GetStakingCurrencyId;
 	type ParachainAccount = ParachainAccount;
-	type RelayChainUnbondingSlashingSpans = ConstU32<5>;
+	type AssetHubUnbondingSlashingSpans = ConstU32<5>;
 	type SovereignSubAccountLocationConvert = SubAccountIndexLocationConvertor;
-	type RelayChainCallBuilder = RelayChainCallBuilder<ParachainInfo, module_relaychain::PolkadotRelayChainCall>;
+	type AssetHubCallBuilder = AssetHubCallBuilder<ParachainInfo, module_assethub::PolkadotAssetHubCall>;
 	type XcmTransfer = XTokens;
 	type SelfLocation = xcm_config::SelfLocation;
 	type AccountIdToLocation = xcm_config::AccountIdToLocation;

--- a/runtime/mandala/src/xcm_config.rs
+++ b/runtime/mandala/src/xcm_config.rs
@@ -17,10 +17,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-	constants::fee::*, AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert,
-	Currencies, CurrencyId, EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue,
-	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, TreasuryAccount, UnknownTokens, XcmpQueue, ACA,
+	AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert, Currencies, CurrencyId,
+	EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue, NativeTokenExistentialDeposit,
+	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, TreasuryAccount,
+	UnknownTokens, XcmpQueue, ACA,
+	{constants::fee::*, parachains},
 };
 pub use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 pub use frame_support::{
@@ -330,6 +331,7 @@ impl Convert<AccountId, Location> for AccountIdToLocation {
 
 parameter_types! {
 	pub SelfLocation: Location = Location::new(1, Parachain(ParachainInfo::get().into()));
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(parachains::asset_hub_polkadot::ID)]);
 	pub const BaseXcmWeight: XcmWeight = XcmWeight::from_parts(100_000_000, 0);
 	pub const MaxAssetsForTransfer: usize = 2;
 }

--- a/runtime/mandala/src/xcm_config.rs
+++ b/runtime/mandala/src/xcm_config.rs
@@ -17,11 +17,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-	constants::{fee::*, parachains},
-	AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert, Currencies, CurrencyId,
-	EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue, NativeTokenExistentialDeposit,
-	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, TreasuryAccount,
-	UnknownTokens, XcmpQueue, ACA,
+	constants::fee::*, AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert,
+	Currencies, CurrencyId, EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue,
+	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
+	RuntimeOrigin, TreasuryAccount, UnknownTokens, XcmpQueue, ACA,
 };
 pub use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 pub use frame_support::{

--- a/runtime/mandala/src/xcm_config.rs
+++ b/runtime/mandala/src/xcm_config.rs
@@ -17,10 +17,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-	constants::fee::*, AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert,
-	Currencies, CurrencyId, EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue,
-	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, TreasuryAccount, UnknownTokens, XcmpQueue, ACA,
+	constants::{fee::*, parachains},
+	AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert, Currencies, CurrencyId,
+	EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue, NativeTokenExistentialDeposit,
+	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, TreasuryAccount,
+	UnknownTokens, XcmpQueue, ACA,
 };
 pub use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 pub use frame_support::{


### PR DESCRIPTION
# Major changes:
- rename relaychain to assethub
- `SubAccountIndexAccountIdConvertor` use `sibling:2000` instead of `para:2000`
- xcm-interface send xcm to assethub instead of relaychain


tested with polkadot_assethub https://github.com/polkadot-fellows/runtimes/pull/812

Setup:
```
# acala.yml
import-storage:
  Homa:
    NominateIntervalEra: 1
  XcmInterface:
    XcmDestWeightAndFee:
     - [[HomaNominate], [{refTime: 5000000000, proofSize: 131072}, 5000000000]]
```

sibling:2000:
13cKp89Msu7M2PiaCuuGr1BzAsD5V3vaVbDMs3YtjMZHdGwR
sibling:2000 index 0:
12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7

```
# assethub.yml
import-storage:
  System:
    Account:
      - [[12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7], { providers: 1, data: { free: '46104761056640463', reserved: '200410000000', frozen: '46101975004999542'}}]
      - [[13cKp89Msu7M2PiaCuuGr1BzAsD5V3vaVbDMs3YtjMZHdGwR], { providers: 1, data: { free: '31888059184720240', reserved: '3400000000000', frozen: '0'}}]
  Staking:
    Validators:
      - [[1d6po5LATxuHeAUTSRd61LGA6QWJ7dJRzi852kojKFLbL3t], { commission: 0, blocked: false }]
      - [[14N5nJ4oR4Wj36DsBcPLh1JqjvrM2Uf23No2yc2ojjCvSC24], { commission: 0, blocked: false }]
      - [[14bUYpiF2oxVpmXDnFxBipSi4m9zYBThMZoLpY8bRQrPQNG1], { commission: 0, blocked: false }]
      - [[14zf4PVrmW7LwLptMkZwhKK2fwroFnMpMLrKiy5jpYCMZBwW], { commission: 0, blocked: false }]
      - [[1569aqCBma2m4TuUe1MxEs8EXBAZFCmwwcZMLde6HNbimuW8], { commission: 0, blocked: false }]
      - [[15XY7oJ99hVscy5jS3zUh5M3H6sxfccovyTVCPt15DuXCRAF], { commission: 0, blocked: false }]
      - [[15iA5hpjUecWBbf38Nfegwmtyux25o3LrGaNodfZDxq5nXXE], { commission: 0, blocked: false }]
      - [[16NWoCHEY67DDHCLe76QhgKD3AAcRQtarY54FFQQaJeftJNu], { commission: 0, blocked: false }]
      - [[15faP4KV8Puvtex2WXnhUoeedhNpTPt4jWcAmZVsUuNMVvUX], { commission: 0, blocked: false }]
      - [[14AakQ4jAmr2ytcrhfmaiHMpj5F9cR6wK1jRrdfC3N1oTbUz], { commission: 0, blocked: false }]
    Bonded:
      - [[12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7], 12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7]
    ledger:
      - [
          [12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7],
          {
            stash: 12pw22Qyy3o28BLshjce9yrSMs3fhSiLsAjqLPAzGktbXYV7,
            total: '46089842061525133',
            active: '42618337842051333',
            unlocking: [
              {
                value: '1133844989535540',
                era: 1872
              },
              {
                value: '1344224653780',
                era: 1874
              },
              {
                value: '17771827209997',
                era: 1876
              },
              {
                value: '16958447545257',
                era: 1877
              },
              {
                value: '184943273868892',
                era: 1878
              },
              {
                value: '413412872141',
                era: 1879
              },
              {
                value: '351965507879238',
                era: 1880
              },
              {
                value: '46970182113266',
                era: 1881
              },
              {
                value: '99129426941179',
                era: 1882
              },
              {
                value: '109664158945638',
                era: 1886
                            },
              {
                value: '2924577587526',
                era: 1887
              },
              {
                value: '387132826378',
                era: 1888
              },
              {
                value: '5111759292783',
                era: 1889
              },
              {
                value: '4562923830023',
                era: 1890,
              },
              {
                value: '8813734252312',
                era: 1893
              },
              {
                value: '139948127216953',
                era: 1894
              },
              {
                value: '91995244397781',
                era: 1895
              },
              {
                value: '1182402471390744',
                era: 1896
              },
              {
                value: '72352797114372',
                era: 1897
              }
            ]
          }
        ]
```


# TODO: 
- [x] debug and fix homa.nominate

```
xcm::validate_xcm_nesting  ERROR: [14] Decode error: Error for xcm: V4(Xcm([WithdrawAsset(Assets([Asset { id: AssetId(Location { parents: 1, interior: Here }), fun: Fungible(0) }])), BuyExecution { fees: Asset { id: AssetId(Location { parents: 1, interior: Here }), fun: Fungible(0) }, weight_limit: Unlimited }, Transact { origin_kind: SovereignAccount, require_weight_at_most: Weight { ref_time: 0, proof_size: 0 }, call: "0x2801000059050400ce5ca095000c6067e61d534542ca57971c066d8260c26ed6eaa66301ec2ebdf0" }, RefundSurplus, DepositAsset { assets: Wild(AllCounted(1)), beneficiary: Location { parents: 0, interior: X1([Parachain(2000)])
} }]))!
xcm-interface  DEBUG: [14] subaccount 0 send XCM to nominate [ce5ca095000c6067e61d534542ca57971c066d8260c26ed6eaa66301ec2ebdf0 (5GjHEj4R...)], result: Err(ExceedsMaxMessageSize)
```
- [ ] check staking pallet index of AssetHub on polkadot/kusama
