### PR TITLE
Update xtoken reserve provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Install deps
-        run: cargo +1.85.0 install staging-chain-spec-builder --force # base64ct 1.8.0 requires the Cargo feature called `edition2024`
+        run: cargo +1.87.0 install staging-chain-spec-builder --force # base64ct 1.8.0 requires the Cargo feature called `edition2024`
       - name: Run ts tests
         run: |
           npm install -g yarn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "nutsfinance-stable-asset",
  "orml-tokens",
+ "orml-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/modules/earning/src/lib.rs
+++ b/modules/earning/src/lib.rs
@@ -26,8 +26,8 @@ use frame_support::{
 	traits::{Currency, ExistenceRequirement, LockIdentifier, LockableCurrency, OnUnbalanced, WithdrawReasons},
 };
 use frame_system::pallet_prelude::*;
-use module_support::EarningManager;
-use orml_traits::{define_parameters, parameters::ParameterStore, Handler};
+use module_support::{EarningManager, EarningParameters, InstantUnstakeFee};
+use orml_traits::{parameters::ParameterStore, Handler};
 use primitives::{
 	bonding::{self, BondingController},
 	Balance,
@@ -45,12 +45,6 @@ pub mod weights;
 
 pub use weights::WeightInfo;
 
-define_parameters! {
-	pub Parameters = {
-		InstantUnstakeFee: Permill = 0,
-	}
-}
-
 #[frame_support::pallet]
 pub mod module {
 	use super::*;
@@ -61,7 +55,7 @@ pub mod module {
 
 		type Currency: LockableCurrency<Self::AccountId, Balance = Balance>;
 
-		type ParameterStore: ParameterStore<Parameters>;
+		type ParameterStore: ParameterStore<EarningParameters>;
 
 		type OnBonded: Handler<(Self::AccountId, Balance)>;
 		type OnUnbonded: Handler<(Self::AccountId, Balance)>;

--- a/modules/earning/src/mock.rs
+++ b/modules/earning/src/mock.rs
@@ -26,6 +26,7 @@ use frame_support::{
 	construct_runtime, derive_impl, parameter_types,
 	traits::{ConstU128, ConstU32, ConstU64, Imbalance},
 };
+use module_support::{EarningParameters, EarningParametersKey, EarningParametersValue};
 use pallet_balances::NegativeImbalance;
 use primitives::mock_handler;
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
@@ -73,17 +74,17 @@ impl OnUnbalanced<NegativeImbalance<Runtime>> for OnUnstakeFee {
 }
 
 pub struct ParameterStoreImpl;
-impl ParameterStore<Parameters> for ParameterStoreImpl {
+impl ParameterStore<EarningParameters> for ParameterStoreImpl {
 	fn get<K>(key: K) -> Option<K::Value>
 	where
 		K: orml_traits::parameters::Key
-			+ Into<<Parameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedKey>,
-		<Parameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedValue: TryInto<K::WrappedValue>,
+			+ Into<<EarningParameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedKey>,
+		<EarningParameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedValue: TryInto<K::WrappedValue>,
 	{
 		let key = key.into();
 		match key {
-			ParametersKey::InstantUnstakeFee(_) => Some(
-				ParametersValue::InstantUnstakeFee(Permill::from_percent(10))
+			EarningParametersKey::InstantUnstakeFee(_) => Some(
+				EarningParametersValue::InstantUnstakeFee(Permill::from_percent(10))
 					.try_into()
 					.ok()?
 					.into(),

--- a/modules/support/Cargo.toml
+++ b/modules/support/Cargo.toml
@@ -19,6 +19,7 @@ sp-io = { workspace = true }
 xcm = { workspace = true }
 
 orml-tokens = { workspace = true }
+orml-traits = { workspace = true }
 nutsfinance-stable-asset = { workspace = true }
 primitives = { workspace = true }
 
@@ -33,6 +34,7 @@ std = [
 	"frame-system/std",
 	"nutsfinance-stable-asset/std",
 	"orml-tokens/std",
+	"orml-traits/std",
 	"primitives/std",
 	"scale-info/std",
 	"serde",

--- a/modules/support/src/lib.rs
+++ b/modules/support/src/lib.rs
@@ -38,6 +38,7 @@ pub mod homa;
 pub mod honzon;
 pub mod incentives;
 pub mod mocks;
+pub mod parameters;
 pub mod stable_asset;
 
 pub use crate::bounded::*;
@@ -47,6 +48,7 @@ pub use crate::evm::*;
 pub use crate::homa::*;
 pub use crate::honzon::*;
 pub use crate::incentives::*;
+pub use crate::parameters::*;
 pub use crate::stable_asset::*;
 
 pub type Price = FixedU128;

--- a/modules/support/src/parameters.rs
+++ b/modules/support/src/parameters.rs
@@ -1,0 +1,40 @@
+// This file is part of Acala.
+
+// Copyright (C) 2020-2025 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Location;
+use orml_traits::{define_aggregrated_parameters, define_parameters};
+use sp_runtime::Permill;
+
+define_parameters! {
+	pub EarningParameters = {
+		InstantUnstakeFee: Permill = 0,
+	}
+}
+
+define_parameters! {
+	pub XtokensParameters = {
+		ReserveLocation: Location = 0,
+	}
+}
+
+define_aggregrated_parameters! {
+	pub RuntimeParameters = {
+		Earning: EarningParameters = 0,
+		Xtokens: XtokensParameters = 1,
+	}
+}

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -57,7 +57,10 @@ use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, PoolId};
+use module_support::{
+	AddressMapping, AssetIdMapping, DispatchableTask, EarningParameters, PoolId, ReserveLocation, RuntimeParameters,
+	XtokensParameters,
+};
 use module_transaction_payment::TargetedFeeAdjustment;
 
 use cumulus_pallet_parachain_system::RelaychainDataProvider;
@@ -77,8 +80,8 @@ use frame_support::{
 	PalletId,
 };
 use orml_traits::{
-	create_median_value_data_provider, define_aggregrated_parameters, parameter_type_with_key,
-	parameters::ParameterStoreAdapter, DataFeeder, DataProviderExtended, MultiCurrency,
+	create_median_value_data_provider, parameter_type_with_key, parameters::ParameterStoreAdapter, DataFeeder,
+	DataProviderExtended, MultiCurrency,
 };
 use pallet_transaction_payment::RuntimeDispatchInfo;
 
@@ -1799,7 +1802,7 @@ parameter_types! {
 impl module_earning::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type ParameterStore = ParameterStoreAdapter<Parameters, module_earning::Parameters>;
+	type ParameterStore = ParameterStoreAdapter<Parameters, EarningParameters>;
 	type OnBonded = module_incentives::OnEarningBonded<Runtime>;
 	type OnUnbonded = module_incentives::OnEarningUnbonded<Runtime>;
 	type OnUnstakeFee = Treasury; // fee goes to treasury
@@ -1808,12 +1811,6 @@ impl module_earning::Config for Runtime {
 	type MaxUnbondingChunks = ConstU32<10>;
 	type LockIdentifier = EarningLockIdentifier;
 	type WeightInfo = ();
-}
-
-define_aggregrated_parameters! {
-	pub RuntimeParameters = {
-		Earning: module_earning::Parameters = 0,
-	}
 }
 
 impl orml_parameters::Config for Runtime {

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -121,6 +121,7 @@ use runtime_common::{
 mod authority;
 mod benchmarking;
 pub mod constants;
+mod migrations;
 /// Weights for pallets used in the runtime.
 mod weights;
 pub mod xcm_config;
@@ -1976,7 +1977,7 @@ pub type Executive = frame_executive::Executive<
 >;
 
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (crate::migrations::v1::ParametersMigrateToV1<Runtime>,);
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/acala/src/migrations.rs
+++ b/runtime/acala/src/migrations.rs
@@ -1,0 +1,85 @@
+// This file is part of Acala.
+
+// Copyright (C) 2020-2025 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use frame_support::{pallet_prelude::StorageVersion, traits::GetStorageVersion, weights::Weight};
+
+pub mod v1 {
+	use super::*;
+	use frame_support::traits::OnRuntimeUpgrade;
+	use module_support::{RuntimeParametersKey, RuntimeParametersValue};
+	use orml_traits::parameters::AggregratedKeyValue;
+	use parity_scale_codec::EncodeLike;
+	use xcm::prelude::Location;
+
+	const LOG_TARGET: &str = "parameters::v1";
+
+	/// Migration to V1
+	pub struct ParametersMigrateToV1<T>(core::marker::PhantomData<T>);
+	impl<T: orml_parameters::Config> OnRuntimeUpgrade for ParametersMigrateToV1<T>
+	where
+		T::AggregratedKeyValue:
+			AggregratedKeyValue<AggregratedKey = RuntimeParametersKey, AggregratedValue = RuntimeParametersValue>,
+		RuntimeParametersKey: EncodeLike<<T::AggregratedKeyValue as AggregratedKeyValue>::AggregratedKey>,
+		RuntimeParametersValue: EncodeLike<<T::AggregratedKeyValue as AggregratedKeyValue>::AggregratedValue>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(target: LOG_TARGET, "Running on_runtime_upgrade()");
+
+			let version = Parameters::on_chain_storage_version();
+			if version == 0 {
+				let key_value = RuntimeParameters::Xtokens(XtokensParameters::ReserveLocation(
+					ReserveLocation,
+					Some(Location::parent()),
+				));
+
+				let (key, value) = key_value.clone().into_parts();
+
+				orml_parameters::Parameters::<T>::set(key, value);
+
+				StorageVersion::new(1).put::<Parameters>();
+
+				log::info!(target: LOG_TARGET, "Migrated on Parameters to v1");
+				T::DbWeight::get().reads_writes(1, 2)
+			} else {
+				log::info!(target: LOG_TARGET, "Parameters need to be removed");
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+			log::info!(target: LOG_TARGET, "Running pre_upgrade()");
+
+			let version = Pallet::<T>::on_chain_storage_version();
+			ensure!(version == 0, "parameters already migrated");
+
+			Ok(Vec::new())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			log::info!(target: LOG_TARGET, "Running post_upgrade()");
+
+			let version = Pallet::<T>::on_chain_storage_version();
+			ensure!(version == 1, "parameters migration failed");
+
+			Ok(())
+		}
+	}
+}

--- a/runtime/acala/src/migrations.rs
+++ b/runtime/acala/src/migrations.rs
@@ -21,10 +21,11 @@ use frame_support::{pallet_prelude::StorageVersion, traits::GetStorageVersion, w
 
 pub mod v1 {
 	use super::*;
-	use frame_support::traits::OnRuntimeUpgrade;
+	use frame_support::{ensure, traits::OnRuntimeUpgrade};
 	use module_support::{RuntimeParametersKey, RuntimeParametersValue};
 	use orml_traits::parameters::AggregratedKeyValue;
 	use parity_scale_codec::EncodeLike;
+	use sp_std::vec;
 	use xcm::prelude::Location;
 
 	const LOG_TARGET: &str = "parameters::v1";
@@ -63,20 +64,20 @@ pub mod v1 {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		fn pre_upgrade() -> Result<vec::Vec<u8>, sp_runtime::TryRuntimeError> {
 			log::info!(target: LOG_TARGET, "Running pre_upgrade()");
 
-			let version = Pallet::<T>::on_chain_storage_version();
+			let version = Parameters::on_chain_storage_version();
 			ensure!(version == 0, "parameters already migrated");
 
 			Ok(Vec::new())
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn post_upgrade(_state: vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 			log::info!(target: LOG_TARGET, "Running post_upgrade()");
 
-			let version = Pallet::<T>::on_chain_storage_version();
+			let version = Parameters::on_chain_storage_version();
 			ensure!(version == 1, "parameters migration failed");
 
 			Ok(())

--- a/runtime/acala/src/xcm_config.rs
+++ b/runtime/acala/src/xcm_config.rs
@@ -20,8 +20,9 @@ use super::{
 	constants::{fee::*, parachains},
 	AcalaTreasuryAccount, AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert,
 	Currencies, CurrencyId, EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, MessageQueue,
-	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, ACA, AUSD, TAP,
+	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, Parameters, PolkadotXcm, ReserveLocation, Runtime,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, XtokensParameters, ACA, AUSD,
+	TAP,
 };
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -33,7 +34,11 @@ use module_asset_registry::{
 };
 use module_support::HomaSubAccountXcm;
 use module_transaction_payment::BuyWeightRateOfTransactionFeePool;
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
+use orml_traits::{
+	location::{AbsoluteReserveProvider, Reserve},
+	parameter_type_with_key,
+	parameters::{ParameterStore, ParameterStoreAdapter},
+};
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use parity_scale_codec::{Decode, Encode};
@@ -363,6 +368,22 @@ parameter_type_with_key! {
 	};
 }
 
+pub struct ReserveProviderStore;
+impl Reserve for ReserveProviderStore {
+	fn reserve(asset: &Asset) -> Option<Location> {
+		let AssetId(location) = &asset.id;
+		match (location.parents, location.first_interior()) {
+			// sibling parachain
+			(1, Some(Parachain(id))) => Some(Location::new(1, [Parachain(*id)])),
+			// parent
+			(1, _) => ParameterStoreAdapter::<Parameters, XtokensParameters>::get(ReserveLocation),
+			// children parachain
+			(0, Some(Parachain(id))) => Some(Location::new(0, [Parachain(*id)])),
+			_ => None,
+		}
+	}
+}
+
 impl orml_xtokens::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
@@ -377,7 +398,7 @@ impl orml_xtokens::Config for Runtime {
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type MinXcmFee = ParachainMinFee;
 	type LocationsFilter = Everything;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = ReserveProviderStore;
 	type RateLimiter = ();
 	type RateLimiterId = ();
 }

--- a/runtime/common/src/precompile/mock.rs
+++ b/runtime/common/src/precompile/mock.rs
@@ -945,18 +945,18 @@ impl module_liquid_crowdloan::Config for Test {
 }
 
 pub struct ParameterStoreImpl;
-impl orml_traits::parameters::ParameterStore<module_earning::Parameters> for ParameterStoreImpl {
+impl orml_traits::parameters::ParameterStore<module_support::EarningParameters> for ParameterStoreImpl {
 	fn get<K>(key: K) -> Option<K::Value>
 	where
 		K: orml_traits::parameters::Key
-			+ Into<<module_earning::Parameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedKey>,
-		<module_earning::Parameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedValue:
+			+ Into<<module_support::EarningParameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedKey>,
+		<module_support::EarningParameters as orml_traits::parameters::AggregratedKeyValue>::AggregratedValue:
 			TryInto<K::WrappedValue>,
 	{
 		let key = key.into();
 		match key {
-			module_earning::ParametersKey::InstantUnstakeFee(_) => Some(
-				module_earning::ParametersValue::InstantUnstakeFee(sp_runtime::Permill::from_percent(10))
+			module_support::EarningParametersKey::InstantUnstakeFee(_) => Some(
+				module_support::EarningParametersValue::InstantUnstakeFee(sp_runtime::Permill::from_percent(10))
 					.try_into()
 					.ok()?
 					.into(),

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -58,13 +58,16 @@ use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, ExchangeRateProvider, FractionalRate, PoolId};
+use module_support::{
+	AddressMapping, AssetIdMapping, DispatchableTask, EarningParameters, ExchangeRateProvider, FractionalRate, PoolId,
+	ReserveLocation, RuntimeParameters, XtokensParameters,
+};
 use module_transaction_payment::TargetedFeeAdjustment;
 
 use cumulus_pallet_parachain_system::RelaychainDataProvider;
 use orml_traits::{
-	create_median_value_data_provider, define_aggregrated_parameters, parameter_type_with_key,
-	parameters::ParameterStoreAdapter, DataFeeder, DataProviderExtended, GetByKey, MultiCurrency,
+	create_median_value_data_provider, parameter_type_with_key, parameters::ParameterStoreAdapter, DataFeeder,
+	DataProviderExtended, GetByKey, MultiCurrency,
 };
 use pallet_transaction_payment::RuntimeDispatchInfo;
 
@@ -1806,7 +1809,7 @@ parameter_types! {
 impl module_earning::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type ParameterStore = ParameterStoreAdapter<Parameters, module_earning::Parameters>;
+	type ParameterStore = ParameterStoreAdapter<Parameters, EarningParameters>;
 	type OnBonded = module_incentives::OnEarningBonded<Runtime>;
 	type OnUnbonded = module_incentives::OnEarningUnbonded<Runtime>;
 	type OnUnstakeFee = Treasury; // fee goes to treasury
@@ -1815,12 +1818,6 @@ impl module_earning::Config for Runtime {
 	type MaxUnbondingChunks = ConstU32<10>;
 	type LockIdentifier = EarningLockIdentifier;
 	type WeightInfo = ();
-}
-
-define_aggregrated_parameters! {
-	pub RuntimeParameters = {
-		Earning: module_earning::Parameters = 0,
-	}
 }
 
 impl orml_parameters::Config for Runtime {

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -125,6 +125,7 @@ pub use nutsfinance_stable_asset;
 mod authority;
 mod benchmarking;
 pub mod constants;
+mod migrations;
 /// Weights for pallets used in the runtime.
 mod weights;
 pub mod xcm_config;
@@ -1984,7 +1985,7 @@ pub type Executive = frame_executive::Executive<
 >;
 
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (crate::migrations::v1::ParametersMigrateToV1<Runtime>,);
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/karura/src/migrations.rs
+++ b/runtime/karura/src/migrations.rs
@@ -1,0 +1,85 @@
+// This file is part of Acala.
+
+// Copyright (C) 2020-2025 Acala Foundation.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use frame_support::{pallet_prelude::StorageVersion, traits::GetStorageVersion, weights::Weight};
+
+pub mod v1 {
+	use super::*;
+	use frame_support::traits::OnRuntimeUpgrade;
+	use module_support::{RuntimeParametersKey, RuntimeParametersValue};
+	use orml_traits::parameters::AggregratedKeyValue;
+	use parity_scale_codec::EncodeLike;
+	use xcm::prelude::Location;
+
+	const LOG_TARGET: &str = "parameters::v1";
+
+	/// Migration to V1
+	pub struct ParametersMigrateToV1<T>(core::marker::PhantomData<T>);
+	impl<T: orml_parameters::Config> OnRuntimeUpgrade for ParametersMigrateToV1<T>
+	where
+		T::AggregratedKeyValue:
+			AggregratedKeyValue<AggregratedKey = RuntimeParametersKey, AggregratedValue = RuntimeParametersValue>,
+		RuntimeParametersKey: EncodeLike<<T::AggregratedKeyValue as AggregratedKeyValue>::AggregratedKey>,
+		RuntimeParametersValue: EncodeLike<<T::AggregratedKeyValue as AggregratedKeyValue>::AggregratedValue>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(target: LOG_TARGET, "Running on_runtime_upgrade()");
+
+			let version = Parameters::on_chain_storage_version();
+			if version == 0 {
+				let key_value = RuntimeParameters::Xtokens(XtokensParameters::ReserveLocation(
+					ReserveLocation,
+					Some(Location::parent()),
+				));
+
+				let (key, value) = key_value.clone().into_parts();
+
+				orml_parameters::Parameters::<T>::set(key, value);
+
+				StorageVersion::new(1).put::<Parameters>();
+
+				log::info!(target: LOG_TARGET, "Migrated on Parameters to v1");
+				T::DbWeight::get().reads_writes(1, 2)
+			} else {
+				log::info!(target: LOG_TARGET, "Parameters need to be removed");
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+			log::info!(target: LOG_TARGET, "Running pre_upgrade()");
+
+			let version = Pallet::<T>::on_chain_storage_version();
+			ensure!(version == 0, "parameters already migrated");
+
+			Ok(Vec::new())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			log::info!(target: LOG_TARGET, "Running post_upgrade()");
+
+			let version = Pallet::<T>::on_chain_storage_version();
+			ensure!(version == 1, "parameters migration failed");
+
+			Ok(())
+		}
+	}
+}

--- a/runtime/karura/src/migrations.rs
+++ b/runtime/karura/src/migrations.rs
@@ -21,10 +21,11 @@ use frame_support::{pallet_prelude::StorageVersion, traits::GetStorageVersion, w
 
 pub mod v1 {
 	use super::*;
-	use frame_support::traits::OnRuntimeUpgrade;
+	use frame_support::{ensure, traits::OnRuntimeUpgrade};
 	use module_support::{RuntimeParametersKey, RuntimeParametersValue};
 	use orml_traits::parameters::AggregratedKeyValue;
 	use parity_scale_codec::EncodeLike;
+	use sp_std::vec;
 	use xcm::prelude::Location;
 
 	const LOG_TARGET: &str = "parameters::v1";
@@ -63,20 +64,20 @@ pub mod v1 {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		fn pre_upgrade() -> Result<vec::Vec<u8>, sp_runtime::TryRuntimeError> {
 			log::info!(target: LOG_TARGET, "Running pre_upgrade()");
 
-			let version = Pallet::<T>::on_chain_storage_version();
+			let version = Parameters::on_chain_storage_version();
 			ensure!(version == 0, "parameters already migrated");
 
 			Ok(Vec::new())
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn post_upgrade(_state: vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 			log::info!(target: LOG_TARGET, "Running post_upgrade()");
 
-			let version = Pallet::<T>::on_chain_storage_version();
+			let version = Parameters::on_chain_storage_version();
 			ensure!(version == 1, "parameters migration failed");
 
 			Ok(())

--- a/runtime/karura/src/xcm_config.rs
+++ b/runtime/karura/src/xcm_config.rs
@@ -20,8 +20,9 @@ use super::{
 	constants::{fee::*, parachains},
 	AccountId, AllPalletsWithSystem, AssetIdMapping, AssetIdMaps, Balance, Balances, Convert, Currencies, CurrencyId,
 	EvmAddressMapping, ExistentialDeposits, GetNativeCurrencyId, KaruraTreasuryAccount, MessageQueue,
-	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, KAR, KUSD, LKSM, TAI, XNFT,
+	NativeTokenExistentialDeposit, ParachainInfo, ParachainSystem, Parameters, PolkadotXcm, ReserveLocation, Runtime,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, UnknownTokens, XcmInterface, XcmpQueue, XtokensParameters, KAR, KUSD,
+	LKSM, TAI, XNFT,
 };
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -31,7 +32,11 @@ use frame_support::{
 use module_asset_registry::{BuyWeightRateOfErc20, BuyWeightRateOfForeignAsset, BuyWeightRateOfStableAsset};
 use module_support::HomaSubAccountXcm;
 use module_transaction_payment::BuyWeightRateOfTransactionFeePool;
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
+use orml_traits::{
+	location::{AbsoluteReserveProvider, Reserve},
+	parameter_type_with_key,
+	parameters::{ParameterStore, ParameterStoreAdapter},
+};
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use parity_scale_codec::{Decode, Encode};
@@ -321,6 +326,22 @@ parameter_type_with_key! {
 	};
 }
 
+pub struct ReserveProviderStore;
+impl Reserve for ReserveProviderStore {
+	fn reserve(asset: &Asset) -> Option<Location> {
+		let AssetId(location) = &asset.id;
+		match (location.parents, location.first_interior()) {
+			// sibling parachain
+			(1, Some(Parachain(id))) => Some(Location::new(1, [Parachain(*id)])),
+			// parent
+			(1, _) => ParameterStoreAdapter::<Parameters, XtokensParameters>::get(ReserveLocation),
+			// children parachain
+			(0, Some(Parachain(id))) => Some(Location::new(0, [Parachain(*id)])),
+			_ => None,
+		}
+	}
+}
+
 impl orml_xtokens::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
@@ -335,7 +356,7 @@ impl orml_xtokens::Config for Runtime {
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type MinXcmFee = ParachainMinFee;
 	type LocationsFilter = Everything;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = ReserveProviderStore;
 	type RateLimiter = ();
 	type RateLimiterId = ();
 }

--- a/runtime/mandala/src/benchmarking/earning.rs
+++ b/runtime/mandala/src/benchmarking/earning.rs
@@ -52,7 +52,7 @@ runtime_benchmarks! {
 		set_balance(NATIVE, &caller, dollar(NATIVE));
 		Parameters::set_parameter(
 			RawOrigin::Root.into(),
-			RuntimeParameters::Earning(module_earning::Parameters::InstantUnstakeFee(module_earning::InstantUnstakeFee, Some(Permill::from_percent(10))))
+			RuntimeParameters::Earning(module_support::EarningParameters::InstantUnstakeFee(module_support::InstantUnstakeFee, Some(Permill::from_percent(10))))
 		)?;
 		Earning::bond(RuntimeOrigin::signed(caller.clone()), 2 * NativeTokenExistentialDeposit::get())?;
 	}: _(RawOrigin::Signed(caller), NativeTokenExistentialDeposit::get())

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -53,7 +53,10 @@ use module_cdp_engine::CollateralCurrencyIds;
 use module_currencies::BasicCurrencyAdapter;
 use module_evm::{runner::RunnerExtended, CallInfo, CreateInfo, EvmChainId, EvmTask};
 use module_evm_accounts::EvmAddressMapping;
-use module_support::{AddressMapping, AssetIdMapping, DispatchableTask, ExchangeRateProvider, FractionalRate, PoolId};
+use module_support::{
+	AddressMapping, AssetIdMapping, DispatchableTask, EarningParameters, ExchangeRateProvider, FractionalRate, PoolId,
+	ReserveLocation, RuntimeParameters, XtokensParameters,
+};
 use module_transaction_payment::TargetedFeeAdjustment;
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
 use polkadot_parachain_primitives::primitives::Sibling;
@@ -61,8 +64,8 @@ use scale_info::TypeInfo;
 
 use orml_tokens::CurrencyAdapter;
 use orml_traits::{
-	create_median_value_data_provider, define_aggregrated_parameters, parameter_type_with_key,
-	parameters::ParameterStoreAdapter, DataFeeder, DataProviderExtended, GetByKey, MultiCurrency,
+	create_median_value_data_provider, parameter_type_with_key, parameters::ParameterStoreAdapter, DataFeeder,
+	DataProviderExtended, GetByKey, MultiCurrency,
 };
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use primitives::{
@@ -1334,7 +1337,7 @@ impl module_transaction_payment::Config for Runtime {
 impl module_earning::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type ParameterStore = ParameterStoreAdapter<Parameters, module_earning::Parameters>;
+	type ParameterStore = ParameterStoreAdapter<Parameters, EarningParameters>;
 	type OnBonded = module_incentives::OnEarningBonded<Runtime>;
 	type OnUnbonded = module_incentives::OnEarningUnbonded<Runtime>;
 	type OnUnstakeFee = Treasury; // fee goes to treasury
@@ -1870,12 +1873,6 @@ impl module_liquid_crowdloan::Config for Runtime {
 	type PalletId = LiquidCrowdloanPalletId;
 	type GovernanceOrigin = EnsureRootOrHalfGeneralCouncil;
 	type WeightInfo = weights::module_liquid_crowdloan::WeightInfo<Runtime>;
-}
-
-define_aggregrated_parameters! {
-	pub RuntimeParameters = {
-		Earning: module_earning::Parameters = 0,
-	}
 }
 
 impl orml_parameters::Config for Runtime {


### PR DESCRIPTION
* add `XtokensParameters` to store `ReserveLocation` with `orml_parameters` pallet
* add `ParametersMigrateToV1` to setup `ReserveLocation`  of `XtokensParameters`

Since the `chain_part` and `non_chain_part` called by `xtokens` are [hard-coded](https://github.com/open-web3-stack/open-runtime-module-library/blob/c02a0baca184d91071e5516de4439df0eddd9d6d/traits/src/location.rs#L22), if we want to use xtokens after AHM, we need to upgrade the runtime first.