### PR TITLE
Fix migrations

### DIFF
--- a/runtime/acala/src/lib.rs
+++ b/runtime/acala/src/lib.rs
@@ -2001,7 +2001,7 @@ pub type Executive = frame_executive::Executive<
 
 pub struct RemoveXTokensMigrationStatus<T>(frame_support::pallet_prelude::PhantomData<T>);
 
-impl<T: frame_system::Config> frame_support::traits::OnRuntimeUpgrade for RemoveOldValue<T> {
+impl<T: frame_system::Config> frame_support::traits::OnRuntimeUpgrade for RemoveXTokensMigrationStatus<T> {
 	fn on_runtime_upgrade() -> Weight {
 		let key = frame_support::storage::storage_prefix(b"XTokens", b"MigrationStatus");
 		log::info!(

--- a/runtime/karura/src/lib.rs
+++ b/runtime/karura/src/lib.rs
@@ -2008,7 +2008,7 @@ pub type Executive = frame_executive::Executive<
 
 pub struct RemoveXTokensMigrationStatus<T>(frame_support::pallet_prelude::PhantomData<T>);
 
-impl<T: frame_system::Config> frame_support::traits::OnRuntimeUpgrade for RemoveOldValue<T> {
+impl<T: frame_system::Config> frame_support::traits::OnRuntimeUpgrade for RemoveXTokensMigrationStatus<T> {
 	fn on_runtime_upgrade() -> Weight {
 		let key = frame_support::storage::storage_prefix(b"XTokens", b"MigrationStatus");
 		log::info!(


### PR DESCRIPTION
https://github.com/paritytech/polkadot-sdk/blob/30cda2aad8612a10ff729d494acd9d5353294d63/substrate/frame/support/src/migrations.rs#L427-L443

frame_support::migrations::RemoveStorage can't remove `StorageValue` item. 
