### PR TITLE
add TransactionPaymentCallApi

### DIFF
--- a/modules/transaction-payment/src/tests.rs
+++ b/modules/transaction-payment/src/tests.rs
@@ -2600,7 +2600,7 @@ fn query_call_info_and_fee_details_works() {
 						base_fee: 5 * 2,          /* base * weight_fee */
 						len_fee: len as u128 * 2, /* len * 2 */
 						adjusted_weight_fee: info.total_weight().min(BlockWeights::get().max_block).ref_time() as u128
-							* 2 * 3 / 2  /* weight * weight_fee * multipler */
+							* 2 * 3 / 2  /* weight * weight_fee * multiplier */
 					}),
 					tip: 0,
 				},

--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -2155,6 +2155,29 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, RuntimeCall>
+		for Runtime
+	{
+		fn query_call_info(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_call_info(call, len)
+		}
+		fn query_call_fee_details(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_call_fee_details(call, len)
+		}
+		fn query_weight_to_fee(weight: Weight) -> Balance {
+			TransactionPayment::weight_to_fee(weight)
+		}
+		fn query_length_to_fee(length: u32) -> Balance {
+			TransactionPayment::length_to_fee(length)
+		}
+	}
+
 	impl orml_oracle_runtime_api::OracleApi<
 		Block,
 		DataProviderId,

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -2162,6 +2162,29 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, RuntimeCall>
+		for Runtime
+	{
+		fn query_call_info(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_call_info(call, len)
+		}
+		fn query_call_fee_details(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_call_fee_details(call, len)
+		}
+		fn query_weight_to_fee(weight: Weight) -> Balance {
+			TransactionPayment::weight_to_fee(weight)
+		}
+		fn query_length_to_fee(length: u32) -> Balance {
+			TransactionPayment::length_to_fee(length)
+		}
+	}
+
 	impl orml_oracle_runtime_api::OracleApi<
 		Block,
 		DataProviderId,

--- a/runtime/mandala/src/lib.rs
+++ b/runtime/mandala/src/lib.rs
@@ -2336,6 +2336,29 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, RuntimeCall>
+		for Runtime
+	{
+		fn query_call_info(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_call_info(call, len)
+		}
+		fn query_call_fee_details(
+			call: RuntimeCall,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_call_fee_details(call, len)
+		}
+		fn query_weight_to_fee(weight: Weight) -> Balance {
+			TransactionPayment::weight_to_fee(weight)
+		}
+		fn query_length_to_fee(length: u32) -> Balance {
+			TransactionPayment::length_to_fee(length)
+		}
+	}
+
 	impl orml_oracle_runtime_api::OracleApi<
 		Block,
 		DataProviderId,


### PR DESCRIPTION
https://github.com/AcalaNetwork/bodhi.js/blob/6d4f8232c33cb03eff0dad2d89f0ef3d6412cac3/packages/eth-providers/src/base-provider.ts#L963-L966


Since `ExtrinsicV5` has upgraded `UncheckedExtrinsic { preamble: Bare, function: <wasm:stripped> }`, if the type is Bare, it returns None. 
https://github.com/AcalaNetwork/Acala/blob/2c877e126f38c7fd38f4a0f54b9a94c91cb7a596/modules/transaction-payment/src/lib.rs#L727-L732


`api.call.transactionPaymentApi.queryFeeDetails` needs a signature to query fee details. 
Therefore, `TransactionPaymentCallApi` is added to query fee details.




